### PR TITLE
feat: enable multi-chamber management

### DIFF
--- a/src/engines/chamber-engine.js
+++ b/src/engines/chamber-engine.js
@@ -4,12 +4,30 @@ class ChamberEngine extends EventTarget {
     this.current = null;
     this.skin = null;
     this.guardian = null;
-    this.payload = null;
+    this.payloads = new Map();
+    this.openChambers = new Set();
   }
 
   open(id) {
     this.current = id;
+    this.openChambers.add(id);
     this.dispatchEvent(new CustomEvent('chamber:open', { detail: id }));
+  }
+
+  openMultiple(ids = []) {
+    ids.forEach((id) => {
+      this.openChambers.add(id);
+      this.dispatchEvent(new CustomEvent('chamber:open', { detail: id }));
+    });
+    this.current = ids.at(-1) ?? this.current;
+  }
+
+  close(id) {
+    this.openChambers.delete(id);
+    if (this.current === id) {
+      this.current = null;
+    }
+    this.dispatchEvent(new CustomEvent('chamber:close', { detail: id }));
   }
 
   applySkin(skinId) {
@@ -22,9 +40,24 @@ class ChamberEngine extends EventTarget {
     this.dispatchEvent(new CustomEvent('guardian:set', { detail: name }));
   }
 
-  setPayload(payload) {
-    this.payload = payload;
-    this.dispatchEvent(new CustomEvent('payload:set', { detail: payload }));
+  setPayload(payload, id = this.current) {
+    if (id == null) return;
+    this.payloads.set(id, payload);
+    this.dispatchEvent(
+      new CustomEvent('payload:set', { detail: { id, payload } })
+    );
+  }
+
+  getPayload(id = this.current) {
+    return id == null ? undefined : this.payloads.get(id);
+  }
+
+  copyPayload(fromId, toId = this.current) {
+    const payload = this.getPayload(fromId);
+    if (payload !== undefined && toId != null) {
+      this.setPayload(payload, toId);
+    }
+    return payload;
   }
 }
 

--- a/test/chamber-engine.test.js
+++ b/test/chamber-engine.test.js
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { chamberEngine } from '../src/engines/chamber-engine.js';
+
+const resetEngine = () => {
+  chamberEngine.openChambers.clear();
+  chamberEngine.payloads.clear();
+  chamberEngine.current = null;
+};
+
+test('openMultiple opens all chambers and sets current', () => {
+  resetEngine();
+  chamberEngine.openMultiple(['alpha', 'beta']);
+  assert.deepEqual([...chamberEngine.openChambers], ['alpha', 'beta']);
+  assert.equal(chamberEngine.current, 'beta');
+});
+
+test('copyPayload duplicates payload between chambers', () => {
+  resetEngine();
+  chamberEngine.openMultiple(['alpha', 'beta']);
+  chamberEngine.setPayload('source data', 'alpha');
+  chamberEngine.copyPayload('alpha', 'beta');
+  assert.equal(chamberEngine.getPayload('beta'), 'source data');
+});


### PR DESCRIPTION
## Summary
- allow ChamberEngine to track multiple open chambers and copy payloads between them
- add tests for multi-chamber handling and payload duplication

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE in existing suites such as config-loader, renderPlate, smoke, soundscape)*

------
https://chatgpt.com/codex/tasks/task_e_68b6109b91ac832893707c712b6b9da9