### PR TITLE
feat: add global healing web experience

### DIFF
--- a/app/experience_e/components/fractalWeb.js
+++ b/app/experience_e/components/fractalWeb.js
@@ -1,0 +1,51 @@
+const traditions = [
+  {
+    name: "Usui Reiki",
+    note: "Japanese method founded by Mikao Usui around 1922."
+  },
+  {
+    name: "Tibetan Raku Kei",
+    note: "Modern lineage linking Reiki practices with Himalayan symbols."
+  },
+  {
+    name: "Karuna Reiki",
+    note: "William Lee Rand's 1990s school centered on compassionate action."
+  },
+  {
+    name: "Seichim / Sekhem",
+    note: "Energy work inspired by the Egyptian word for vital force."
+  },
+  {
+    name: "Hypnosis",
+    note: "Trance arts traced to Greek and Egyptian dream temples."
+  },
+  {
+    name: "EMDR",
+    note: "Eye-movement therapy created by Francine Shapiro in 1987."
+  },
+  {
+    name: "Brainspotting",
+    note: "David Grand's gaze-based trauma release technique from 2003."
+  }
+];
+
+export default function mount(el) {
+  let idx = 0;
+  const btn = document.createElement("button");
+  const note = document.createElement("p");
+
+  function update() {
+    const t = traditions[idx];
+    btn.textContent = `Explore: ${t.name}`;
+    note.textContent = t.note;
+  }
+
+  btn.addEventListener("click", () => {
+    idx = (idx + 1) % traditions.length;
+    update();
+  });
+
+  update();
+  el.appendChild(btn);
+  el.appendChild(note);
+}

--- a/app/experience_e/config.json
+++ b/app/experience_e/config.json
@@ -1,0 +1,6 @@
+{
+  "title": "Global Healing Web",
+  "description": "Fractal map linking Tibetan Raku Kei, Usui and Karuna Reiki, Egyptian Sekhem, hypnosis, EMDR, brainspotting, and more.",
+  "pages": ["fractal-web.md"],
+  "components": ["components/fractalWeb.js"]
+}

--- a/app/experience_e/pages/fractal-web.md
+++ b/app/experience_e/pages/fractal-web.md
@@ -1,0 +1,15 @@
+You step into the **Global Healing Web**.
+
+Threads glimmer with stories from across time:
+
+- **Tibetan Raku Kei** – modern interpretations tie Reiki to Himalayan mantra and symbol lore.
+- **Usui Reiki** – Japanese Buddhist Mikao Usui systematized this approach to universal life energy in 1922.
+- **Karuna Reiki** – introduced by William Lee Rand in the 1990s, drawing on the Sanskrit idea of compassionate action.
+- **Seichim / Sekhem** – practices inspired by the Egyptian term for vital force, echoing temple traditions of Hathor.
+- **Hypnosis** – trance healing noted in Greek dream temples and Egyptian sleep sanctuaries, refined by modern science.
+- **EMDR** – Francine Shapiro's 1987 eye-movement method for processing trauma.
+- **Brainspotting** – David Grand's technique linking fixed gaze points to emotional release.
+
+Ancient paths from Greek philosophers, Celtic druids, and the priests of Hathor weave into this lattice of healing.
+Each node invites you to follow a lineage and celebrate its wisdom.
+

--- a/data/demos.json
+++ b/data/demos.json
@@ -4,7 +4,6 @@
     "config": {
       "layout": "wheel",
       "mode": 7,
-      "labels": ["Red", "Orange", "Yellow", "Green", "Cyan", "Blue", "Violet"]
       "labels": [
         "Red",
         "Orange",
@@ -29,50 +28,4 @@
     }
   }
 ]
-  {
--+    "title": "Art • 7 Colors (Basic Design)",
--+    "config": {
--+      "layout": "wheel",
--+      "mode": 7,
--+      "labels": ["Red","Orange","Yellow","Green","Cyan","Blue","Violet"]
--+    }
--+  }
--+]
-+[
-+  {
-+    "title": "Art \u2022 7 Colors (Basic Design)",
-+    "config": {
-+      "layout": "wheel",
-+      "mode": 7,
-+      "labels": [
-+        "Red",
-+        "Orange",
-+        "Yellow",
-+        "Green",
-+        "Cyan",
-+        "Blue",
-+        "Violet"
-+      ]
-+    }
-+  },
-+  {
-+    "title": "Art \u2022 Visionary Dream",
-+    "config": {
-+      "layout": "spiral",
-+      "mode": 3,
-+      "labels": [
-+        "Community Garden",
-+        "Small Business Workflow",
-+        "Sustainable City Plan"
-+      ]
-+    }
-+  }
-+]
-    "title": "Art • 7 Colors (Basic Design)",
-    "config": {
-      "layout": "wheel",
-      "mode": 7,
-      "labels": ["Red","Orange","Yellow","Green","Cyan","Blue","Violet"]
-    }
-  }
-]
+

