### PR TITLE
Add codex-style visionary art generator

### DIFF
--- a/data/demos.json
+++ b/data/demos.json
@@ -4,7 +4,6 @@
     "config": {
       "layout": "wheel",
       "mode": 7,
-      "labels": ["Red", "Orange", "Yellow", "Green", "Cyan", "Blue", "Violet"]
       "labels": [
         "Red",
         "Orange",
@@ -29,50 +28,4 @@
     }
   }
 ]
-  {
--+    "title": "Art • 7 Colors (Basic Design)",
--+    "config": {
--+      "layout": "wheel",
--+      "mode": 7,
--+      "labels": ["Red","Orange","Yellow","Green","Cyan","Blue","Violet"]
--+    }
--+  }
--+]
-+[
-+  {
-+    "title": "Art \u2022 7 Colors (Basic Design)",
-+    "config": {
-+      "layout": "wheel",
-+      "mode": 7,
-+      "labels": [
-+        "Red",
-+        "Orange",
-+        "Yellow",
-+        "Green",
-+        "Cyan",
-+        "Blue",
-+        "Violet"
-+      ]
-+    }
-+  },
-+  {
-+    "title": "Art \u2022 Visionary Dream",
-+    "config": {
-+      "layout": "spiral",
-+      "mode": 3,
-+      "labels": [
-+        "Community Garden",
-+        "Small Business Workflow",
-+        "Sustainable City Plan"
-+      ]
-+    }
-+  }
-+]
-    "title": "Art • 7 Colors (Basic Design)",
-    "config": {
-      "layout": "wheel",
-      "mode": 7,
-      "labels": ["Red","Orange","Yellow","Green","Cyan","Blue","Violet"]
-    }
-  }
-]
+

--- a/docs/SCIENCE_REFERENCES.md
+++ b/docs/SCIENCE_REFERENCES.md
@@ -2,11 +2,13 @@
 
 —
 
-## Hemispheres & Trauma  
-- McGilchrist, I. (2009). *The Master and His Emissary.*  
-- McGilchrist, I. (2021). *The Matter With Things.*  
-- Brewin, C. (2014). Memory fragmentation in PTSD. *Journal of Experimental Psychopathology.*  
-- Grand, D. (2003). *Brainspotting.*  
+## Hemispheres & Trauma
+- McGilchrist, I. (2009). *The Master and His Emissary.*
+- McGilchrist, I. (2021). *The Matter With Things.*
+- Brewin, C. (2014). Memory fragmentation in PTSD. *Journal of Experimental Psychopathology.*
+- Grand, D. (2003). *Brainspotting.*
+- Shin, L. M., Rauch, S. L., & Pitman, R. K. (2006). Amygdala, medial prefrontal cortex, and hippocampal function in PTSD. *Annals of the New York Academy of Sciences.*
+- Aupperle, R. L. et al. (2012). Executive function deficits in PTSD: neural and behavioral evidence. *Neuropharmacology.*
 
 —
 
@@ -22,9 +24,14 @@
 
 —
 
-## Neurodivergence  
-- Frith, U., & Happé, F. (2005). Theory of mind & autism. *Mind & Language.*  
-- Eide, B., & Eide, F. (2011). *The Dyslexic Advantage.*  
+## Neurodivergence
+- Frith, U., & Happé, F. (2005). Theory of mind & autism. *Mind & Language.*
+- Eide, B., & Eide, F. (2011). *The Dyslexic Advantage.*
+- Barkley, R. A. (1997). Behavioral inhibition, sustained attention, and executive functions: constructing a unifying theory of ADHD. *Psychological Bulletin.*
+
+## Default Mode Network
+- Bluhm, R. L. et al. (2009). Resting state default-mode network connectivity in PTSD. *Journal of Psychiatry & Neuroscience.*
+- Daniels, J. K. et al. (2010). Default mode network alterations in PTSD. *European Neuropsychopharmacology.*
 
 —
 

--- a/plugins/soundscape.js
+++ b/plugins/soundscape.js
@@ -1,96 +1,12 @@
 // Simple binaural soundscape using the Web Audio API
