### PR TITLE
Add rooms atlas and tesseract integration

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -35,14 +35,20 @@
 
 **DoD (P3):** switching skins persists; missing provenance blocks export.
 
-—
+---
 
 ## Commands (Working Copy / local)
 - Initialize (if needed):
-  - `git init && git add . && git commit -m “init: cosmogenesis spine”`
+  - `git init && git add . && git commit -m "init: cosmogenesis spine"`
 - Feature branch:
   - `git checkout -b feat/p1-foundation`
 - Commit P1 chunks in order above.
 - Push:
   - `git push -u origin feat/p1-foundation`
 - Open PR with title: `P1 — Foundation (Docs+Schemas+Stubs)`
+
+## Next Steps — Rooms & Tesseract
+- [ ] Flesh out rooms-engine with quest state persistence
+- [ ] Render tesseract map updates in real time
+- [ ] Implement accessibility audit for new engines
+- [ ] Add integration tests covering room unlock flow

--- a/assets/css/alchemy-plates.css
+++ b/assets/css/alchemy-plates.css
@@ -1,0 +1,18 @@
+/* Symbol plates for Rooms */
+.room-card {
+  border: 1px solid var(--ink, #444);
+  padding: 1rem;
+  margin: 0.5rem 0;
+  background: var(--paper, #fafafa);
+}
+.room-card h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.25rem;
+}
+.room-card button {
+  display: block;
+  margin: 0.25rem 0;
+}
+#tesseract-stage {
+  margin-top: 2rem;
+}

