### PR TITLE
Normalize experience modules

### DIFF
--- a/experiences/agrippa/components/counter.js
+++ b/experiences/agrippa/components/counter.js
@@ -1,10 +1,10 @@
-+export default function mount(el) {
-+  let sigils = 0;
-+  const btn = document.createElement('button');
-+  btn.textContent = `Agrippa sigils: ${sigils}`;
-+  btn.addEventListener('click', () => {
-+    sigils++;
-+    btn.textContent = `Agrippa sigils: ${sigils}`;
-+  });
-+  el.appendChild(btn);
-+}
+export default function mount(el) {
+  let sigils = 0;
+  const btn = document.createElement('button');
+  btn.textContent = `Agrippa sigils: ${sigils}`;
+  btn.addEventListener('click', () => {
+    sigils++;
+    btn.textContent = `Agrippa sigils: ${sigils}`;
+  });
+  el.appendChild(btn);
+}

--- a/experiences/agrippa/config.json
+++ b/experiences/agrippa/config.json
@@ -1,6 +1,6 @@
-+{
-+  "title": "Agrippa",
-+  "components": [
-+    { "id": "counter", "src": "./components/counter.js" }
-+  ]
-+}
+{
+  "title": "Agrippa",
+  "components": [
+    { "id": "counter", "src": "./components/counter.js" }
+  ]
+}

--- a/experiences/alexandrian-scriptorium/components/counter.js
+++ b/experiences/alexandrian-scriptorium/components/counter.js
@@ -1,10 +1,10 @@
-+export default function mount(el) {
-+  let scrolls = 0;
-+  const btn = document.createElement('button');
-+  btn.textContent = `Scriptorium scrolls: ${scrolls}`;
-+  btn.addEventListener('click', () => {
-+    scrolls++;
-+    btn.textContent = `Scriptorium scrolls: ${scrolls}`;
-+  });
-+  el.appendChild(btn);
-+}
+export default function mount(el) {
+  let scrolls = 0;
+  const btn = document.createElement('button');
+  btn.textContent = `Scriptorium scrolls: ${scrolls}`;
+  btn.addEventListener('click', () => {
+    scrolls++;
+    btn.textContent = `Scriptorium scrolls: ${scrolls}`;
+  });
+  el.appendChild(btn);
+}

--- a/experiences/alexandrian-scriptorium/config.json
+++ b/experiences/alexandrian-scriptorium/config.json
@@ -1,6 +1,6 @@
-+{
-+  "title": "Alexandrian Scriptorium",
-+  "components": [
-+    { "id": "counter", "src": "./components/counter.js" }
-+  ]
-+}
+{
+  "title": "Alexandrian Scriptorium",
+  "components": [
+    { "id": "counter", "src": "./components/counter.js" }
+  ]
+}

--- a/experiences/hypatia/components/counter.js
+++ b/experiences/hypatia/components/counter.js
@@ -1,10 +1,10 @@
-+export default function mount(el) {
-+  let count = 0;
-+  const btn = document.createElement('button');
-+  btn.textContent = `Hypatia clicks: ${count}`;
-+  btn.addEventListener('click', () => {
-+    count++;
-+    btn.textContent = `Hypatia clicks: ${count}`;
-+  });
-+  el.appendChild(btn);
-+}
+export default function mount(el) {
+  let count = 0;
+  const btn = document.createElement('button');
+  btn.textContent = `Hypatia clicks: ${count}`;
+  btn.addEventListener('click', () => {
+    count++;
+    btn.textContent = `Hypatia clicks: ${count}`;
+  });
+  el.appendChild(btn);
+}

--- a/experiences/hypatia/config.json
+++ b/experiences/hypatia/config.json
@@ -1,6 +1,6 @@
-+{
-+  "title": "Hypatia",
-+  "components": [
-+    { "id": "counter", "src": "./components/counter.js" }
-+  ]
-+}
+{
+  "title": "Hypatia",
+  "components": [
+    { "id": "counter", "src": "./components/counter.js" }
+  ]
+}

--- a/experiences/tesla/components/counter.js
+++ b/experiences/tesla/components/counter.js
@@ -1,10 +1,10 @@
-+export default function mount(el) {
-+  let volts = 0;
-+  const btn = document.createElement('button');
-+  btn.textContent = `Tesla volts: ${volts}`;
-+  btn.addEventListener('click', () => {
-+    volts++;
-+    btn.textContent = `Tesla volts: ${volts}`;
-+  });
-+  el.appendChild(btn);
-+}
+export default function mount(el) {
+  let volts = 0;
+  const btn = document.createElement('button');
+  btn.textContent = `Tesla volts: ${volts}`;
+  btn.addEventListener('click', () => {
+    volts++;
+    btn.textContent = `Tesla volts: ${volts}`;
+  });
+  el.appendChild(btn);
+}

--- a/experiences/tesla/config.json
+++ b/experiences/tesla/config.json
@@ -1,6 +1,6 @@
-+{
-+  "title": "Tesla",
-+  "components": [
-+    { "id": "counter", "src": "./components/counter.js" }
-+  ]
-+}
+{
+  "title": "Tesla",
+  "components": [
+    { "id": "counter", "src": "./components/counter.js" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Remove stray patch markers from Agrippa, Alexandrian Scriptorium, Hypatia, and Tesla experience configs and counters

## Testing
- `npm test` (fails: SyntaxError in test suite)

------
https://chatgpt.com/codex/tasks/task_e_68b3d81175dc8328ba8486008f023836