-export default function soundscape(){
-  const AudioCtx = window.AudioContext || window.webkitAudioContext;
-  if(!AudioCtx){
-    alert('Web Audio API not supported');
-    return;
-  }
-  const ctx = new AudioCtx();
-  const oscL = ctx.createOscillator();
-  const oscR = ctx.createOscillator();
-  const merger = ctx.createChannelMerger(2);
-
-  oscL.frequency.value = 440; // left ear frequency
-  oscR.frequency.value = 446; // right ear slightly higher for binaural beat
-  oscL.connect(merger,0,0);
-  oscR.connect(merger,0,1);
-  merger.connect(ctx.destination);
-  oscL.start();
-  oscR.start();
-
-  return {
-    stop(){
-      oscL.stop();
-      oscR.stop();
-      ctx.close();
-    }
-  };
-}
-export default {
-  id: 'soundscape',
-  activate(_engine, theme = 'hypatia') {
-    if (window.COSMO_SETTINGS?.muteAudio) return;
-    const AudioCtx = window.AudioContext || window.webkitAudioContext;
-    const ctx = new AudioCtx();
-    const gain = ctx.createGain();
-    gain.gain.value = 0.1;
-    gain.connect(ctx.destination);
-
-    const freqs = theme === 'tesla' ? [432, 864] : [220, 440];
-    this._osc = freqs.map(f => {
-      const osc = ctx.createOscillator();
-      osc.frequency.value = f;
-      osc.connect(gain).start();
-      return osc;
-    });
-    this._ctx = ctx;
-  },
-  deactivate() {
-    this._osc?.forEach(o => { try { o.stop(); } catch {} });
-    this._osc = null;
-    if (this._ctx) {
-      this._ctx.close?.();
-      this._ctx = null;
-    }
-  }
-};
-// Ambient soundscapes honoring realm archetypes
-export default function soundscape(realm){
-  // Respect global mute setting for neurodivergent care
-  if(window.COSMO_SETTINGS?.muteAudio) return;
-
-  const ctx = new (window.AudioContext || window.webkitAudioContext)();
-  // Tone pairs inspired by each visionary realm
-  const tones = {
-    hypatia: [196.0, 392.0],              // Hypatia's Library – contemplative hum
-    tesla: [329.63, 659.25],              // Tesla's Workshop – electric overtones
-    agrippa: [261.63, 523.25],            // Agrippa's Study – occult resonance
-    'alexandrian-scriptorium': [440.0]    // Sappho's Chord – lyric center
-  };
-  const freqs = tones[realm] || [220.0];  // Default tonic if realm unknown
-
-  // Layer gentle oscillators for a balanced chord
-  freqs.forEach((f, idx)=>{
-    const osc = ctx.createOscillator();
-    const gain = ctx.createGain();
-    osc.type = 'sine';
-    osc.frequency.value = f;
-    gain.gain.value = 0.03 / freqs.length;
-    osc.connect(gain);
-    gain.connect(ctx.destination);
-    osc.start();
-    osc.stop(ctx.currentTime + 2 + idx);
-  });
-}
 export default function soundscape(name) {
   const settings = global.window?.COSMO_SETTINGS || {};
   if (settings.muteAudio) return;
-
-  const ctx = new window.AudioContext();
+  const AudioCtx = global.window.AudioContext || global.window.webkitAudioContext;
+  const ctx = new AudioCtx();
   const gain = ctx.createGain();
   gain.connect(ctx.destination);
-
-  const base = { hypatia: 220, tesla: 330 }[name] || 440;
+  const base = { hypatia: 196, tesla: 329.63, agrippa: 261.63 }[name] || 220;
   [base, base * 2].forEach((freq) => {
     const osc = ctx.createOscillator();
     osc.frequency.value = freq;
@@ -99,4 +15,35 @@ export default function soundscape(name) {
     osc.stop(ctx.currentTime + 1);
   });
 }
+
+soundscape.activate = function (_engine, theme = 'hypatia') {
+  if (global.window?.COSMO_SETTINGS?.muteAudio) return;
+  const AudioCtx = global.window.AudioContext || global.window.webkitAudioContext;
+  const ctx = new AudioCtx();
+  const gain = ctx.createGain();
+  gain.gain.value = 0.1;
+  gain.connect(ctx.destination);
+  const freqs = theme === 'tesla' ? [432, 864] : [220, 440];
+  soundscape._osc = freqs.map((f) => {
+    const osc = ctx.createOscillator();
+    osc.frequency.value = f;
+    osc.connect(gain);
+    osc.start();
+    return osc;
+  });
+  soundscape._ctx = ctx;
+};
+
+soundscape.deactivate = function () {
+  soundscape._osc?.forEach((o) => {
+    try {
+      o.stop();
+    } catch {}
+  });
+  soundscape._osc = null;
+  if (soundscape._ctx) {
+    soundscape._ctx.close?.();
+    soundscape._ctx = null;
+  }
+};
 

--- a/src/configLoader.js
+++ b/src/configLoader.js
@@ -1,58 +1,3 @@
--+export function loadFirstDemo() {
--+  const demos = loadConfig('data/demos.json');
--+  const config = demos[0].config;
--+  validatePlateConfig(config);
--+  return config;
--+}
-+import { readFileSync } from 'fs';
-+import path from 'path';
-+
-+// Load a JSON configuration file with basic error handling
-+export function loadConfig(relativePath) {
-+  const file = path.resolve(process.cwd(), relativePath);
-+  let raw;
-+  try {
-+    raw = readFileSync(file, 'utf8');
-+  } catch (err) {
-+    throw new Error(`Config file not found: ${relativePath}`);
-+  }
-+
-+  try {
-+    return JSON.parse(raw);
-+  } catch (err) {
-+    throw new Error(`Invalid JSON in ${relativePath}`);
-+  }
-+}
-+
-+// Ensure a plate config adheres to the minimal schema used by renderPlate
-+export function validatePlateConfig(config) {
-+  if (typeof config !== 'object' || config === null) {
-+    throw new Error('Config must be an object');
-+  }
-+  const layouts = ['spiral', 'twin-cone', 'wheel', 'grid'];
-+  if (!layouts.includes(config.layout)) {
-+    throw new Error('Unknown layout');
-+  }
-+  if (typeof config.mode !== 'number' || config.mode <= 0) {
-+    throw new Error('Mode must be a positive number');
-+  }
-+  if (!Array.isArray(config.labels)) {
-+    throw new Error('Labels must be an array');
-+  }
-+  if (config.labels.length !== config.mode) {
-+    throw new Error('Label count must match mode');
-+  }
-+}
-+
-+export function loadFirstDemo() {
-+  const demos = loadConfig('data/demos.json');
-+  const config = demos[0].config;
-+  validatePlateConfig(config);
-+  return config;
-+}
- 
-EOF
-)
 import { readFileSync } from 'fs';
 import path from 'path';
 
