### PR TITLE
Add rooms atlas and tesseract integration

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -9,6 +9,9 @@
 
 ## Priority Spiral (P1 → P3)
 
+### Legacy Cleanup
+- [ ] Fix legacy file issues blocking `npm test` and `npm run check`
+
 ### P1 — Foundation (today)
 - [ ] Add docs: `docs/CODEX_EXT_RUNBOOK.md`, `docs/SCIENCE_REFERENCES.md`, `docs/STYLE_GUIDE.md`
 - [ ] Add schemas: `schemas/provenance.json`, `schemas/stylepack.json`

--- a/assets/css/alchemy-plates.css
+++ b/assets/css/alchemy-plates.css
@@ -1,0 +1,16 @@
+.room {
+  border: 1px solid #ccc;
+  padding: 1rem;
+  margin: 1rem;
+}
+.room h2 {
+  margin: 0 0 0.5rem 0;
+}
+.room ul {
+  list-style: none;
+  padding: 0;
+}
+.room li {
+  display: inline-block;
+  margin-right: 0.5rem;
+}

--- a/assets/js/engines/rooms-engine.js
+++ b/assets/js/engines/rooms-engine.js
@@ -1,0 +1,47 @@
+(() => {
+  "use strict";
+  async function fetchRooms() {
+    const res = await fetch("/data/rooms.json", { cache: "no-store" });
+    return res.json();
+  }
+  function emit(name, detail) {
+    document.dispatchEvent(new CustomEvent(name, { detail }));
+  }
+  function renderRooms(rooms) {
+    const container = document.getElementById("rooms");
+    if (!container) return;
+    rooms.forEach((room) => {
+      const section = document.createElement("section");
+      section.className = "room";
+      const title = document.createElement("h2");
+      title.textContent = room.name;
+      const enter = document.createElement("button");
+      enter.textContent = "Enter";
+      enter.addEventListener("click", () => {
+        emit("room:enter", { id: room.id });
+      });
+      section.appendChild(title);
+      section.appendChild(enter);
+      const list = document.createElement("ul");
+      Object.entries(room.quests || {}).forEach(([q, url]) => {
+        const li = document.createElement("li");
+        const a = document.createElement("a");
+        a.textContent = q;
+        a.href = url;
+        a.target = "_blank";
+        a.rel = "noopener";
+        a.addEventListener("click", () => {
+          emit("quest:complete", { roomId: room.id, quest: q });
+        });
+        li.appendChild(a);
+        list.appendChild(li);
+      });
+      section.appendChild(list);
+      container.appendChild(section);
+    });
+  }
+  document.addEventListener("DOMContentLoaded", async () => {
+    const rooms = await fetchRooms();
+    renderRooms(rooms);
+  });
+})();

--- a/assets/js/engines/tesseract-bridge.js
+++ b/assets/js/engines/tesseract-bridge.js
@@ -1,0 +1,15 @@
+(() => {
+  "use strict";
+  function bridgeRoomEnter(e) {
+    const id = e.detail.id;
+    document.dispatchEvent(
+      new CustomEvent("tesseract:unlockNode", { detail: { id } }),
+    );
+    document.dispatchEvent(
+      new CustomEvent("tesseract:unlockEdge", {
+        detail: { from: "home", to: id },
+      }),
+    );
+  }
+  document.addEventListener("room:enter", bridgeRoomEnter);
+})();

--- a/assets/js/engines/tesseract-hooks.js
+++ b/assets/js/engines/tesseract-hooks.js
@@ -1,0 +1,22 @@
+(() => {
+  "use strict";
+  const unlocked = { nodes: new Set(), edges: new Set() };
+  function unlockNode(id) {
+    if (unlocked.nodes.has(id)) return;
+    unlocked.nodes.add(id);
+    console.log("Node unlocked:", id);
+  }
+  function unlockEdge(edge) {
+    const key = edge.from + "->" + edge.to;
+    if (unlocked.edges.has(key)) return;
+    unlocked.edges.add(key);
+    console.log("Edge unlocked:", edge.from, edge.to);
+  }
+  document.addEventListener("tesseract:unlockNode", (e) => {
+    unlockNode(e.detail.id);
+  });
+  document.addEventListener("tesseract:unlockEdge", (e) => {
+    unlockEdge(e.detail);
+  });
+  window.tesseractHooks = { unlockNode, unlockEdge };
+})();