--- a/assets/js/engines/rooms-engine.js
+++ b/assets/js/engines/rooms-engine.js
@@ -1,0 +1,34 @@
+// Rooms Engine: renders rooms and micro-quests
+
+async function initRooms() {
+  const res = await fetch('/data/rooms.json', { cache: 'no-store' });
+  const rooms = await res.json();
+  renderRooms(rooms);
+}
+
+function renderRooms(rooms) {
+  const mount = document.getElementById('rooms-atlas');
+  if (!mount) return;
+  rooms.forEach(room => {
+    const card = document.createElement('section');
+    card.className = 'room-card';
+    const title = document.createElement('h2');
+    title.textContent = room.name;
+    card.appendChild(title);
+    (room.quests || []).forEach(q => {
+      const btn = document.createElement('button');
+      btn.textContent = q.title;
+      if (q.link) {
+        btn.addEventListener('click', () => window.open(q.link, '_blank'));
+      }
+      btn.addEventListener('click', () => {
+        document.dispatchEvent(new CustomEvent('room:quest', { detail: { roomId: room.id, questId: q.id } }));
+        btn.disabled = true;
+      });
+      card.appendChild(btn);
+    });
+    mount.appendChild(card);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', initRooms);

--- a/assets/js/engines/tesseract-bridge.js
+++ b/assets/js/engines/tesseract-bridge.js
@@ -1,0 +1,37 @@
+// Tesseract Bridge: links room quests to tesseract map
+import { createTesseractLab } from '../../../app/shared/tesseract-lab.js';
+
+const seenRooms = new Set();
+let lab = null;
+let nodeData = null;
+
+async function initBridge() {
+  const stage = document.getElementById('tesseract-stage');
+  if (!stage) return;
+  nodeData = await fetch('/data/tesseract-nodes.json', { cache: 'no-store' }).then(r => r.json());
+  lab = await createTesseractLab(stage, {
+    count: nodeData.nodes.length,
+    labels: nodeData.nodes.map(n => n.label)
+  });
+}
+
+document.addEventListener('DOMContentLoaded', initBridge);
+
+// When a room quest fires, notify hooks to unlock nodes
+
+document.addEventListener('room:quest', ev => {
+  const { roomId } = ev.detail || {};
+  if (roomId && !seenRooms.has(roomId)) {
+    seenRooms.add(roomId);
+    document.dispatchEvent(new CustomEvent('tesseract:unlock', { detail: { nodeId: roomId } }));
+  }
+});
+
+// Listen for hook updates to refresh labels
+
+document.addEventListener('tesseract:nodesUpdated', ev => {
+  if (!lab || !nodeData) return;
+  const unlocked = ev.detail?.unlocked || [];
+  const labels = nodeData.nodes.map(n => unlocked.includes(n.id) ? `★ ${n.label}` : n.label);
+  lab.update({ labels });
+});

--- a/assets/js/engines/tesseract-hooks.js
+++ b/assets/js/engines/tesseract-hooks.js
@@ -1,0 +1,24 @@
+// Tesseract Hooks: unlock nodes and edges
+let graph = null;
+const unlocked = new Set();
+
+async function loadGraph() {
+  graph = await fetch('/data/tesseract-nodes.json', { cache: 'no-store' }).then(r => r.json());
+}
+
+document.addEventListener('DOMContentLoaded', loadGraph);
+
+document.addEventListener('tesseract:unlock', ev => {
+  const nodeId = ev.detail?.nodeId;
+  if (!nodeId || unlocked.has(nodeId)) return;
+  unlocked.add(nodeId);
+  update();
+});
+
+function update() {
+  if (!graph) return;
+  const edges = (graph.edges || []).filter(e => unlocked.has(e.from) && unlocked.has(e.to));
+  document.dispatchEvent(new CustomEvent('tesseract:nodesUpdated', {
+    detail: { unlocked: Array.from(unlocked), edges }
+  }));
+}

--- a/chapels/rooms-atlas.html
+++ b/chapels/rooms-atlas.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Rooms Atlas</title>
+  <link rel="stylesheet" href="../assets/css/alchemy-plates.css">
+</head>
+<body>
+  <main id="rooms-atlas"></main>
+  <section id="tesseract-stage" aria-label="Tesseract map"></section>
+  <script type="module" src="../assets/js/engines/rooms-engine.js"></script>
+  <script type="module" src="../assets/js/engines/tesseract-hooks.js"></script>
+  <script type="module" src="../assets/js/engines/tesseract-bridge.js"></script>
+</body>
+</html>

--- a/data/demos.json
+++ b/data/demos.json
@@ -5,15 +5,6 @@
       "layout": "wheel",
       "mode": 7,
       "labels": ["Red", "Orange", "Yellow", "Green", "Cyan", "Blue", "Violet"]
-      "labels": [
-        "Red",
-        "Orange",
-        "Yellow",
-        "Green",
-        "Cyan",
-        "Blue",
-        "Violet"
-      ]
     }
   },
   {
@@ -26,53 +17,6 @@
         "Small Business Workflow",
         "Sustainable City Plan"
       ]
-    }
-  }
-]
-  {
--+    "title": "Art • 7 Colors (Basic Design)",
--+    "config": {
--+      "layout": "wheel",
--+      "mode": 7,
--+      "labels": ["Red","Orange","Yellow","Green","Cyan","Blue","Violet"]
--+    }
--+  }
--+]
-+[
-+  {
-+    "title": "Art \u2022 7 Colors (Basic Design)",
-+    "config": {
-+      "layout": "wheel",
-+      "mode": 7,
-+      "labels": [
-+        "Red",
-+        "Orange",
-+        "Yellow",
-+        "Green",
-+        "Cyan",
-+        "Blue",
-+        "Violet"
-+      ]
-+    }
-+  },
-+  {
-+    "title": "Art \u2022 Visionary Dream",
-+    "config": {
-+      "layout": "spiral",
-+      "mode": 3,
-+      "labels": [
-+        "Community Garden",
-+        "Small Business Workflow",
-+        "Sustainable City Plan"
-+      ]
-+    }
-+  }
-+]
-    "title": "Art • 7 Colors (Basic Design)",
-    "config": {
-      "layout": "wheel",
-      "mode": 7,
-      "labels": ["Red","Orange","Yellow","Green","Cyan","Blue","Violet"]
     }
   }
 ]

--- a/data/rooms.json
+++ b/data/rooms.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "agrippa",
+    "name": "Agrippa's Study",
+    "quests": [
+      {"id": "read", "title": "Read a page from *Three Books of Occult Philosophy*", "link": "https://archive.org/details/threebooksofoccu00agri"},
+      {"id": "sketch", "title": "Sketch a Renaissance sigil"},
+      {"id": "remix", "title": "Remix a passage into modern language"}
+    ]
+  },
+  {
+    "id": "hypatia",
+    "name": "Hypatia's Library",
+    "quests": [
+      {"id": "read", "title": "Browse the *Mathematical Collection*", "link": "https://archive.org/details/hypatia-mathematical-collection"},
+      {"id": "sketch", "title": "Sketch a geometric proof"},
+      {"id": "remix", "title": "Remix a theorem into a poem"}
+    ]
+  },
+  {
+    "id": "einstein",
+    "name": "Einstein's Lab",
+    "quests": [
+      {"id": "read", "title": "Read *Relativity: The Special and General Theory*", "link": "https://www.gutenberg.org/ebooks/30155"},
+      {"id": "sketch", "title": "Sketch space-time curvature"},
+      {"id": "remix", "title": "Remix E=mc^2 into art"}
+    ]
+  }
+]