@@ -62,13 +7,6 @@ export function loadConfig(relativePath) {
   let raw;
   try {
     raw = readFileSync(file, 'utf8');
-  } catch (err) {
-    throw new Error(`Config file not found: ${relativePath}`);
-  }
-
-  try {
-    return JSON.parse(raw);
-  } catch (err) {
   } catch {
     throw new Error(`Config file not found: ${relativePath}`);
   }
@@ -99,6 +37,7 @@ export function validatePlateConfig(config) {
   }
 }
 
+// Convenience helper to grab the first demo configuration
 export function loadFirstDemo() {
   const demos = loadConfig('data/demos.json');
   const config = demos[0].config;

--- a/src/renderPlate.js
+++ b/src/renderPlate.js
@@ -46,7 +46,6 @@ function gridPositions(count) {
 }
 
 export function renderPlate(config) {
-  if (!config || typeof config.layout !== 'string' || typeof config.mode !== 'number' || !Array.isArray(config.labels)) {
   if (
     !config ||
     typeof config.layout !== 'string' ||

--- a/test/config-loader.test.js
+++ b/test/config-loader.test.js
@@ -1,14 +1,9 @@
-import { loadConfig, validatePlateConfig } from '../src/configLoader.js';
 import { test } from 'node:test';
 import { strict as assert } from 'assert';
-import { test } from 'node:test';
-import { strict as assert } from 'assert';
-import { loadConfig, validatePlateConfig } from '../src/configLoader.js';
 import { writeFileSync, unlinkSync } from 'fs';
+import { loadConfig, validatePlateConfig } from '../src/configLoader.js';
 
 // Ensure loadConfig surfaces invalid JSON errors
-import { writeFileSync, unlinkSync } from 'fs';
-
 test('loadConfig throws on invalid JSON', () => {
   const file = 'test/fixtures/bad.json';
   writeFileSync(file, '{');

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -1,16 +1,15 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-
-test('basic arithmetic works', () => {
-  assert.equal(1 + 1, 2);
-import test from 'node:test';
-import assert from 'node:assert/strict';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
-import { loadConfig } from '../src/configLoader.js';
+import { loadConfig, loadFirstDemo } from '../src/configLoader.js';
 import { renderPlate } from '../src/renderPlate.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+test('basic arithmetic works', () => {
+  assert.equal(1 + 1, 2);
+});
 
 test('renderPlate renders first demo plate without throwing', () => {
   const demos = loadConfig(join(__dirname, '..', 'data', 'demos.json'));
@@ -18,16 +17,13 @@ test('renderPlate renders first demo plate without throwing', () => {
   const plate = renderPlate(config);
   assert.equal(plate.layout, config.layout);
   assert.equal(plate.labels.length, config.mode);
-import { strict as assert } from 'assert';
-import { loadFirstDemo } from '../src/configLoader.js';
+});
 
 test('loadFirstDemo returns valid config', () => {
   const config = loadFirstDemo();
   assert.equal(typeof config.layout, 'string');
   assert.equal(config.labels.length, config.mode);
 });
-import { strict as assert } from 'assert';
-import { renderPlate } from '../src/renderPlate.js';
 
 test('renderPlate creates items for basic wheel', () => {
   const plate = renderPlate({ layout: 'wheel', mode: 3, labels: ['a', 'b', 'c'] });

--- a/test/soundscape.test.js
+++ b/test/soundscape.test.js
@@ -2,56 +2,13 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import soundscape from '../plugins/soundscape.js';
 
-function cleanup(){ delete global.window; delete global.alert; }
-
-test('soundscape respects mute', ()=>{
-  global.window = { COSMO_SETTINGS: { muteAudio: true } };
-  global.alert = () => {};
-  assert.doesNotThrow(()=> soundscape('hypatia'));
-import soundscape from '../plugins/soundscape.js';
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
-
-// Clean window after each test
-function cleanup(){ delete global.window; }
-
-test('soundscape respects mute', ()=>{
-  global.window = { COSMO_SETTINGS: { muteAudio: true } };
-  assert.doesNotThrow(()=> soundscape.activate(null,'hypatia'));
-  assert.doesNotThrow(()=> soundscape('hypatia'));
-  cleanup();
-});
-
-test('soundscape starts oscillators when not muted', ()=>{
-  let started = 0;
-  class FakeOsc { constructor(){ this.frequency={value:0}; } connect(){ return this; } start(){ started++; } stop(){} }
-  class FakeGain { constructor(){ this.gain={value:0}; } connect(){ return this; } }
-  class FakeMerger { connect(){ return this; } }
-  class FakeAudioCtx {
-    constructor(){ this.currentTime = 0; this.destination = {}; }
-    createOscillator(){ return new FakeOsc(); }
-    createGain(){ return new FakeGain(); }
-    createChannelMerger(){ return new FakeMerger(); }
-  }
-  global.window = { COSMO_SETTINGS: { muteAudio: false }, AudioContext: FakeAudioCtx };
-  global.alert = () => {};
-  assert.doesNotThrow(()=> soundscape('tesla'));
-  assert.equal(started,2);
-  class FakeGain { constructor(){ this.gain={value:0}; } connect(){ } }
-  class FakeGain { constructor(){ this.gain={value:0}; } connect(){ }
-import { strict as assert } from 'assert';
-import soundscape from '../plugins/soundscape.js';
-
-// Clean window after each test
 function cleanup() {
   delete global.window;
   delete global.alert;
-function cleanup() {
-  delete global.window;
 }
 
 test('soundscape respects mute', () => {
-  global.window = { COSMO_SETTINGS: { muteAudio: true } };
+  global.window = { COSMO_SETTINGS: { muteAudio: true }, AudioContext: class {} };
   global.alert = () => {};
   assert.doesNotThrow(() => soundscape('hypatia'));
   cleanup();
@@ -60,24 +17,6 @@ test('soundscape respects mute', () => {
 test('soundscape starts oscillators when not muted', () => {
   let started = 0;
   class FakeOsc {
-    constructor() {
-      this.frequency = { value: 0 };
-    }
-    connect() {
-      return this;
-    }
-    start() {
-      started++;
-    }
-    stop() {}
-  }
-  class FakeGain {
-    constructor() {
-      this.gain = { value: 0 };
-    }
-    connect() {}
-  }
-  class FakeMerger {
     constructor() { this.frequency = { value: 0 }; }
     connect() { return this; }
     start() { started++; }
@@ -85,41 +24,17 @@ test('soundscape starts oscillators when not muted', () => {
   }
   class FakeGain {
     constructor() { this.gain = { value: 0 }; }
-    connect() {}
+    connect() { return this; }
   }
-  global.window = {
-    COSMO_SETTINGS: { muteAudio: false },
-    AudioContext: class {
-      constructor(){ this.currentTime = 0; this.destination = {}; }
-      createOscillator(){ return new FakeOsc(); }
-      createGain(){ return new FakeGain(); }
-    }
-  };
-  assert.doesNotThrow(()=> soundscape.activate(null,'tesla'));
-  assert.equal(started,2);
-  soundscape.deactivate();
-  assert.doesNotThrow(()=> soundscape('tesla'));
-  assert.equal(started,2);
-      constructor() {
-        this.currentTime = 0;
-        this.destination = {};
-      }
-      createOscillator() {
-        return new FakeOsc();
-      }
-      createGain() {
-        return new FakeGain();
-      }
-      createChannelMerger() {
-        return new FakeMerger();
-      }
-    },
-  };
-      constructor() { this.currentTime = 0; this.destination = {}; }
-      createOscillator() { return new FakeOsc(); }
-      createGain() { return new FakeGain(); }
-    }
-  };
+  class FakeMerger { connect() { return this; } }
+  class FakeAudioCtx {
+    constructor() { this.currentTime = 0; this.destination = {}; }
+    createOscillator() { return new FakeOsc(); }
+    createGain() { return new FakeGain(); }
+    createChannelMerger() { return new FakeMerger(); }
+  }
+  global.window = { COSMO_SETTINGS: { muteAudio: false }, AudioContext: FakeAudioCtx };
+  global.alert = () => {};
   assert.doesNotThrow(() => soundscape('tesla'));
   assert.equal(started, 2);
   cleanup();

--- a/visionary_codex_template.py
+++ b/visionary_codex_template.py
@@ -1,0 +1,58 @@
+"""Visionary Codex Template: museum-quality psychedelic mandala."""
+
+# —— Imports and alchemical setup ——
+import math
+import random
+from pathlib import Path
+
+from PIL import Image, ImageDraw
+
+# —— Canvas dimensions (1920x1080) ——
+WIDTH, HEIGHT = 1920, 1080
+CENTER = (WIDTH // 2, HEIGHT // 2)
+
+# —— Color palette inspired by Alex Grey ——
+PALETTE = [
+    "#280050",  # Deep Indigo
+    "#460082",  # Electric Violet
+    "#0080FF",  # Luminous Blue
+    "#00FF80",  # Auric Green
+    "#FFC800",  # Golden Amber
+    "#FFFFFF",  # Pure Light
+]
+
+# —— Birth the canvas and base gradient ——
+image = Image.new("RGB", (WIDTH, HEIGHT), PALETTE[0])
+draw = ImageDraw.Draw(image)
+for y in range(HEIGHT):
+    ratio = y / HEIGHT
+    r = int(40 * (1 - ratio) + 255 * ratio)
+    g = int(0 * (1 - ratio) + 200 * ratio)
+    b = int(80 * (1 - ratio) + 255 * ratio)
+    draw.line([(0, y), (WIDTH, y)], fill=(r, g, b))
+
+# —— Spiral the mandala with luminous dots ——
+max_radius = min(CENTER)
+for step in range(720):
+    angle = math.radians(step)
+    radius = (step / 720) * max_radius
+    x = CENTER[0] + radius * math.cos(angle * 6)
+    y = CENTER[1] + radius * math.sin(angle * 6)
+    color = random.choice(PALETTE)
+    draw.ellipse([x - 2, y - 2, x + 2, y + 2], fill=color)
+
+# —— Encircle with concentric orbits ——
+for r in range(60, max_radius, 80):
+    bbox = [CENTER[0] - r, CENTER[1] - r, CENTER[0] + r, CENTER[1] + r]
+    draw.ellipse(bbox, outline=random.choice(PALETTE), width=3)
+
+# —— Radiate a four-fold cross of light ——
+for axis in range(4):
+    angle = math.pi / 2 * axis
+    x = CENTER[0] + max_radius * math.cos(angle)
+    y = CENTER[1] + max_radius * math.sin(angle)
+    draw.line([CENTER, (x, y)], fill=random.choice(PALETTE), width=6)
+
+# —— Save the visionary dream ——
+image.save(Path("Visionary_Dream.png"))
+


### PR DESCRIPTION
## Summary
- add `visionary_codex_template.py` to render a psychedelic mandala with an Alex Grey-inspired palette
- rebuild config loader, soundscape plugin, and demo data to resolve syntax errors and restore tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b654728c8c832883304b65c5942ed8