### PR TITLE
feat: add global healing web experience

### DIFF
--- a/app/experience_e/components/fractalWeb.js
+++ b/app/experience_e/components/fractalWeb.js
@@ -1,0 +1,10 @@
+export default function mount(el) {
+  let threads = 0;
+  const btn = document.createElement("button");
+  btn.textContent = `Threads of healing: ${threads}`;
+  btn.addEventListener("click", () => {
+    threads++;
+    btn.textContent = `Threads of healing: ${threads}`;
+  });
+  el.appendChild(btn);
+}

--- a/app/experience_e/config.json
+++ b/app/experience_e/config.json
@@ -1,0 +1,6 @@
+{
+  "title": "Global Healing Web",
+  "description": "Connects Tibetan Reiki, Karuna, Egyptian Seichem, hypnosis, and more in a fractal history of world healing.",
+  "pages": ["fractal-web.md"],
+  "components": ["components/fractalWeb.js"]
+}

--- a/app/experience_e/pages/fractal-web.md
+++ b/app/experience_e/pages/fractal-web.md
@@ -1,0 +1,3 @@
+You step into the **Global Healing Web**.
+Threads glimmer with stories from Tibetan Reiki, Usui and Karuna lineages, Egyptian Seichem and SEKEM, hypnosis, brainspotting, EMDR, and the ancient rites of Greeks, Druids, and Hathor's temple.
+Each node invites you to follow a lineage and celebrate its wisdom.

--- a/data/experiences.json
+++ b/data/experiences.json
@@ -1,6 +1,27 @@
 [
-  {"id":"experience_a","title":"Hypatia's Library","src":"app/experience_a/config.json"},
-  {"id":"experience_b","title":"Tesla's Workshop","src":"app/experience_b/config.json"},
-  {"id":"experience_c","title":"Agrippa's Study","src":"app/experience_c/config.json"},
-  {"id":"experience_d","title":"Alexandrian Scriptorium","src":"app/experience_d/config.json"}
+  {
+    "id": "experience_a",
+    "title": "Hypatia's Library",
+    "src": "app/experience_a/config.json"
+  },
+  {
+    "id": "experience_b",
+    "title": "Tesla's Workshop",
+    "src": "app/experience_b/config.json"
+  },
+  {
+    "id": "experience_c",
+    "title": "Agrippa's Study",
+    "src": "app/experience_c/config.json"
+  },
+  {
+    "id": "experience_d",
+    "title": "Alexandrian Scriptorium",
+    "src": "app/experience_d/config.json"
+  },
+  {
+    "id": "experience_e",
+    "title": "Global Healing Web",
+    "src": "app/experience_e/config.json"
+  }
 ]


### PR DESCRIPTION
## Summary
- add Global Healing Web experience celebrating world healing traditions
- register Global Healing Web in experience list

## Testing
- `npm run check` *(fails: Unexpected PostCSS node type in assets/css/fusion-kink.css, SyntaxError in various JS/CSS/JSON files, etc.)*
- `npm test` *(fails: test/soundscape.test.js and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b60ac63f0883289e7c4dd31a35e51a