### PR TITLE
feat: load experiences from remote repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,3 +295,18 @@ python3 scripts/visionary_fractal.py --width 1920 --height 1080
 ```
 
 The image saves as `Visionary_Dream.png` in the project root.
+
+## Remote Experiences
+
+Use the helper `src/remoteExperienceLoader.js` to load experiences directly from another public GitHub repository without cloning it.
+
+```html
+<script type="module">
+import { fetchRemoteExperiences } from './src/remoteExperienceLoader.js';
+
+const experiences = await fetchRemoteExperiences('user/other-repo');
+console.log(experiences);
+</script>
+```
+
+Each experience fetched this way resolves its components and first page from the remote repo using raw GitHub URLs.

--- a/docs/repo_integration.md
+++ b/docs/repo_integration.md
@@ -18,3 +18,18 @@ The Cosmogenesis engine can grow alongside other creative projects. Treat each e
 - Document each module's API and expected events in its own repository for easier maintenance.
 
 These practices let the Learning Engine evolve with your other projects while staying cohesive and open to community contributions.
+
+## Remote Experience Loader
+
+Use `src/remoteExperienceLoader.js` to pull experience definitions straight from a public GitHub repository. This lets the engine run modules without cloning their repos.
+
+```html
+<script type="module">
+import { fetchRemoteExperiences } from '../src/remoteExperienceLoader.js';
+
+const experiences = await fetchRemoteExperiences('user/other-repo');
+console.log(experiences);
+</script>
+```
+
+Each loaded experience resolves its components and optional prologue pages using raw GitHub URLs.

--- a/src/remoteExperienceLoader.js
+++ b/src/remoteExperienceLoader.js
@@ -1,0 +1,38 @@
+// Utility to fetch experiences from a remote GitHub repository
+// This allows running Cosmogenesis without cloning the other repo.
+
+export async function fetchRemoteExperiences(repo, branch = 'main') {
+  if (!repo) {
+    throw new Error('Repository name is required (e.g. "user/project")');
+  }
+  const base = `https://raw.githubusercontent.com/${repo}/${branch}/`;
+
+  // Load list of experiences
+  const listRes = await fetch(`${base}data/experiences.json`);
+  if (!listRes.ok) {
+    throw new Error(`Unable to fetch experiences.json from ${repo}`);
+  }
+  const list = await listRes.json();
+
+  // Fetch config for each experience and resolve component paths
+  return Promise.all(
+    list.map(async (exp) => {
+      const cfg = await fetch(base + exp.src).then((r) => r.json());
+      let prologue = '';
+      if (cfg.pages && cfg.pages[0]) {
+        const pageUrl = `${base}app/${exp.id}/pages/${cfg.pages[0]}`;
+        prologue = await fetch(pageUrl).then((r) => r.text());
+      }
+      const components = Array.isArray(cfg.components)
+        ? cfg.components.map((c) => `${base}app/${exp.id}/${c}`)
+        : [];
+      return {
+        ...exp,
+        title: cfg.title || exp.title,
+        description: cfg.description,
+        prologue,
+        components,
+      };
+    })
+  );
+}


### PR DESCRIPTION
## Summary
- add `fetchRemoteExperiences` helper to pull experience configs from public GitHub repos
- document cross-repo loading in repo integration guide
- note remote experience usage in README

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b54dcff294832880cfcca926ad1779