--- a/chapels/rooms-atlas.html
+++ b/chapels/rooms-atlas.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Rooms Atlas</title>
+    <link rel="stylesheet" href="/assets/css/alchemy-plates.css" />
+  </head>
+  <body>
+    <div id="rooms"></div>
+    <script src="/assets/js/engines/rooms-engine.js"></script>
+    <script src="/assets/js/engines/tesseract-bridge.js"></script>
+    <script src="/assets/js/engines/tesseract-hooks.js"></script>
+  </body>
+</html>

--- a/data/rooms.json
+++ b/data/rooms.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "agrippa",
+    "name": "Agrippa",
+    "description": "Renaissance polymath exploring occult philosophy.",
+    "quests": {
+      "read": "https://www.gutenberg.org/ebooks/33952",
+      "sketch": "https://commons.wikimedia.org/wiki/File:Agrippa_Von_Nettenheim.jpg",
+      "remix": "https://archive.org/details/threebooksoccult00agri"
+    }
+  },
+  {
+    "id": "hypatia",
+    "name": "Hypatia",
+    "description": "Alexandrian astronomer and philosopher.",
+    "quests": {
+      "read": "https://en.wikipedia.org/wiki/Hypatia",
+      "sketch": "https://commons.wikimedia.org/wiki/File:HYPATIA_(Museo_del_Prado).jpg",
+      "remix": "https://archive.org/details/hypatia00knip"
+    }
+  },
+  {
+    "id": "einstein",
+    "name": "Einstein",
+    "description": "Physicist of relativity and quanta.",
+    "quests": {
+      "read": "https://www.gutenberg.org/ebooks/5001",
+      "sketch": "https://commons.wikimedia.org/wiki/File:Einstein_1921_portrait2.jpg",
+      "remix": "https://archive.org/details/alberteinsteinre00einso"
+    }
+  }
+]

--- a/data/tesseract-nodes.json
+++ b/data/tesseract-nodes.json
@@ -1,0 +1,13 @@
+{
+  "nodes": [
+    { "id": "home", "label": "Home" },
+    { "id": "agrippa", "label": "Agrippa" },
+    { "id": "hypatia", "label": "Hypatia" },
+    { "id": "einstein", "label": "Einstein" }
+  ],
+  "edges": [
+    { "from": "home", "to": "agrippa" },
+    { "from": "home", "to": "hypatia" },
+    { "from": "home", "to": "einstein" }
+  ]
+}

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -1,0 +1,19 @@
+# Room Provenance
+
+## Agrippa
+
+- Read: [De Occulta Philosophia, Project Gutenberg](https://www.gutenberg.org/ebooks/33952)
+- Sketch: [Agrippa portrait, Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Agrippa_Von_Nettenheim.jpg)
+- Remix: [Three Books of Occult Philosophy, Internet Archive](https://archive.org/details/threebooksoccult00agri)
+
+## Hypatia
+
+- Read: [Hypatia entry, Wikipedia](https://en.wikipedia.org/wiki/Hypatia)
+- Sketch: [Hypatia painting, Wikimedia Commons](<https://commons.wikimedia.org/wiki/File:HYPATIA_(Museo_del_Prado).jpg>)
+- Remix: [Hypatia biography, Internet Archive](https://archive.org/details/hypatia00knip)
+
+## Einstein
+
+- Read: [Relativity, Project Gutenberg](https://www.gutenberg.org/ebooks/5001)
+- Sketch: [Einstein portrait, Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Einstein_1921_portrait2.jpg)
+- Remix: [Albert Einstein: Relativity, Internet Archive](https://archive.org/details/alberteinsteinre00einso)

--- a/modules/rooms-atlas.html
+++ b/modules/rooms-atlas.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Rooms Atlas</title>
+    <link rel="stylesheet" href="/assets/css/alchemy-plates.css" />
+  </head>
+  <body>
+    <div id="rooms"></div>
+    <script src="/assets/js/engines/rooms-engine.js"></script>
+    <script src="/assets/js/engines/tesseract-bridge.js"></script>
+    <script src="/assets/js/engines/tesseract-hooks.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add canonical rooms data and tesseract node map
- render rooms and micro-quests with events for tesseract
- link new rooms atlas pages in Cosmogenesis and Cathedral
- document legacy file cleanup task in TASKS.md

## Testing
- `npm test` *(fails: test/soundscape.test.js: test failed)*
- `npm run check` *(fails: SyntaxError: Unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68b6063451708328bef41ed2661e5305