### PR TITLE
feat: enable multi-chamber management

### DIFF
--- a/data/demos.json
+++ b/data/demos.json
@@ -5,15 +5,6 @@
       "layout": "wheel",
       "mode": 7,
       "labels": ["Red", "Orange", "Yellow", "Green", "Cyan", "Blue", "Violet"]
-      "labels": [
-        "Red",
-        "Orange",
-        "Yellow",
-        "Green",
-        "Cyan",
-        "Blue",
-        "Violet"
-      ]
     }
   },
   {
@@ -26,53 +17,6 @@
         "Small Business Workflow",
         "Sustainable City Plan"
       ]
-    }
-  }
-]
-  {
--+    "title": "Art • 7 Colors (Basic Design)",
--+    "config": {
--+      "layout": "wheel",
--+      "mode": 7,
--+      "labels": ["Red","Orange","Yellow","Green","Cyan","Blue","Violet"]
--+    }
--+  }
--+]
-+[
-+  {
-+    "title": "Art \u2022 7 Colors (Basic Design)",
-+    "config": {
-+      "layout": "wheel",
-+      "mode": 7,
-+      "labels": [
-+        "Red",
-+        "Orange",
-+        "Yellow",
-+        "Green",
-+        "Cyan",
-+        "Blue",
-+        "Violet"
-+      ]
-+    }
-+  },
-+  {
-+    "title": "Art \u2022 Visionary Dream",
-+    "config": {
-+      "layout": "spiral",
-+      "mode": 3,
-+      "labels": [
-+        "Community Garden",
-+        "Small Business Workflow",
-+        "Sustainable City Plan"
-+      ]
-+    }
-+  }
-+]
-    "title": "Art • 7 Colors (Basic Design)",
-    "config": {
-      "layout": "wheel",
-      "mode": 7,
-      "labels": ["Red","Orange","Yellow","Green","Cyan","Blue","Violet"]
     }
   }
 ]

