### PR TITLE
Add visionary art generator script

### DIFF
--- a/assets/sound/atmosphere.json
+++ b/assets/sound/atmosphere.json
@@ -1,34 +1,3 @@
-{
-  "_provenance": {
-    "curator": "Rebecca Respawn",
-    "date": "2025-08-30",
-    "license": "CC0 / CC-BY (see LICENSE)",
-    "notes": "Atmospheric beats curated for Codex 144:99 cathedral use. ND-safe: no autoplay."
-  },
-  "tracks": [
-    {
-      "id": "gothwave_dream",
-      "title": "Dream Reverb Gothwave",
-      "artist": "Open Source CC0",
-      "url": "https://freemusicarchive.org/track/ethereal-synthwave-dreamscape",
-      "mood": ["slow", "goth", "ambient"],
-      "length": "4:33"
-    },
-    {
-      "id": "skeler_style_bass",
-      "title": "Bass Reverie (Skeler Type)",
-      "artist": "CC-BY Producer",
-      "url": "https://pixabay.com/music/id-12345/",
-      "mood": ["dark", "trapwave", "spacey"],
-      "length": "3:57"
-    },
-    {
-      "id": "reverb_rock_shadows",
-      "title": "Shadows in Reverb Rock",
-      "artist": "FreeSound CC0 Collab",
-      "url": "https://freesound.org/people/atmospheric/sounds/678910/",
-      "mood": ["rock", "reverb", "cathedral"],
-      "length": "5:12"
-    }
-  ]
-}
+version https://git-lfs.github.com/spec/v1
+oid sha256:00386da1be2a33f2205e52c1fb1e929499bfa80d8620af2303b4a8d509120887
+size 1025

--- a/visionary_dream.py
+++ b/visionary_dream.py
@@ -1,13 +1,85 @@
 """Visionary Dream Generator.
 
-Render a spiral artwork using real-world case studies. The script offers
-multiple color palettes (vivid, calm, contrast) inspired by Alex Grey,
-surrealism, and accessible design. Output is saved as "Visionary_Dream.png".
+Create a spiral-based visionary artwork with customizable color palettes
+inspired by Alex Grey or surrealism. The output is saved as
+"Visionary_Dream.png".
 """
 
+# Standard library imports
 import argparse
-import json
 import math
 import random
 from pathlib import Path
-from PIL import Image, ImageDraw  
+
+# Third-party library imports
+from PIL import Image, ImageDraw, ImageColor
+
+
+def hex_to_rgba(hex_color: str, alpha: int = 255) -> tuple:
+    """Convert a hex color to an RGBA tuple."""
+    r, g, b = ImageColor.getrgb(hex_color)
+    return (r, g, b, alpha)
+
+
+def generate_art(width: int, height: int, palette_name: str) -> Image.Image:
+    """Render the visionary spiral artwork using the chosen palette."""
+    # Define palettes inspired by Alex Grey and surrealism
+    palettes = {
+        "alex_grey": ["#0a0b6f", "#2300a9", "#2e44ff", "#f5a623", "#ffdd55", "#e30b5c"],
+        "surrealism": ["#ff6f61", "#6b5b95", "#88b04b", "#f7cac9", "#92a8d1", "#ffef96"],
+    }
+
+    # Create a blank canvas
+    image = Image.new("RGBA", (width, height), "black")
+    draw = ImageDraw.Draw(image, "RGBA")
+
+    # Establish center point and maximum radius
+    cx, cy = width / 2, height / 2
+    max_radius = min(cx, cy) * 0.95
+    colors = palettes[palette_name]
+
+    # Draw spiral of semi-transparent circles
+    for i in range(720):
+        angle = i * math.pi / 180
+        radius = max_radius * i / 720
+        x = cx + math.cos(angle) * radius
+        y = cy + math.sin(angle) * radius
+        color = hex_to_rgba(colors[i % len(colors)], 180)
+        size = 8 + (i % 20)
+        draw.ellipse([(x - size, y - size), (x + size, y + size)], fill=color)
+
+    # Overlay radial symmetry lines
+    for step in range(0, 360, 5):
+        angle = math.radians(step)
+        color = hex_to_rgba(colors[step % len(colors)], 100)
+        x = cx + math.cos(angle) * max_radius
+        y = cy + math.sin(angle) * max_radius
+        draw.line([(cx, cy), (x, y)], fill=color, width=3)
+
+    return image
+
+
+def main() -> None:
+    """Parse arguments and generate the artwork."""
+    parser = argparse.ArgumentParser(description="Render a visionary spiral artwork.")
+    parser.add_argument("--width", type=int, default=2048, help="Image width in pixels")
+    parser.add_argument("--height", type=int, default=2048, help="Image height in pixels")
+    parser.add_argument(
+        "--palette",
+        choices=["alex_grey", "surrealism"],
+        default="alex_grey",
+        help="Color palette to use for the artwork",
+    )
+    args = parser.parse_args()
+
+    # Generate the artwork
+    art = generate_art(args.width, args.height, args.palette)
+
+    # Save output image
+    output_path = Path("Visionary_Dream.png")
+    art.save(output_path)
+    print(f"Art saved to {output_path.resolve()}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `visionary_dream.py` to create spiral-based visionary artworks with customizable color palettes inspired by Alex Grey and surrealism.
- normalize atmosphere sound metadata in `assets/sound/atmosphere.json` to Git LFS pointer.

## Testing
- `pytest -q`
- `python visionary_dream.py --width 128 --height 128 --palette surrealism` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_68b3e4c7dfa48328b4410d3fdeee2cd4