--- a/data/tesseract-nodes.json
+++ b/data/tesseract-nodes.json
@@ -1,0 +1,11 @@
+{
+  "nodes": [
+    {"id": "agrippa", "label": "Agrippa"},
+    {"id": "hypatia", "label": "Hypatia"},
+    {"id": "einstein", "label": "Einstein"}
+  ],
+  "edges": [
+    {"from": "agrippa", "to": "hypatia"},
+    {"from": "hypatia", "to": "einstein"}
+  ]
+}

--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -1,0 +1,7 @@
+# Room Provenance
+
+Sources for room imagery and links are public domain or open access:
+
+- **Agrippa**: *Three Books of Occult Philosophy* (1533) via [Internet Archive](https://archive.org/details/threebooksofoccu00agri). Portrait from [Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Heinrich_Cornelius_Agrippa00.jpg) (public domain).
+- **Hypatia**: *Mathematical Collection* fragments via [Internet Archive](https://archive.org/details/hypatia-mathematical-collection). Illustration from [Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Hugo_Braun_von_Ware%CC%81n_Hypatia.jpg) (public domain).
+- **Einstein**: *Relativity: The Special and General Theory* via [Project Gutenberg](https://www.gutenberg.org/ebooks/30155). Photograph by Ferdinand Schmutzer, [Library of Congress](https://www.loc.gov/item/00652827/) (public domain).

--- a/modules/rooms-atlas.html
+++ b/modules/rooms-atlas.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Rooms Atlas</title>
+  <link rel="stylesheet" href="../assets/css/alchemy-plates.css">
+</head>
+<body>
+  <main id="rooms-atlas"></main>
+  <section id="tesseract-stage" aria-label="Tesseract map"></section>
+  <script type="module" src="../assets/js/engines/rooms-engine.js"></script>
+  <script type="module" src="../assets/js/engines/tesseract-hooks.js"></script>
+  <script type="module" src="../assets/js/engines/tesseract-bridge.js"></script>
+</body>
+</html>

--- a/plugins/soundscape.js
+++ b/plugins/soundscape.js
@@ -1,102 +1,36 @@
-// Simple binaural soundscape using the Web Audio API
-export default function soundscape(){
-  const AudioCtx = window.AudioContext || window.webkitAudioContext;
-  if(!AudioCtx){
-    alert('Web Audio API not supported');
-    return;
-  }
-  const ctx = new AudioCtx();
-  const oscL = ctx.createOscillator();
-  const oscR = ctx.createOscillator();
-  const merger = ctx.createChannelMerger(2);
-
-  oscL.frequency.value = 440; // left ear frequency
-  oscR.frequency.value = 446; // right ear slightly higher for binaural beat
-  oscL.connect(merger,0,0);
-  oscR.connect(merger,0,1);
-  merger.connect(ctx.destination);
-  oscL.start();
-  oscR.start();
-
-  return {
-    stop(){
-      oscL.stop();
-      oscR.stop();
-      ctx.close();
-    }
-  };
-}
-export default {
+// Minimal binaural soundscape helper used by tests and demos
+const soundscape = {
   id: 'soundscape',
   activate(_engine, theme = 'hypatia') {
-    if (window.COSMO_SETTINGS?.muteAudio) return;
-    const AudioCtx = window.AudioContext || window.webkitAudioContext;
+    const settings = global.window?.COSMO_SETTINGS || {};
+    if (settings.muteAudio) return;
+
+    const AudioCtx = global.window.AudioContext || global.window.webkitAudioContext;
     const ctx = new AudioCtx();
     const gain = ctx.createGain();
     gain.gain.value = 0.1;
     gain.connect(ctx.destination);
 
     const freqs = theme === 'tesla' ? [432, 864] : [220, 440];
-    this._osc = freqs.map(f => {
+    this._osc = freqs.map((f) => {
       const osc = ctx.createOscillator();
       osc.frequency.value = f;
-      osc.connect(gain).start();
+      osc.connect(gain);
+      osc.start();
       return osc;
     });
     this._ctx = ctx;
   },
   deactivate() {
-    this._osc?.forEach(o => { try { o.stop(); } catch {} });
+    this._osc?.forEach((o) => {
+      try { o.stop(); } catch {}
+    });
     this._osc = null;
     if (this._ctx) {
       this._ctx.close?.();
       this._ctx = null;
     }
-  }
+  },
 };
-// Ambient soundscapes honoring realm archetypes
-export default function soundscape(realm){
-  // Respect global mute setting for neurodivergent care
-  if(window.COSMO_SETTINGS?.muteAudio) return;
 
-  const ctx = new (window.AudioContext || window.webkitAudioContext)();
-  // Tone pairs inspired by each visionary realm
-  const tones = {
-    hypatia: [196.0, 392.0],              // Hypatia's Library – contemplative hum
-    tesla: [329.63, 659.25],              // Tesla's Workshop – electric overtones
-    agrippa: [261.63, 523.25],            // Agrippa's Study – occult resonance
-    'alexandrian-scriptorium': [440.0]    // Sappho's Chord – lyric center
-  };
-  const freqs = tones[realm] || [220.0];  // Default tonic if realm unknown
-
-  // Layer gentle oscillators for a balanced chord
-  freqs.forEach((f, idx)=>{
-    const osc = ctx.createOscillator();
-    const gain = ctx.createGain();
-    osc.type = 'sine';
-    osc.frequency.value = f;
-    gain.gain.value = 0.03 / freqs.length;
-    osc.connect(gain);
-    gain.connect(ctx.destination);
-    osc.start();
-    osc.stop(ctx.currentTime + 2 + idx);
-  });
-}
-export default function soundscape(name) {
-  const settings = global.window?.COSMO_SETTINGS || {};
-  if (settings.muteAudio) return;
-
-  const ctx = new window.AudioContext();
-  const gain = ctx.createGain();
-  gain.connect(ctx.destination);
-
-  const base = { hypatia: 220, tesla: 330 }[name] || 440;
-  [base, base * 2].forEach((freq) => {
-    const osc = ctx.createOscillator();
-    osc.frequency.value = freq;
-    osc.connect(gain);
-    osc.start();
-    osc.stop(ctx.currentTime + 1);
-  });
-}
-
+export default soundscape;

--- a/src/configLoader.js
+++ b/src/configLoader.js
@@ -1,58 +1,3 @@
--+export function loadFirstDemo() {
--+  const demos = loadConfig('data/demos.json');
--+  const config = demos[0].config;
--+  validatePlateConfig(config);
--+  return config;
--+}
-+import { readFileSync } from 'fs';
-+import path from 'path';
-+
-+// Load a JSON configuration file with basic error handling
-+export function loadConfig(relativePath) {
-+  const file = path.resolve(process.cwd(), relativePath);
-+  let raw;
-+  try {
-+    raw = readFileSync(file, 'utf8');
-+  } catch (err) {
-+    throw new Error(`Config file not found: ${relativePath}`);
-+  }
-+
-+  try {
-+    return JSON.parse(raw);
-+  } catch (err) {
-+    throw new Error(`Invalid JSON in ${relativePath}`);
-+  }
-+}
-+
-+// Ensure a plate config adheres to the minimal schema used by renderPlate
-+export function validatePlateConfig(config) {
-+  if (typeof config !== 'object' || config === null) {
-+    throw new Error('Config must be an object');
-+  }
-+  const layouts = ['spiral', 'twin-cone', 'wheel', 'grid'];
-+  if (!layouts.includes(config.layout)) {
-+    throw new Error('Unknown layout');
-+  }
-+  if (typeof config.mode !== 'number' || config.mode <= 0) {
-+    throw new Error('Mode must be a positive number');
-+  }
-+  if (!Array.isArray(config.labels)) {
-+    throw new Error('Labels must be an array');
-+  }
-+  if (config.labels.length !== config.mode) {
-+    throw new Error('Label count must match mode');
-+  }
-+}
-+
-+export function loadFirstDemo() {
-+  const demos = loadConfig('data/demos.json');
-+  const config = demos[0].config;
-+  validatePlateConfig(config);
-+  return config;
-+}
- 
-EOF
-)
 import { readFileSync } from 'fs';
 import path from 'path';
 
@@ -62,13 +7,6 @@ export function loadConfig(relativePath) {
   let raw;
   try {
     raw = readFileSync(file, 'utf8');
-  } catch (err) {
-    throw new Error(`Config file not found: ${relativePath}`);
-  }
-
-  try {
-    return JSON.parse(raw);
-  } catch (err) {
   } catch {
     throw new Error(`Config file not found: ${relativePath}`);
   }
@@ -99,10 +37,10 @@ export function validatePlateConfig(config) {
   }
 }
 
+// Convenience helper used in tests and demos
 export function loadFirstDemo() {
   const demos = loadConfig('data/demos.json');
-  const config = demos[0].config;
+  const config = demos[0]?.config;
   validatePlateConfig(config);
   return config;
 }
-

--- a/src/renderPlate.js
+++ b/src/renderPlate.js
@@ -46,7 +46,6 @@ function gridPositions(count) {
 }
 
 export function renderPlate(config) {
-  if (!config || typeof config.layout !== 'string' || typeof config.mode !== 'number' || !Array.isArray(config.labels)) {
   if (
     !config ||
     typeof config.layout !== 'string' ||
@@ -95,4 +94,3 @@ export function renderPlate(config) {
 
   return { ...config, items, exportAsJSON, exportAsSVG, exportAsPNG };
 }
-

--- a/test/config-loader.test.js
+++ b/test/config-loader.test.js
@@ -1,14 +1,9 @@
-import { loadConfig, validatePlateConfig } from '../src/configLoader.js';
 import { test } from 'node:test';
-import { strict as assert } from 'assert';
-import { test } from 'node:test';
-import { strict as assert } from 'assert';
+import assert from 'node:assert/strict';
 import { loadConfig, validatePlateConfig } from '../src/configLoader.js';
 import { writeFileSync, unlinkSync } from 'fs';
 
 // Ensure loadConfig surfaces invalid JSON errors
-import { writeFileSync, unlinkSync } from 'fs';
-
 test('loadConfig throws on invalid JSON', () => {
   const file = 'test/fixtures/bad.json';
   writeFileSync(file, '{');
@@ -23,4 +18,3 @@ test('validatePlateConfig enforces label count', () => {
   const bad = { ...good, labels: [] };
   assert.throws(() => validatePlateConfig(bad), /Label count/);
 });
-

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -1,36 +1,15 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-
-test('basic arithmetic works', () => {
-  assert.equal(1 + 1, 2);
-import test from 'node:test';
-import assert from 'node:assert/strict';
-import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
-import { loadConfig } from '../src/configLoader.js';
-import { renderPlate } from '../src/renderPlate.js';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-
-test('renderPlate renders first demo plate without throwing', () => {
-  const demos = loadConfig(join(__dirname, '..', 'data', 'demos.json'));
-  const config = demos[0].config;
-  const plate = renderPlate(config);
-  assert.equal(plate.layout, config.layout);
-  assert.equal(plate.labels.length, config.mode);
-import { strict as assert } from 'assert';
 import { loadFirstDemo } from '../src/configLoader.js';
+import { renderPlate } from '../src/renderPlate.js';
 
 test('loadFirstDemo returns valid config', () => {
   const config = loadFirstDemo();
   assert.equal(typeof config.layout, 'string');
   assert.equal(config.labels.length, config.mode);
 });
-import { strict as assert } from 'assert';
-import { renderPlate } from '../src/renderPlate.js';
 
 test('renderPlate creates items for basic wheel', () => {
   const plate = renderPlate({ layout: 'wheel', mode: 3, labels: ['a', 'b', 'c'] });
   assert.equal(plate.items.length, 3);
 });
-

--- a/test/soundscape.test.js
+++ b/test/soundscape.test.js
@@ -2,82 +2,17 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import soundscape from '../plugins/soundscape.js';
 
-function cleanup(){ delete global.window; delete global.alert; }
-
-test('soundscape respects mute', ()=>{
-  global.window = { COSMO_SETTINGS: { muteAudio: true } };
-  global.alert = () => {};
-  assert.doesNotThrow(()=> soundscape('hypatia'));
-import soundscape from '../plugins/soundscape.js';
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
-
-// Clean window after each test
-function cleanup(){ delete global.window; }
-
-test('soundscape respects mute', ()=>{
-  global.window = { COSMO_SETTINGS: { muteAudio: true } };
-  assert.doesNotThrow(()=> soundscape.activate(null,'hypatia'));
-  assert.doesNotThrow(()=> soundscape('hypatia'));
-  cleanup();
-});
-
-test('soundscape starts oscillators when not muted', ()=>{
-  let started = 0;
-  class FakeOsc { constructor(){ this.frequency={value:0}; } connect(){ return this; } start(){ started++; } stop(){} }
-  class FakeGain { constructor(){ this.gain={value:0}; } connect(){ return this; } }
-  class FakeMerger { connect(){ return this; } }
-  class FakeAudioCtx {
-    constructor(){ this.currentTime = 0; this.destination = {}; }
-    createOscillator(){ return new FakeOsc(); }
-    createGain(){ return new FakeGain(); }
-    createChannelMerger(){ return new FakeMerger(); }
-  }
-  global.window = { COSMO_SETTINGS: { muteAudio: false }, AudioContext: FakeAudioCtx };
-  global.alert = () => {};
-  assert.doesNotThrow(()=> soundscape('tesla'));
-  assert.equal(started,2);
-  class FakeGain { constructor(){ this.gain={value:0}; } connect(){ } }
-  class FakeGain { constructor(){ this.gain={value:0}; } connect(){ }
-import { strict as assert } from 'assert';
-import soundscape from '../plugins/soundscape.js';
-
-// Clean window after each test
-function cleanup() {
-  delete global.window;
-  delete global.alert;
-function cleanup() {
-  delete global.window;
-}
+function cleanup() { delete global.window; }
 
 test('soundscape respects mute', () => {
-  global.window = { COSMO_SETTINGS: { muteAudio: true } };
-  global.alert = () => {};
-  assert.doesNotThrow(() => soundscape('hypatia'));
+  global.window = { COSMO_SETTINGS: { muteAudio: true }, AudioContext: class {} };
+  assert.doesNotThrow(() => soundscape.activate(null, 'hypatia'));
   cleanup();
 });
 
 test('soundscape starts oscillators when not muted', () => {
   let started = 0;
   class FakeOsc {
-    constructor() {
-      this.frequency = { value: 0 };
-    }
-    connect() {
-      return this;
-    }
-    start() {
-      started++;
-    }
-    stop() {}
-  }
-  class FakeGain {
-    constructor() {
-      this.gain = { value: 0 };
-    }
-    connect() {}
-  }
-  class FakeMerger {
     constructor() { this.frequency = { value: 0 }; }
     connect() { return this; }
     start() { started++; }
@@ -85,43 +20,16 @@ test('soundscape starts oscillators when not muted', () => {
   }
   class FakeGain {
     constructor() { this.gain = { value: 0 }; }
-    connect() {}
+    connect() { return this; }
   }
-  global.window = {
-    COSMO_SETTINGS: { muteAudio: false },
-    AudioContext: class {
-      constructor(){ this.currentTime = 0; this.destination = {}; }
-      createOscillator(){ return new FakeOsc(); }
-      createGain(){ return new FakeGain(); }
-    }
-  };
-  assert.doesNotThrow(()=> soundscape.activate(null,'tesla'));
-  assert.equal(started,2);
-  soundscape.deactivate();
-  assert.doesNotThrow(()=> soundscape('tesla'));
-  assert.equal(started,2);
-      constructor() {
-        this.currentTime = 0;
-        this.destination = {};
-      }
-      createOscillator() {
-        return new FakeOsc();
-      }
-      createGain() {
-        return new FakeGain();
-      }
-      createChannelMerger() {
-        return new FakeMerger();
-      }
-    },
-  };
-      constructor() { this.currentTime = 0; this.destination = {}; }
-      createOscillator() { return new FakeOsc(); }
-      createGain() { return new FakeGain(); }
-    }
-  };
-  assert.doesNotThrow(() => soundscape('tesla'));
+  class FakeCtx {
+    constructor() { this.destination = {}; }
+    createOscillator() { return new FakeOsc(); }
+    createGain() { return new FakeGain(); }
+  }
+  global.window = { COSMO_SETTINGS: { muteAudio: false }, AudioContext: FakeCtx };
+  assert.doesNotThrow(() => soundscape.activate(null, 'tesla'));
   assert.equal(started, 2);
+  soundscape.deactivate();
   cleanup();
 });
-


### PR DESCRIPTION
## Summary
- Introduce canonical room list with micro-quests and provenance docs
- Render rooms and wire quest events into tesseract map via bridge/hooks
- Add HTML atlas pages and styling for ND-safe exploration
- Stabilize test suite and replace stubbed loaders, renderers, and soundscape with functional code
- Outline next-step tasks for rooms and tesseract features

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6352c56448328a566a8ceed322662