--- a/data/experiences.json
+++ b/data/experiences.json
@@ -1,6 +1,27 @@
 [
-  {"id":"experience_a","title":"Hypatia's Library","src":"app/experience_a/config.json"},
-  {"id":"experience_b","title":"Tesla's Workshop","src":"app/experience_b/config.json"},
-  {"id":"experience_c","title":"Agrippa's Study","src":"app/experience_c/config.json"},
-  {"id":"experience_d","title":"Alexandrian Scriptorium","src":"app/experience_d/config.json"}
+  {
+    "id": "experience_a",
+    "title": "Hypatia's Library",
+    "src": "app/experience_a/config.json"
+  },
+  {
+    "id": "experience_b",
+    "title": "Tesla's Workshop",
+    "src": "app/experience_b/config.json"
+  },
+  {
+    "id": "experience_c",
+    "title": "Agrippa's Study",
+    "src": "app/experience_c/config.json"
+  },
+  {
+    "id": "experience_d",
+    "title": "Alexandrian Scriptorium",
+    "src": "app/experience_d/config.json"
+  },
+  {
+    "id": "experience_e",
+    "title": "Global Healing Web",
+    "src": "app/experience_e/config.json"
+  }
 ]

--- a/plugins/soundscape.js
+++ b/plugins/soundscape.js
@@ -1,102 +1,39 @@
-// Simple binaural soundscape using the Web Audio API
-export default function soundscape(){
-  const AudioCtx = window.AudioContext || window.webkitAudioContext;
-  if(!AudioCtx){
-    alert('Web Audio API not supported');
+// Minimal soundscape plugin using the Web Audio API
+
+export function playSoundscape(theme = 'hypatia') {
+  const settings = globalThis.window?.COSMO_SETTINGS;
+  if (settings?.muteAudio) return;
+
+  const AudioCtx = globalThis.window?.AudioContext || globalThis.window?.webkitAudioContext;
+  if (!AudioCtx) {
+    globalThis.alert?.('Web Audio API not supported');
     return;
   }
+
   const ctx = new AudioCtx();
-  const oscL = ctx.createOscillator();
-  const oscR = ctx.createOscillator();
-  const merger = ctx.createChannelMerger(2);
-
-  oscL.frequency.value = 440; // left ear frequency
-  oscR.frequency.value = 446; // right ear slightly higher for binaural beat
-  oscL.connect(merger,0,0);
-  oscR.connect(merger,0,1);
-  merger.connect(ctx.destination);
-  oscL.start();
-  oscR.start();
-
-  return {
-    stop(){
-      oscL.stop();
-      oscR.stop();
-      ctx.close();
-    }
-  };
-}
-export default {
-  id: 'soundscape',
-  activate(_engine, theme = 'hypatia') {
-    if (window.COSMO_SETTINGS?.muteAudio) return;
-    const AudioCtx = window.AudioContext || window.webkitAudioContext;
-    const ctx = new AudioCtx();
-    const gain = ctx.createGain();
-    gain.gain.value = 0.1;
-    gain.connect(ctx.destination);
-
-    const freqs = theme === 'tesla' ? [432, 864] : [220, 440];
-    this._osc = freqs.map(f => {
-      const osc = ctx.createOscillator();
-      osc.frequency.value = f;
-      osc.connect(gain).start();
-      return osc;
-    });
-    this._ctx = ctx;
-  },
-  deactivate() {
-    this._osc?.forEach(o => { try { o.stop(); } catch {} });
-    this._osc = null;
-    if (this._ctx) {
-      this._ctx.close?.();
-      this._ctx = null;
-    }
-  }
-};
-// Ambient soundscapes honoring realm archetypes
-export default function soundscape(realm){
-  // Respect global mute setting for neurodivergent care
-  if(window.COSMO_SETTINGS?.muteAudio) return;
-
-  const ctx = new (window.AudioContext || window.webkitAudioContext)();
-  // Tone pairs inspired by each visionary realm
-  const tones = {
-    hypatia: [196.0, 392.0],              // Hypatia's Library – contemplative hum
-    tesla: [329.63, 659.25],              // Tesla's Workshop – electric overtones
-    agrippa: [261.63, 523.25],            // Agrippa's Study – occult resonance
-    'alexandrian-scriptorium': [440.0]    // Sappho's Chord – lyric center
-  };
-  const freqs = tones[realm] || [220.0];  // Default tonic if realm unknown
-
-  // Layer gentle oscillators for a balanced chord
-  freqs.forEach((f, idx)=>{
-    const osc = ctx.createOscillator();
-    const gain = ctx.createGain();
-    osc.type = 'sine';
-    osc.frequency.value = f;
-    gain.gain.value = 0.03 / freqs.length;
-    osc.connect(gain);
-    gain.connect(ctx.destination);
-    osc.start();
-    osc.stop(ctx.currentTime + 2 + idx);
-  });
-}
-export default function soundscape(name) {
-  const settings = global.window?.COSMO_SETTINGS || {};
-  if (settings.muteAudio) return;
-
-  const ctx = new window.AudioContext();
   const gain = ctx.createGain();
+  gain.gain.value = 0.1;
   gain.connect(ctx.destination);
 
-  const base = { hypatia: 220, tesla: 330 }[name] || 440;
-  [base, base * 2].forEach((freq) => {
+  const freqs = theme === 'tesla' ? [432, 864] : [220, 440];
+  freqs.forEach((f) => {
     const osc = ctx.createOscillator();
-    osc.frequency.value = freq;
+    osc.frequency.value = f;
     osc.connect(gain);
     osc.start();
     osc.stop(ctx.currentTime + 1);
   });
+
+  ctx.close?.();
 }
+
+const soundscape = {
+  id: 'soundscape',
+  activate(_engine, theme) {
+    playSoundscape(theme);
+  },
+  deactivate() {},
+};
+
+export default soundscape;
 

--- a/src/configLoader.js
+++ b/src/configLoader.js
@@ -1,58 +1,3 @@
--+export function loadFirstDemo() {
--+  const demos = loadConfig('data/demos.json');
--+  const config = demos[0].config;
--+  validatePlateConfig(config);
--+  return config;
--+}
-+import { readFileSync } from 'fs';
-+import path from 'path';
-+
-+// Load a JSON configuration file with basic error handling
-+export function loadConfig(relativePath) {
-+  const file = path.resolve(process.cwd(), relativePath);
-+  let raw;
-+  try {
-+    raw = readFileSync(file, 'utf8');
-+  } catch (err) {
-+    throw new Error(`Config file not found: ${relativePath}`);
-+  }
-+
-+  try {
-+    return JSON.parse(raw);
-+  } catch (err) {
-+    throw new Error(`Invalid JSON in ${relativePath}`);
-+  }
-+}
-+
-+// Ensure a plate config adheres to the minimal schema used by renderPlate
-+export function validatePlateConfig(config) {
-+  if (typeof config !== 'object' || config === null) {
-+    throw new Error('Config must be an object');
-+  }
-+  const layouts = ['spiral', 'twin-cone', 'wheel', 'grid'];
-+  if (!layouts.includes(config.layout)) {
-+    throw new Error('Unknown layout');
-+  }
-+  if (typeof config.mode !== 'number' || config.mode <= 0) {
-+    throw new Error('Mode must be a positive number');
-+  }
-+  if (!Array.isArray(config.labels)) {
-+    throw new Error('Labels must be an array');
-+  }
-+  if (config.labels.length !== config.mode) {
-+    throw new Error('Label count must match mode');
-+  }
-+}
-+
-+export function loadFirstDemo() {
-+  const demos = loadConfig('data/demos.json');
-+  const config = demos[0].config;
-+  validatePlateConfig(config);
-+  return config;
-+}
- 
-EOF
-)
 import { readFileSync } from 'fs';
 import path from 'path';
 
@@ -62,16 +7,10 @@ export function loadConfig(relativePath) {
   let raw;
   try {
     raw = readFileSync(file, 'utf8');
-  } catch (err) {
-    throw new Error(`Config file not found: ${relativePath}`);
-  }
-
-  try {
-    return JSON.parse(raw);
-  } catch (err) {
   } catch {
     throw new Error(`Config file not found: ${relativePath}`);
   }
+
   try {
     return JSON.parse(raw);
   } catch {

--- a/src/renderPlate.js
+++ b/src/renderPlate.js
@@ -46,7 +46,6 @@ function gridPositions(count) {
 }
 
 export function renderPlate(config) {
-  if (!config || typeof config.layout !== 'string' || typeof config.mode !== 'number' || !Array.isArray(config.labels)) {
   if (
     !config ||
     typeof config.layout !== 'string' ||

--- a/test/config-loader.test.js
+++ b/test/config-loader.test.js
@@ -1,12 +1,6 @@
-import { loadConfig, validatePlateConfig } from '../src/configLoader.js';
 import { test } from 'node:test';
-import { strict as assert } from 'assert';
-import { test } from 'node:test';
-import { strict as assert } from 'assert';
+import assert from 'node:assert/strict';
 import { loadConfig, validatePlateConfig } from '../src/configLoader.js';
-import { writeFileSync, unlinkSync } from 'fs';
-
-// Ensure loadConfig surfaces invalid JSON errors
 import { writeFileSync, unlinkSync } from 'fs';
 
 test('loadConfig throws on invalid JSON', () => {
@@ -16,7 +10,6 @@ test('loadConfig throws on invalid JSON', () => {
   unlinkSync(file);
 });
 
-// Validate schema enforcement
 test('validatePlateConfig enforces label count', () => {
   const good = { layout: 'spiral', mode: 1, labels: ['x'] };
   validatePlateConfig(good);

--- a/test/renderPlate.test.js
+++ b/test/renderPlate.test.js
@@ -1,6 +1,6 @@
-import { renderPlate } from '../src/renderPlate.js';
 import { test } from 'node:test';
-import { strict as assert } from 'assert';
+import { renderPlate } from '../src/renderPlate.js';
+import assert from 'node:assert/strict';
 
 const base = { mode: 4, labels: ['a', 'b', 'c', 'd'] };
 

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -1,33 +1,13 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-
-test('basic arithmetic works', () => {
-  assert.equal(1 + 1, 2);
-import test from 'node:test';
-import assert from 'node:assert/strict';
-import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
-import { loadConfig } from '../src/configLoader.js';
-import { renderPlate } from '../src/renderPlate.js';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-
-test('renderPlate renders first demo plate without throwing', () => {
-  const demos = loadConfig(join(__dirname, '..', 'data', 'demos.json'));
-  const config = demos[0].config;
-  const plate = renderPlate(config);
-  assert.equal(plate.layout, config.layout);
-  assert.equal(plate.labels.length, config.mode);
-import { strict as assert } from 'assert';
 import { loadFirstDemo } from '../src/configLoader.js';
+import { renderPlate } from '../src/renderPlate.js';
 
 test('loadFirstDemo returns valid config', () => {
   const config = loadFirstDemo();
   assert.equal(typeof config.layout, 'string');
   assert.equal(config.labels.length, config.mode);
 });
-import { strict as assert } from 'assert';
-import { renderPlate } from '../src/renderPlate.js';
 
 test('renderPlate creates items for basic wheel', () => {
   const plate = renderPlate({ layout: 'wheel', mode: 3, labels: ['a', 'b', 'c'] });

--- a/test/soundscape.test.js
+++ b/test/soundscape.test.js
@@ -1,83 +1,23 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import soundscape from '../plugins/soundscape.js';
+import soundscape, { playSoundscape } from '../plugins/soundscape.js';
 
-function cleanup(){ delete global.window; delete global.alert; }
-
-test('soundscape respects mute', ()=>{
-  global.window = { COSMO_SETTINGS: { muteAudio: true } };
-  global.alert = () => {};
-  assert.doesNotThrow(()=> soundscape('hypatia'));
-import soundscape from '../plugins/soundscape.js';
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
-
-// Clean window after each test
-function cleanup(){ delete global.window; }
-
-test('soundscape respects mute', ()=>{
-  global.window = { COSMO_SETTINGS: { muteAudio: true } };
-  assert.doesNotThrow(()=> soundscape.activate(null,'hypatia'));
-  assert.doesNotThrow(()=> soundscape('hypatia'));
-  cleanup();
-});
-
-test('soundscape starts oscillators when not muted', ()=>{
-  let started = 0;
-  class FakeOsc { constructor(){ this.frequency={value:0}; } connect(){ return this; } start(){ started++; } stop(){} }
-  class FakeGain { constructor(){ this.gain={value:0}; } connect(){ return this; } }
-  class FakeMerger { connect(){ return this; } }
-  class FakeAudioCtx {
-    constructor(){ this.currentTime = 0; this.destination = {}; }
-    createOscillator(){ return new FakeOsc(); }
-    createGain(){ return new FakeGain(); }
-    createChannelMerger(){ return new FakeMerger(); }
-  }
-  global.window = { COSMO_SETTINGS: { muteAudio: false }, AudioContext: FakeAudioCtx };
-  global.alert = () => {};
-  assert.doesNotThrow(()=> soundscape('tesla'));
-  assert.equal(started,2);
-  class FakeGain { constructor(){ this.gain={value:0}; } connect(){ } }
-  class FakeGain { constructor(){ this.gain={value:0}; } connect(){ }
-import { strict as assert } from 'assert';
-import soundscape from '../plugins/soundscape.js';
-
-// Clean window after each test
 function cleanup() {
   delete global.window;
   delete global.alert;
-function cleanup() {
-  delete global.window;
 }
 
 test('soundscape respects mute', () => {
-  global.window = { COSMO_SETTINGS: { muteAudio: true } };
+  global.window = { COSMO_SETTINGS: { muteAudio: true }, AudioContext: class {} };
   global.alert = () => {};
-  assert.doesNotThrow(() => soundscape('hypatia'));
+  assert.doesNotThrow(() => playSoundscape('hypatia'));
+  assert.doesNotThrow(() => soundscape.activate(null, 'hypatia'));
   cleanup();
 });
 
 test('soundscape starts oscillators when not muted', () => {
   let started = 0;
   class FakeOsc {
-    constructor() {
-      this.frequency = { value: 0 };
-    }
-    connect() {
-      return this;
-    }
-    start() {
-      started++;
-    }
-    stop() {}
-  }
-  class FakeGain {
-    constructor() {
-      this.gain = { value: 0 };
-    }
-    connect() {}
-  }
-  class FakeMerger {
     constructor() { this.frequency = { value: 0 }; }
     connect() { return this; }
     start() { started++; }
@@ -85,42 +25,16 @@ test('soundscape starts oscillators when not muted', () => {
   }
   class FakeGain {
     constructor() { this.gain = { value: 0 }; }
-    connect() {}
+    connect() { return this; }
   }
-  global.window = {
-    COSMO_SETTINGS: { muteAudio: false },
-    AudioContext: class {
-      constructor(){ this.currentTime = 0; this.destination = {}; }
-      createOscillator(){ return new FakeOsc(); }
-      createGain(){ return new FakeGain(); }
-    }
-  };
-  assert.doesNotThrow(()=> soundscape.activate(null,'tesla'));
-  assert.equal(started,2);
-  soundscape.deactivate();
-  assert.doesNotThrow(()=> soundscape('tesla'));
-  assert.equal(started,2);
-      constructor() {
-        this.currentTime = 0;
-        this.destination = {};
-      }
-      createOscillator() {
-        return new FakeOsc();
-      }
-      createGain() {
-        return new FakeGain();
-      }
-      createChannelMerger() {
-        return new FakeMerger();
-      }
-    },
-  };
-      constructor() { this.currentTime = 0; this.destination = {}; }
-      createOscillator() { return new FakeOsc(); }
-      createGain() { return new FakeGain(); }
-    }
-  };
-  assert.doesNotThrow(() => soundscape('tesla'));
+  class FakeAudioCtx {
+    constructor() { this.currentTime = 0; this.destination = {}; }
+    createOscillator() { return new FakeOsc(); }
+    createGain() { return new FakeGain(); }
+    close() {}
+  }
+  global.window = { COSMO_SETTINGS: { muteAudio: false }, AudioContext: FakeAudioCtx };
+  assert.doesNotThrow(() => playSoundscape('tesla'));
   assert.equal(started, 2);
   cleanup();
 });


### PR DESCRIPTION
## Summary
- enrich Global Healing Web page with details on Tibetan, Japanese, Egyptian and modern healing modalities
- rotate through global traditions interactively in fractalWeb component
- update Global Healing Web config description
- rebuild config loader and renderPlate modules, streamline soundscape plugin, and replace corrupted demos JSON

## Testing
- `npm run check` *(fails: Unexpected PostCSS node type and syntax errors across unrelated assets)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b60ac63f0883289e7c4dd31a35e51a