--- a/plugins/soundscape.js
+++ b/plugins/soundscape.js
@@ -1,52 +1,31 @@
-// Simple binaural soundscape using the Web Audio API
-export default function soundscape(){
-  const AudioCtx = window.AudioContext || window.webkitAudioContext;
-  if(!AudioCtx){
-    alert('Web Audio API not supported');
-    return;
-  }
-  const ctx = new AudioCtx();
-  const oscL = ctx.createOscillator();
-  const oscR = ctx.createOscillator();
-  const merger = ctx.createChannelMerger(2);
-
-  oscL.frequency.value = 440; // left ear frequency
-  oscR.frequency.value = 446; // right ear slightly higher for binaural beat
-  oscL.connect(merger,0,0);
-  oscR.connect(merger,0,1);
-  merger.connect(ctx.destination);
-  oscL.start();
-  oscR.start();
-
-  return {
-    stop(){
-      oscL.stop();
-      oscR.stop();
-      ctx.close();
-    }
-  };
-}
+// Minimal binaural soundscape plugin
 export default {
   id: 'soundscape',
   activate(_engine, theme = 'hypatia') {
-    if (window.COSMO_SETTINGS?.muteAudio) return;
-    const AudioCtx = window.AudioContext || window.webkitAudioContext;
+    if (global.window?.COSMO_SETTINGS?.muteAudio) return;
+    const AudioCtx = global.window?.AudioContext;
+    if (!AudioCtx) {
+      global.window?.alert?.('Web Audio API not supported');
+      return;
+    }
     const ctx = new AudioCtx();
     const gain = ctx.createGain();
     gain.gain.value = 0.1;
     gain.connect(ctx.destination);
-
     const freqs = theme === 'tesla' ? [432, 864] : [220, 440];
     this._osc = freqs.map(f => {
       const osc = ctx.createOscillator();
       osc.frequency.value = f;
-      osc.connect(gain).start();
+      osc.connect(gain);
+      osc.start();
       return osc;
     });
     this._ctx = ctx;
   },
   deactivate() {
-    this._osc?.forEach(o => { try { o.stop(); } catch {} });
+    this._osc?.forEach(o => {
+      try { o.stop(); } catch {}
+    });
     this._osc = null;
     if (this._ctx) {
       this._ctx.close?.();
@@ -54,49 +33,3 @@ export default {
     }
   }
 };
-// Ambient soundscapes honoring realm archetypes
-export default function soundscape(realm){
-  // Respect global mute setting for neurodivergent care
-  if(window.COSMO_SETTINGS?.muteAudio) return;
-
-  const ctx = new (window.AudioContext || window.webkitAudioContext)();
-  // Tone pairs inspired by each visionary realm
-  const tones = {
-    hypatia: [196.0, 392.0],              // Hypatia's Library – contemplative hum
-    tesla: [329.63, 659.25],              // Tesla's Workshop – electric overtones
-    agrippa: [261.63, 523.25],            // Agrippa's Study – occult resonance
-    'alexandrian-scriptorium': [440.0]    // Sappho's Chord – lyric center
-  };
-  const freqs = tones[realm] || [220.0];  // Default tonic if realm unknown
-
-  // Layer gentle oscillators for a balanced chord
-  freqs.forEach((f, idx)=>{
-    const osc = ctx.createOscillator();
-    const gain = ctx.createGain();
-    osc.type = 'sine';
-    osc.frequency.value = f;
-    gain.gain.value = 0.03 / freqs.length;
-    osc.connect(gain);
-    gain.connect(ctx.destination);
-    osc.start();
-    osc.stop(ctx.currentTime + 2 + idx);
-  });
-}
-export default function soundscape(name) {
-  const settings = global.window?.COSMO_SETTINGS || {};
-  if (settings.muteAudio) return;
-
-  const ctx = new window.AudioContext();
-  const gain = ctx.createGain();
-  gain.connect(ctx.destination);
-
-  const base = { hypatia: 220, tesla: 330 }[name] || 440;
-  [base, base * 2].forEach((freq) => {
-    const osc = ctx.createOscillator();
-    osc.frequency.value = freq;
-    osc.connect(gain);
-    osc.start();
-    osc.stop(ctx.currentTime + 1);
-  });
-}
-

--- a/src/configLoader.js
+++ b/src/configLoader.js
@@ -1,60 +1,5 @@
--+export function loadFirstDemo() {
--+  const demos = loadConfig('data/demos.json');
--+  const config = demos[0].config;
--+  validatePlateConfig(config);
--+  return config;
--+}
-+import { readFileSync } from 'fs';
-+import path from 'path';
-+
-+// Load a JSON configuration file with basic error handling
-+export function loadConfig(relativePath) {
-+  const file = path.resolve(process.cwd(), relativePath);
-+  let raw;
-+  try {
-+    raw = readFileSync(file, 'utf8');
-+  } catch (err) {
-+    throw new Error(`Config file not found: ${relativePath}`);
-+  }
-+
-+  try {
-+    return JSON.parse(raw);
-+  } catch (err) {
-+    throw new Error(`Invalid JSON in ${relativePath}`);
-+  }
-+}
-+
-+// Ensure a plate config adheres to the minimal schema used by renderPlate
-+export function validatePlateConfig(config) {
-+  if (typeof config !== 'object' || config === null) {
-+    throw new Error('Config must be an object');
-+  }
-+  const layouts = ['spiral', 'twin-cone', 'wheel', 'grid'];
-+  if (!layouts.includes(config.layout)) {
-+    throw new Error('Unknown layout');
-+  }
-+  if (typeof config.mode !== 'number' || config.mode <= 0) {
-+    throw new Error('Mode must be a positive number');
-+  }
-+  if (!Array.isArray(config.labels)) {
-+    throw new Error('Labels must be an array');
-+  }
-+  if (config.labels.length !== config.mode) {
-+    throw new Error('Label count must match mode');
-+  }
-+}
-+
-+export function loadFirstDemo() {
-+  const demos = loadConfig('data/demos.json');
-+  const config = demos[0].config;
-+  validatePlateConfig(config);
-+  return config;
-+}
- 
-EOF
-)
-import { readFileSync } from 'fs';
-import path from 'path';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 
 // Load a JSON configuration file with basic error handling
 export function loadConfig(relativePath) {
@@ -62,16 +7,10 @@ export function loadConfig(relativePath) {
   let raw;
   try {
     raw = readFileSync(file, 'utf8');
-  } catch (err) {
-    throw new Error(`Config file not found: ${relativePath}`);
-  }
-
-  try {
-    return JSON.parse(raw);
-  } catch (err) {
   } catch {
     throw new Error(`Config file not found: ${relativePath}`);
   }
+
   try {
     return JSON.parse(raw);
   } catch {
@@ -105,4 +44,3 @@ export function loadFirstDemo() {
   validatePlateConfig(config);
   return config;
 }
-

--- a/src/engines/chamber-engine.js
+++ b/src/engines/chamber-engine.js
@@ -4,12 +4,30 @@ class ChamberEngine extends EventTarget {
     this.current = null;
     this.skin = null;
     this.guardian = null;
-    this.payload = null;
+    this.payloads = new Map();
+    this.openChambers = new Set();
   }
 
   open(id) {
     this.current = id;
+    this.openChambers.add(id);
     this.dispatchEvent(new CustomEvent('chamber:open', { detail: id }));
+  }
+
+  openMultiple(ids = []) {
+    ids.forEach((id) => {
+      this.openChambers.add(id);
+      this.dispatchEvent(new CustomEvent('chamber:open', { detail: id }));
+    });
+    this.current = ids.at(-1) ?? this.current;
+  }
+
+  close(id) {
+    this.openChambers.delete(id);
+    if (this.current === id) {
+      this.current = null;
+    }
+    this.dispatchEvent(new CustomEvent('chamber:close', { detail: id }));
   }
 
   applySkin(skinId) {
@@ -22,9 +40,24 @@ class ChamberEngine extends EventTarget {
     this.dispatchEvent(new CustomEvent('guardian:set', { detail: name }));
   }
 
-  setPayload(payload) {
-    this.payload = payload;
-    this.dispatchEvent(new CustomEvent('payload:set', { detail: payload }));
+  setPayload(payload, id = this.current) {
+    if (id == null) return;
+    this.payloads.set(id, payload);
+    this.dispatchEvent(
+      new CustomEvent('payload:set', { detail: { id, payload } })
+    );
+  }
+
+  getPayload(id = this.current) {
+    return id == null ? undefined : this.payloads.get(id);
+  }
+
+  copyPayload(fromId, toId = this.current) {
+    const payload = this.getPayload(fromId);
+    if (payload !== undefined && toId != null) {
+      this.setPayload(payload, toId);
+    }
+    return payload;
   }
 }
 

--- a/src/renderPlate.js
+++ b/src/renderPlate.js
@@ -46,7 +46,6 @@ function gridPositions(count) {
 }
 
 export function renderPlate(config) {
-  if (!config || typeof config.layout !== 'string' || typeof config.mode !== 'number' || !Array.isArray(config.labels)) {
   if (
     !config ||
     typeof config.layout !== 'string' ||
@@ -95,4 +94,3 @@ export function renderPlate(config) {
 
   return { ...config, items, exportAsJSON, exportAsSVG, exportAsPNG };
 }
-

--- a/test/chamber-engine.test.js
+++ b/test/chamber-engine.test.js
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { chamberEngine } from '../src/engines/chamber-engine.js';
+
+const resetEngine = () => {
+  chamberEngine.openChambers.clear();
+  chamberEngine.payloads.clear();
+  chamberEngine.current = null;
+};
+
+test('openMultiple opens all chambers and sets current', () => {
+  resetEngine();
+  chamberEngine.openMultiple(['alpha', 'beta']);
+  assert.deepEqual([...chamberEngine.openChambers], ['alpha', 'beta']);
+  assert.equal(chamberEngine.current, 'beta');
+});
+
+test('copyPayload duplicates payload between chambers', () => {
+  resetEngine();
+  chamberEngine.openMultiple(['alpha', 'beta']);
+  chamberEngine.setPayload('source data', 'alpha');
+  chamberEngine.copyPayload('alpha', 'beta');
+  assert.equal(chamberEngine.getPayload('beta'), 'source data');
+});

--- a/test/config-loader.test.js
+++ b/test/config-loader.test.js
@@ -1,14 +1,9 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { writeFileSync, unlinkSync } from 'node:fs';
 import { loadConfig, validatePlateConfig } from '../src/configLoader.js';
-import { test } from 'node:test';
-import { strict as assert } from 'assert';
-import { test } from 'node:test';
-import { strict as assert } from 'assert';
-import { loadConfig, validatePlateConfig } from '../src/configLoader.js';
-import { writeFileSync, unlinkSync } from 'fs';
 
 // Ensure loadConfig surfaces invalid JSON errors
-import { writeFileSync, unlinkSync } from 'fs';
-
 test('loadConfig throws on invalid JSON', () => {
   const file = 'test/fixtures/bad.json';
   writeFileSync(file, '{');
@@ -23,4 +18,3 @@ test('validatePlateConfig enforces label count', () => {
   const bad = { ...good, labels: [] };
   assert.throws(() => validatePlateConfig(bad), /Label count/);
 });
-

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -1,16 +1,15 @@
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
-
-test('basic arithmetic works', () => {
-  assert.equal(1 + 1, 2);
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
 import { loadConfig } from '../src/configLoader.js';
 import { renderPlate } from '../src/renderPlate.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+test('basic arithmetic works', () => {
+  assert.equal(1 + 1, 2);
+});
 
 test('renderPlate renders first demo plate without throwing', () => {
   const demos = loadConfig(join(__dirname, '..', 'data', 'demos.json'));
@@ -18,19 +17,4 @@ test('renderPlate renders first demo plate without throwing', () => {
   const plate = renderPlate(config);
   assert.equal(plate.layout, config.layout);
   assert.equal(plate.labels.length, config.mode);
-import { strict as assert } from 'assert';
-import { loadFirstDemo } from '../src/configLoader.js';
-
-test('loadFirstDemo returns valid config', () => {
-  const config = loadFirstDemo();
-  assert.equal(typeof config.layout, 'string');
-  assert.equal(config.labels.length, config.mode);
 });
-import { strict as assert } from 'assert';
-import { renderPlate } from '../src/renderPlate.js';
-
-test('renderPlate creates items for basic wheel', () => {
-  const plate = renderPlate({ layout: 'wheel', mode: 3, labels: ['a', 'b', 'c'] });
-  assert.equal(plate.items.length, 3);
-});
-

--- a/test/soundscape.test.js
+++ b/test/soundscape.test.js
@@ -1,127 +1,41 @@
-import { test } from 'node:test';
+import test from 'node:test';
 import assert from 'node:assert/strict';
 import soundscape from '../plugins/soundscape.js';
 
-function cleanup(){ delete global.window; delete global.alert; }
-
-test('soundscape respects mute', ()=>{
-  global.window = { COSMO_SETTINGS: { muteAudio: true } };
-  global.alert = () => {};
-  assert.doesNotThrow(()=> soundscape('hypatia'));
-import soundscape from '../plugins/soundscape.js';
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
-
-// Clean window after each test
-function cleanup(){ delete global.window; }
-
-test('soundscape respects mute', ()=>{
-  global.window = { COSMO_SETTINGS: { muteAudio: true } };
-  assert.doesNotThrow(()=> soundscape.activate(null,'hypatia'));
-  assert.doesNotThrow(()=> soundscape('hypatia'));
-  cleanup();
-});
-
-test('soundscape starts oscillators when not muted', ()=>{
-  let started = 0;
-  class FakeOsc { constructor(){ this.frequency={value:0}; } connect(){ return this; } start(){ started++; } stop(){} }
-  class FakeGain { constructor(){ this.gain={value:0}; } connect(){ return this; } }
-  class FakeMerger { connect(){ return this; } }
-  class FakeAudioCtx {
-    constructor(){ this.currentTime = 0; this.destination = {}; }
-    createOscillator(){ return new FakeOsc(); }
-    createGain(){ return new FakeGain(); }
-    createChannelMerger(){ return new FakeMerger(); }
-  }
-  global.window = { COSMO_SETTINGS: { muteAudio: false }, AudioContext: FakeAudioCtx };
-  global.alert = () => {};
-  assert.doesNotThrow(()=> soundscape('tesla'));
-  assert.equal(started,2);
-  class FakeGain { constructor(){ this.gain={value:0}; } connect(){ } }
-  class FakeGain { constructor(){ this.gain={value:0}; } connect(){ }
-import { strict as assert } from 'assert';
-import soundscape from '../plugins/soundscape.js';
-
-// Clean window after each test
-function cleanup() {
-  delete global.window;
-  delete global.alert;
 function cleanup() {
   delete global.window;
 }
 
 test('soundscape respects mute', () => {
   global.window = { COSMO_SETTINGS: { muteAudio: true } };
-  global.alert = () => {};
-  assert.doesNotThrow(() => soundscape('hypatia'));
+  assert.doesNotThrow(() => soundscape.activate(null, 'hypatia'));
   cleanup();
 });
 
 test('soundscape starts oscillators when not muted', () => {
   let started = 0;
+
   class FakeOsc {
-    constructor() {
-      this.frequency = { value: 0 };
-    }
-    connect() {
-      return this;
-    }
-    start() {
-      started++;
-    }
-    stop() {}
-  }
-  class FakeGain {
-    constructor() {
-      this.gain = { value: 0 };
-    }
-    connect() {}
-  }
-  class FakeMerger {
     constructor() { this.frequency = { value: 0 }; }
     connect() { return this; }
     start() { started++; }
     stop() {}
   }
+
   class FakeGain {
     constructor() { this.gain = { value: 0 }; }
-    connect() {}
+    connect() { return this; }
   }
-  global.window = {
-    COSMO_SETTINGS: { muteAudio: false },
-    AudioContext: class {
-      constructor(){ this.currentTime = 0; this.destination = {}; }
-      createOscillator(){ return new FakeOsc(); }
-      createGain(){ return new FakeGain(); }
-    }
-  };
-  assert.doesNotThrow(()=> soundscape.activate(null,'tesla'));
-  assert.equal(started,2);
-  soundscape.deactivate();
-  assert.doesNotThrow(()=> soundscape('tesla'));
-  assert.equal(started,2);
-      constructor() {
-        this.currentTime = 0;
-        this.destination = {};
-      }
-      createOscillator() {
-        return new FakeOsc();
-      }
-      createGain() {
-        return new FakeGain();
-      }
-      createChannelMerger() {
-        return new FakeMerger();
-      }
-    },
-  };
-      constructor() { this.currentTime = 0; this.destination = {}; }
-      createOscillator() { return new FakeOsc(); }
-      createGain() { return new FakeGain(); }
-    }
-  };
-  assert.doesNotThrow(() => soundscape('tesla'));
+
+  class FakeCtx {
+    constructor() { this.currentTime = 0; this.destination = {}; }
+    createOscillator() { return new FakeOsc(); }
+    createGain() { return new FakeGain(); }
+  }
+
+  global.window = { COSMO_SETTINGS: { muteAudio: false }, AudioContext: FakeCtx };
+  assert.doesNotThrow(() => soundscape.activate(null, 'tesla'));
   assert.equal(started, 2);
+  soundscape.deactivate();
   cleanup();
 });
-


### PR DESCRIPTION
## Summary
- allow ChamberEngine to track multiple open chambers and copy payloads between them
- fix syntax errors and clean up config loader, render plate, soundscape plugin, and data fixtures
- add tests for multi-chamber handling, payload duplication, and soundscape behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6109b91ac832893707c712b6b9da9