### PR TITLE
Strengthen config validation and audio fallback

### DIFF
--- a/data/demos.json
+++ b/data/demos.json
@@ -4,7 +4,6 @@
     "config": {
       "layout": "wheel",
       "mode": 7,
-      "labels": ["Red", "Orange", "Yellow", "Green", "Cyan", "Blue", "Violet"]
       "labels": [
         "Red",
         "Orange",
@@ -26,53 +25,6 @@
         "Small Business Workflow",
         "Sustainable City Plan"
       ]
-    }
-  }
-]
-  {
--+    "title": "Art • 7 Colors (Basic Design)",
--+    "config": {
--+      "layout": "wheel",
--+      "mode": 7,
--+      "labels": ["Red","Orange","Yellow","Green","Cyan","Blue","Violet"]
--+    }
--+  }
--+]
-+[
-+  {
-+    "title": "Art \u2022 7 Colors (Basic Design)",
-+    "config": {
-+      "layout": "wheel",
-+      "mode": 7,
-+      "labels": [
-+        "Red",
-+        "Orange",
-+        "Yellow",
-+        "Green",
-+        "Cyan",
-+        "Blue",
-+        "Violet"
-+      ]
-+    }
-+  },
-+  {
-+    "title": "Art \u2022 Visionary Dream",
-+    "config": {
-+      "layout": "spiral",
-+      "mode": 3,
-+      "labels": [
-+        "Community Garden",
-+        "Small Business Workflow",
-+        "Sustainable City Plan"
-+      ]
-+    }
-+  }
-+]
-    "title": "Art • 7 Colors (Basic Design)",
-    "config": {
-      "layout": "wheel",
-      "mode": 7,
-      "labels": ["Red","Orange","Yellow","Green","Cyan","Blue","Violet"]
     }
   }
 ]

--- a/plugins/fractalArt.js
+++ b/plugins/fractalArt.js
@@ -1,226 +1,10 @@
--+// Render Visionary_Dream fractal artwork using p5.js
--+export default async function(){
--+  // Load p5 library if not already present
--+  if(!window.p5){
--+    try{
--+      await import('../vendor/p5.min.js');
--+    }catch{
--+      await import('https://cdn.jsdelivr.net/npm/p5@1.9.0/lib/p5.min.js');
--+    }
--+  }
--+
--+  // Fetch case studies dataset
--+  const res = await fetch('data/real_world_examples.json');
--+  const cases = await res.json();
--+
--+  // Color palette inspired by Alex Grey & surrealism
--+  const PALETTE = ['#0d3b66','#845ec2','#ff6f91','#ff9671','#ffc75f','#f9f871'];
--+
--+  // Canvas resolution
--+  const WIDTH = 1920;
--+  const HEIGHT = 1080;
--+  const CENTER = { x: WIDTH/2, y: HEIGHT/2 };
--+
--+  new p5(p=>{
--+    // Prepare prompts
--+    const prompts = cases.map(c=>c.prompt);
--+    // Simple shuffle
--+    for(let i=prompts.length-1;i>0;i--){
--+      const j=Math.floor(Math.random()*(i+1));
--+      [prompts[i],prompts[j]]=[prompts[j],prompts[i]];
--+    }
--+
--+    p.setup=()=>{
--+      p.createCanvas(WIDTH,HEIGHT);
--+      p.noLoop();
--+      p.angleMode(p.RADIANS);
--+      p.textFont('sans-serif');
--+    };
--+
--+    // Draw layered gradient background
--+    function drawBackground(){
--+      for(let i=PALETTE.length-1;i>=0;i--){
--+        p.noStroke();
--+        p.fill(PALETTE[i]);
--+        const r=Math.max(WIDTH,HEIGHT)*(i+1)/PALETTE.length;
--+        p.ellipse(CENTER.x,CENTER.y,r,r);
--+      }
--+    }
--+
--+    // Draw spiral path
--+    function drawSpiral(){
--+      const turns=3.5;
--+      const points=500;
--+      const maxR=Math.min(WIDTH,HEIGHT)*0.45;
--+      p.stroke(PALETTE[PALETTE.length-1]);
--+      p.noFill();
--+      p.beginShape();
--+      for(let i=0;i<points;i++){
--+        const t=i/points;
--+        const angle=turns*2*Math.PI*t;
--+        const r=maxR*t;
--+        const x=CENTER.x+r*Math.cos(angle);
--+        const y=CENTER.y+r*Math.sin(angle);
--+        p.vertex(x,y);
--+      }
--+      p.endShape();
--+      return maxR;
--+    }
--+
--+    // Draw case study nodes around outer ring
--+    function drawNodes(maxR){
--+      const r=maxR*0.9;
--+      cases.forEach((c,idx)=>{
--+        const phi=idx*(2*Math.PI/cases.length);
--+        const x=CENTER.x+r*Math.cos(phi);
--+        const y=CENTER.y+r*Math.sin(phi);
--+        p.fill(PALETTE[idx%PALETTE.length]);
--+        p.noStroke();
--+        p.circle(x,y,36);
--+        p.fill(255);
--+        p.textAlign(p.CENTER,p.BOTTOM);
--+        p.text(c.title,x,y-24);
--+      });
--+    }
--+
--+    // Draw shuffled prompts near center
--+    function drawPrompts(maxR){
--+      const r=maxR*0.3;
--+      p.fill(255);
--+      p.textAlign(p.CENTER,p.CENTER);
--+      prompts.forEach((txt,i)=>{
--+        const angle=i*(2*Math.PI/prompts.length);
--+        const x=CENTER.x+r*Math.cos(angle);
--+        const y=CENTER.y+r*Math.sin(angle);
--+        p.text(txt,x,y);
--+      });
--+    }
--+
--+    p.draw=()=>{
--+      drawBackground();
--+      const maxR=drawSpiral();
--+      drawNodes(maxR);
--+      drawPrompts(maxR);
--+      // Save final artwork
--+      p.saveCanvas('Visionary_Dream','png');
--+    };
--+  });
--+}
-+// Render Visionary_Dream fractal artwork using p5.js
-+export default async function fractalArt(){
-+  // Load p5 library if not already present
-+  if(!window.p5){
-+    try{
-+      await import('../vendor/p5.min.js');
-+    }catch{
-+      await import('https://cdn.jsdelivr.net/npm/p5@1.9.0/lib/p5.min.js');
-+    }
-+  }
-+
-+  // Fetch case studies dataset
-+  const res = await fetch('data/real_world_examples.json');
-+  const cases = await res.json();
-+
-+  // Color palette inspired by Alex Grey & surrealism
-+  const PALETTE = ['#0d3b66','#845ec2','#ff6f91','#ff9671','#ffc75f','#f9f871'];
-+
-+  // Canvas resolution
-+  const WIDTH = 1920;
-+  const HEIGHT = 1080;
-+  const CENTER = { x: WIDTH/2, y: HEIGHT/2 };
-+
-+  new p5(p=>{
-+    // Prepare prompts
-+    const prompts = cases.map(c=>c.prompt);
-+    // Simple shuffle
-+    for(let i=prompts.length-1;i>0;i--){
-+      const j=Math.floor(Math.random()*(i+1));
-+      [prompts[i],prompts[j]]=[prompts[j],prompts[i]];
-+    }
-+
-+    p.setup=()=>{
-+      p.createCanvas(WIDTH,HEIGHT);
-+      p.noLoop();
-+      p.angleMode(p.RADIANS);
-+      p.textFont('sans-serif');
-+    };
-+
-+    // Draw layered gradient background
-+    function drawBackground(){
-+      for(let i=PALETTE.length-1;i>=0;i--){
-+        p.noStroke();
-+        p.fill(PALETTE[i]);
-+        const r=Math.max(WIDTH,HEIGHT)*(i+1)/PALETTE.length;
-+        p.ellipse(CENTER.x,CENTER.y,r,r);
-+      }
-+    }
-+
-+    // Draw spiral path
-+    function drawSpiral(){
-+      const turns=3.5;
-+      const points=500;
-+      const maxR=Math.min(WIDTH,HEIGHT)*0.45;
-+      p.stroke(PALETTE[PALETTE.length-1]);
-+      p.noFill();
-+      p.beginShape();
-+      for(let i=0;i<points;i++){
-+        const t=i/points;
-+        const angle=turns*2*Math.PI*t;
-+        const r=maxR*t;
-+        const x=CENTER.x+r*Math.cos(angle);
-+        const y=CENTER.y+r*Math.sin(angle);
-+        p.vertex(x,y);
-+      }
-+      p.endShape();
-+      return maxR;
-+    }
-+
-+    // Draw case study nodes around outer ring
-+    function drawNodes(maxR){
-+      const r=maxR*0.9;
-+      cases.forEach((c,idx)=>{
-+        const phi=idx*(2*Math.PI/cases.length);
-+        const x=CENTER.x+r*Math.cos(phi);
-+        const y=CENTER.y+r*Math.sin(phi);
-+        p.fill(PALETTE[idx%PALETTE.length]);
-+        p.noStroke();
-+        p.circle(x,y,36);
-+        p.fill(255);
-+        p.textAlign(p.CENTER,p.BOTTOM);
-+        p.text(c.title,x,y-24);
-+      });
-+    }
-+
-+    // Draw shuffled prompts near center
-+    function drawPrompts(maxR){
-+      const r=maxR*0.3;
-+      p.fill(255);
-+      p.textAlign(p.CENTER,p.CENTER);
-+      prompts.forEach((txt,i)=>{
-+        const angle=i*(2*Math.PI/prompts.length);
-+        const x=CENTER.x+r*Math.cos(angle);
-+        const y=CENTER.y+r*Math.sin(angle);
-+        p.text(txt,x,y);
-+      });
-+    }
-+
-+    p.draw=()=>{
-+      drawBackground();
-+      const maxR=drawSpiral();
-+      drawNodes(maxR);
-+      drawPrompts(maxR);
-+      // Save final artwork
-+      p.saveCanvas('Visionary_Dream','png');
-+    };
-+  });
-+}
 // Render Visionary_Dream fractal artwork using p5.js
-export default async function fractalArt(){
+export default async function fractalArt() {
   // Load p5 library if not already present
-  if(!window.p5){
-    try{
+  if (!window.p5) {
+    try {
       await import('../vendor/p5.min.js');
-    }catch{
+    } catch {
       await import('https://cdn.jsdelivr.net/npm/p5@1.9.0/lib/p5.min.js');
     }
   }
@@ -235,90 +19,90 @@ export default async function fractalArt(){
   // Canvas resolution
   const WIDTH = 1920;
   const HEIGHT = 1080;
-  const CENTER = { x: WIDTH/2, y: HEIGHT/2 };
+  const CENTER = { x: WIDTH / 2, y: HEIGHT / 2 };
 
-  new p5(p=>{
+  new p5(p => {
     // Prepare prompts
-    const prompts = cases.map(c=>c.prompt);
+    const prompts = cases.map(c => c.prompt);
     // Simple shuffle
-    for(let i=prompts.length-1;i>0;i--){
-      const j=Math.floor(Math.random()*(i+1));
-      [prompts[i],prompts[j]]=[prompts[j],prompts[i]];
+    for (let i = prompts.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [prompts[i], prompts[j]] = [prompts[j], prompts[i]];
     }
 
-    p.setup=()=>{
-      p.createCanvas(WIDTH,HEIGHT);
+    p.setup = () => {
+      p.createCanvas(WIDTH, HEIGHT);
       p.noLoop();
       p.angleMode(p.RADIANS);
       p.textFont('sans-serif');
     };
 
     // Draw layered gradient background
-    function drawBackground(){
-      for(let i=PALETTE.length-1;i>=0;i--){
+    function drawBackground() {
+      for (let i = PALETTE.length - 1; i >= 0; i--) {
         p.noStroke();
         p.fill(PALETTE[i]);
-        const r=Math.max(WIDTH,HEIGHT)*(i+1)/PALETTE.length;
-        p.ellipse(CENTER.x,CENTER.y,r,r);
+        const r = Math.max(WIDTH, HEIGHT) * (i + 1) / PALETTE.length;
+        p.ellipse(CENTER.x, CENTER.y, r, r);
       }
     }
 
     // Draw spiral path
-    function drawSpiral(){
-      const turns=3.5;
-      const points=500;
-      const maxR=Math.min(WIDTH,HEIGHT)*0.45;
-      p.stroke(PALETTE[PALETTE.length-1]);
+    function drawSpiral() {
+      const turns = 3.5;
+      const points = 500;
+      const maxR = Math.min(WIDTH, HEIGHT) * 0.45;
+      p.stroke(PALETTE[PALETTE.length - 1]);
       p.noFill();
       p.beginShape();
-      for(let i=0;i<points;i++){
-        const t=i/points;
-        const angle=turns*2*Math.PI*t;
-        const r=maxR*t;
-        const x=CENTER.x+r*Math.cos(angle);
-        const y=CENTER.y+r*Math.sin(angle);
-        p.vertex(x,y);
+      for (let i = 0; i < points; i++) {
+        const t = i / points;
+        const angle = turns * 2 * Math.PI * t;
+        const r = maxR * t;
+        const x = CENTER.x + r * Math.cos(angle);
+        const y = CENTER.y + r * Math.sin(angle);
+        p.vertex(x, y);
       }
       p.endShape();
       return maxR;
     }
 
     // Draw case study nodes around outer ring
-    function drawNodes(maxR){
-      const r=maxR*0.9;
-      cases.forEach((c,idx)=>{
-        const phi=idx*(2*Math.PI/cases.length);
-        const x=CENTER.x+r*Math.cos(phi);
-        const y=CENTER.y+r*Math.sin(phi);
-        p.fill(PALETTE[idx%PALETTE.length]);
+    function drawNodes(maxR) {
+      const r = maxR * 0.9;
+      cases.forEach((c, idx) => {
+        const phi = idx * (2 * Math.PI / cases.length);
+        const x = CENTER.x + r * Math.cos(phi);
+        const y = CENTER.y + r * Math.sin(phi);
+        p.fill(PALETTE[idx % PALETTE.length]);
         p.noStroke();
-        p.circle(x,y,36);
+        p.circle(x, y, 36);
         p.fill(255);
-        p.textAlign(p.CENTER,p.BOTTOM);
-        p.text(c.title,x,y-24);
+        p.textAlign(p.CENTER, p.BOTTOM);
+        p.text(c.title, x, y - 24);
       });
     }
 
     // Draw shuffled prompts near center
-    function drawPrompts(maxR){
-      const r=maxR*0.3;
+    function drawPrompts(maxR) {
+      const r = maxR * 0.3;
       p.fill(255);
-      p.textAlign(p.CENTER,p.CENTER);
-      prompts.forEach((txt,i)=>{
-        const angle=i*(2*Math.PI/prompts.length);
-        const x=CENTER.x+r*Math.cos(angle);
-        const y=CENTER.y+r*Math.sin(angle);
-        p.text(txt,x,y);
+      p.textAlign(p.CENTER, p.CENTER);
+      prompts.forEach((txt, i) => {
+        const angle = i * (2 * Math.PI / prompts.length);
+        const x = CENTER.x + r * Math.cos(angle);
+        const y = CENTER.y + r * Math.sin(angle);
+        p.text(txt, x, y);
       });
     }
 
-    p.draw=()=>{
+    p.draw = () => {
       drawBackground();
-      const maxR=drawSpiral();
+      const maxR = drawSpiral();
       drawNodes(maxR);
       drawPrompts(maxR);
       // Save final artwork
-      p.saveCanvas('Visionary_Dream','png');
+      p.saveCanvas('Visionary_Dream', 'png');
     };
   });
 }

--- a/plugins/soundscape.js
+++ b/plugins/soundscape.js
@@ -1,102 +1,30 @@
 // Simple binaural soundscape using the Web Audio API
-export default function soundscape(){
-  const AudioCtx = window.AudioContext || window.webkitAudioContext;
-  if(!AudioCtx){
-    alert('Web Audio API not supported');
-    return;
-  }
-  const ctx = new AudioCtx();
-  const oscL = ctx.createOscillator();
-  const oscR = ctx.createOscillator();
-  const merger = ctx.createChannelMerger(2);
-
-  oscL.frequency.value = 440; // left ear frequency
-  oscR.frequency.value = 446; // right ear slightly higher for binaural beat
-  oscL.connect(merger,0,0);
-  oscR.connect(merger,0,1);
-  merger.connect(ctx.destination);
-  oscL.start();
-  oscR.start();
-
-  return {
-    stop(){
-      oscL.stop();
-      oscR.stop();
-      ctx.close();
-    }
-  };
-}
-export default {
-  id: 'soundscape',
-  activate(_engine, theme = 'hypatia') {
-    if (window.COSMO_SETTINGS?.muteAudio) return;
-    const AudioCtx = window.AudioContext || window.webkitAudioContext;
-    const ctx = new AudioCtx();
-    const gain = ctx.createGain();
-    gain.gain.value = 0.1;
-    gain.connect(ctx.destination);
-
-    const freqs = theme === 'tesla' ? [432, 864] : [220, 440];
-    this._osc = freqs.map(f => {
-      const osc = ctx.createOscillator();
-      osc.frequency.value = f;
-      osc.connect(gain).start();
-      return osc;
-    });
-    this._ctx = ctx;
-  },
-  deactivate() {
-    this._osc?.forEach(o => { try { o.stop(); } catch {} });
-    this._osc = null;
-    if (this._ctx) {
-      this._ctx.close?.();
-      this._ctx = null;
-    }
-  }
-};
-// Ambient soundscapes honoring realm archetypes
-export default function soundscape(realm){
-  // Respect global mute setting for neurodivergent care
-  if(window.COSMO_SETTINGS?.muteAudio) return;
-
-  const ctx = new (window.AudioContext || window.webkitAudioContext)();
-  // Tone pairs inspired by each visionary realm
-  const tones = {
-    hypatia: [196.0, 392.0],              // Hypatia's Library – contemplative hum
-    tesla: [329.63, 659.25],              // Tesla's Workshop – electric overtones
-    agrippa: [261.63, 523.25],            // Agrippa's Study – occult resonance
-    'alexandrian-scriptorium': [440.0]    // Sappho's Chord – lyric center
-  };
-  const freqs = tones[realm] || [220.0];  // Default tonic if realm unknown
-
-  // Layer gentle oscillators for a balanced chord
-  freqs.forEach((f, idx)=>{
-    const osc = ctx.createOscillator();
-    const gain = ctx.createGain();
-    osc.type = 'sine';
-    osc.frequency.value = f;
-    gain.gain.value = 0.03 / freqs.length;
-    osc.connect(gain);
-    gain.connect(ctx.destination);
-    osc.start();
-    osc.stop(ctx.currentTime + 2 + idx);
-  });
-}
 export default function soundscape(name) {
   const settings = global.window?.COSMO_SETTINGS || {};
   if (settings.muteAudio) return;
 
-  const ctx = new window.AudioContext();
-  const gain = ctx.createGain();
-  gain.connect(ctx.destination);
+  const AudioCtx = global.window?.AudioContext || global.window?.webkitAudioContext;
+  if (!AudioCtx) {
+    console.warn('Web Audio API not supported');
+    return;
+  }
 
-  const base = { hypatia: 220, tesla: 330 }[name] || 440;
-  [base, base * 2].forEach((freq) => {
-    const osc = ctx.createOscillator();
-    osc.frequency.value = freq;
-    osc.connect(gain);
-    osc.start();
-    osc.stop(ctx.currentTime + 1);
-  });
+  const ctx = new AudioCtx();
+  try {
+    const gain = ctx.createGain();
+    gain.connect(ctx.destination);
+
+    const base = { hypatia: 220, tesla: 330 }[name] || 440;
+    [base, base * 2].forEach((freq) => {
+      const osc = ctx.createOscillator();
+      osc.frequency.value = freq;
+      osc.connect(gain);
+      osc.start();
+      osc.stop(ctx.currentTime + 1);
+    });
+  } catch (err) {
+    console.error('Failed to initialize soundscape', err);
+  } finally {
+    ctx.close?.();
+  }
 }
-

--- a/src/configLoader.js
+++ b/src/configLoader.js
@@ -1,108 +1,65 @@
--+export function loadFirstDemo() {
--+  const demos = loadConfig('data/demos.json');
--+  const config = demos[0].config;
--+  validatePlateConfig(config);
--+  return config;
--+}
-+import { readFileSync } from 'fs';
-+import path from 'path';
-+
-+// Load a JSON configuration file with basic error handling
-+export function loadConfig(relativePath) {
-+  const file = path.resolve(process.cwd(), relativePath);
-+  let raw;
-+  try {
-+    raw = readFileSync(file, 'utf8');
-+  } catch (err) {
-+    throw new Error(`Config file not found: ${relativePath}`);
-+  }
-+
-+  try {
-+    return JSON.parse(raw);
-+  } catch (err) {
-+    throw new Error(`Invalid JSON in ${relativePath}`);
-+  }
-+}
-+
-+// Ensure a plate config adheres to the minimal schema used by renderPlate
-+export function validatePlateConfig(config) {
-+  if (typeof config !== 'object' || config === null) {
-+    throw new Error('Config must be an object');
-+  }
-+  const layouts = ['spiral', 'twin-cone', 'wheel', 'grid'];
-+  if (!layouts.includes(config.layout)) {
-+    throw new Error('Unknown layout');
-+  }
-+  if (typeof config.mode !== 'number' || config.mode <= 0) {
-+    throw new Error('Mode must be a positive number');
-+  }
-+  if (!Array.isArray(config.labels)) {
-+    throw new Error('Labels must be an array');
-+  }
-+  if (config.labels.length !== config.mode) {
-+    throw new Error('Label count must match mode');
-+  }
-+}
-+
-+export function loadFirstDemo() {
-+  const demos = loadConfig('data/demos.json');
-+  const config = demos[0].config;
-+  validatePlateConfig(config);
-+  return config;
-+}
- 
-EOF
-)
 import { readFileSync } from 'fs';
 import path from 'path';
 
-// Load a JSON configuration file with basic error handling
+// Custom error type that aggregates structural problems
+export class ConfigError extends Error {
+  constructor(file, messages) {
+    super(messages.join('; '));
+    this.file = file;
+    this.messages = messages;
+  }
+}
+
+// Load a JSON configuration file with expanded error handling
 export function loadConfig(relativePath) {
   const file = path.resolve(process.cwd(), relativePath);
   let raw;
   try {
     raw = readFileSync(file, 'utf8');
   } catch (err) {
-    throw new Error(`Config file not found: ${relativePath}`);
+    throw new ConfigError(relativePath, [`Unable to read file: ${err.message}`]);
   }
 
   try {
     return JSON.parse(raw);
-  } catch (err) {
   } catch {
-    throw new Error(`Config file not found: ${relativePath}`);
-  }
-  try {
-    return JSON.parse(raw);
-  } catch {
-    throw new Error(`Invalid JSON in ${relativePath}`);
+    throw new ConfigError(relativePath, ['Invalid JSON']);
   }
 }
 
-// Ensure a plate config adheres to the minimal schema used by renderPlate
-export function validatePlateConfig(config) {
+// Validate a plate config and surface all structural issues
+export function validatePlateConfig(config, source = 'config') {
+  const errors = [];
+
   if (typeof config !== 'object' || config === null) {
-    throw new Error('Config must be an object');
+    errors.push('config must be an object');
+  } else {
+    const layouts = ['spiral', 'twin-cone', 'wheel', 'grid'];
+    if (!layouts.includes(config.layout)) {
+      errors.push(`layout must be one of: ${layouts.join(', ')}`);
+    }
+    if (!Number.isInteger(config.mode) || config.mode <= 0) {
+      errors.push('mode must be a positive integer');
+    }
+    if (!Array.isArray(config.labels)) {
+      errors.push('labels must be an array');
+    } else if (config.labels.length !== config.mode) {
+      errors.push('label count must match mode');
+    }
   }
-  const layouts = ['spiral', 'twin-cone', 'wheel', 'grid'];
-  if (!layouts.includes(config.layout)) {
-    throw new Error('Unknown layout');
+
+  if (errors.length) {
+    throw new ConfigError(source, errors);
   }
-  if (typeof config.mode !== 'number' || config.mode <= 0) {
-    throw new Error('Mode must be a positive number');
-  }
-  if (!Array.isArray(config.labels)) {
-    throw new Error('Labels must be an array');
-  }
-  if (config.labels.length !== config.mode) {
-    throw new Error('Label count must match mode');
-  }
+  return true;
 }
 
 export function loadFirstDemo() {
   const demos = loadConfig('data/demos.json');
+  if (!Array.isArray(demos) || demos.length === 0 || typeof demos[0].config !== 'object') {
+    throw new ConfigError('data/demos.json', ['Expected array with a config object']);
+  }
   const config = demos[0].config;
-  validatePlateConfig(config);
+  validatePlateConfig(config, 'data/demos.json[0].config');
   return config;
 }
-

--- a/src/renderPlate.js
+++ b/src/renderPlate.js
@@ -46,7 +46,6 @@ function gridPositions(count) {
 }
 
 export function renderPlate(config) {
-  if (!config || typeof config.layout !== 'string' || typeof config.mode !== 'number' || !Array.isArray(config.labels)) {
   if (
     !config ||
     typeof config.layout !== 'string' ||
@@ -95,4 +94,3 @@ export function renderPlate(config) {
 
   return { ...config, items, exportAsJSON, exportAsSVG, exportAsPNG };
 }
-

--- a/test/config-loader.test.js
+++ b/test/config-loader.test.js
@@ -1,26 +1,30 @@
-import { loadConfig, validatePlateConfig } from '../src/configLoader.js';
 import { test } from 'node:test';
 import { strict as assert } from 'assert';
-import { test } from 'node:test';
-import { strict as assert } from 'assert';
-import { loadConfig, validatePlateConfig } from '../src/configLoader.js';
 import { writeFileSync, unlinkSync } from 'fs';
+import { loadConfig, validatePlateConfig, ConfigError } from '../src/configLoader.js';
 
 // Ensure loadConfig surfaces invalid JSON errors
-import { writeFileSync, unlinkSync } from 'fs';
-
 test('loadConfig throws on invalid JSON', () => {
   const file = 'test/fixtures/bad.json';
   writeFileSync(file, '{');
-  assert.throws(() => loadConfig(file), /Invalid JSON/);
+  assert.throws(() => loadConfig(file), (err) => err instanceof ConfigError && /Invalid JSON/.test(err.message));
   unlinkSync(file);
 });
 
-// Validate schema enforcement
-test('validatePlateConfig enforces label count', () => {
-  const good = { layout: 'spiral', mode: 1, labels: ['x'] };
-  validatePlateConfig(good);
-  const bad = { ...good, labels: [] };
-  assert.throws(() => validatePlateConfig(bad), /Label count/);
+// Ensure loadConfig surfaces missing file errors
+test('loadConfig throws on missing file', () => {
+  assert.throws(() => loadConfig('nope.json'), ConfigError);
 });
 
+// Validate schema enforcement
+test('validatePlateConfig aggregates errors', () => {
+  const bad = { layout: 'unknown', mode: -1, labels: [] };
+  assert.throws(() => validatePlateConfig(bad), (err) => {
+    return (
+      err instanceof ConfigError &&
+      err.messages.includes('layout must be one of: spiral, twin-cone, wheel, grid') &&
+      err.messages.includes('mode must be a positive integer') &&
+      err.messages.includes('label count must match mode')
+    );
+  });
+});

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -1,36 +1,20 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-
-test('basic arithmetic works', () => {
-  assert.equal(1 + 1, 2);
-import test from 'node:test';
-import assert from 'node:assert/strict';
-import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
-import { loadConfig } from '../src/configLoader.js';
+import { loadFirstDemo } from '../src/configLoader.js';
 import { renderPlate } from '../src/renderPlate.js';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-
-test('renderPlate renders first demo plate without throwing', () => {
-  const demos = loadConfig(join(__dirname, '..', 'data', 'demos.json'));
-  const config = demos[0].config;
-  const plate = renderPlate(config);
-  assert.equal(plate.layout, config.layout);
-  assert.equal(plate.labels.length, config.mode);
-import { strict as assert } from 'assert';
-import { loadFirstDemo } from '../src/configLoader.js';
+// Simple sanity check
+test('basic arithmetic works', () => {
+  assert.equal(1 + 1, 2);
+});
 
 test('loadFirstDemo returns valid config', () => {
   const config = loadFirstDemo();
   assert.equal(typeof config.layout, 'string');
   assert.equal(config.labels.length, config.mode);
 });
-import { strict as assert } from 'assert';
-import { renderPlate } from '../src/renderPlate.js';
 
 test('renderPlate creates items for basic wheel', () => {
   const plate = renderPlate({ layout: 'wheel', mode: 3, labels: ['a', 'b', 'c'] });
   assert.equal(plate.items.length, 3);
 });
-

--- a/test/soundscape.test.js
+++ b/test/soundscape.test.js
@@ -2,52 +2,9 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import soundscape from '../plugins/soundscape.js';
 
-function cleanup(){ delete global.window; delete global.alert; }
-
-test('soundscape respects mute', ()=>{
-  global.window = { COSMO_SETTINGS: { muteAudio: true } };
-  global.alert = () => {};
-  assert.doesNotThrow(()=> soundscape('hypatia'));
-import soundscape from '../plugins/soundscape.js';
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
-
-// Clean window after each test
-function cleanup(){ delete global.window; }
-
-test('soundscape respects mute', ()=>{
-  global.window = { COSMO_SETTINGS: { muteAudio: true } };
-  assert.doesNotThrow(()=> soundscape.activate(null,'hypatia'));
-  assert.doesNotThrow(()=> soundscape('hypatia'));
-  cleanup();
-});
-
-test('soundscape starts oscillators when not muted', ()=>{
-  let started = 0;
-  class FakeOsc { constructor(){ this.frequency={value:0}; } connect(){ return this; } start(){ started++; } stop(){} }
-  class FakeGain { constructor(){ this.gain={value:0}; } connect(){ return this; } }
-  class FakeMerger { connect(){ return this; } }
-  class FakeAudioCtx {
-    constructor(){ this.currentTime = 0; this.destination = {}; }
-    createOscillator(){ return new FakeOsc(); }
-    createGain(){ return new FakeGain(); }
-    createChannelMerger(){ return new FakeMerger(); }
-  }
-  global.window = { COSMO_SETTINGS: { muteAudio: false }, AudioContext: FakeAudioCtx };
-  global.alert = () => {};
-  assert.doesNotThrow(()=> soundscape('tesla'));
-  assert.equal(started,2);
-  class FakeGain { constructor(){ this.gain={value:0}; } connect(){ } }
-  class FakeGain { constructor(){ this.gain={value:0}; } connect(){ }
-import { strict as assert } from 'assert';
-import soundscape from '../plugins/soundscape.js';
-
-// Clean window after each test
 function cleanup() {
   delete global.window;
   delete global.alert;
-function cleanup() {
-  delete global.window;
 }
 
 test('soundscape respects mute', () => {
@@ -60,68 +17,32 @@ test('soundscape respects mute', () => {
 test('soundscape starts oscillators when not muted', () => {
   let started = 0;
   class FakeOsc {
-    constructor() {
-      this.frequency = { value: 0 };
-    }
-    connect() {
-      return this;
-    }
-    start() {
-      started++;
-    }
-    stop() {}
-  }
-  class FakeGain {
-    constructor() {
-      this.gain = { value: 0 };
-    }
-    connect() {}
-  }
-  class FakeMerger {
     constructor() { this.frequency = { value: 0 }; }
     connect() { return this; }
     start() { started++; }
     stop() {}
   }
-  class FakeGain {
-    constructor() { this.gain = { value: 0 }; }
-    connect() {}
+  class FakeGain { constructor() { this.gain = { value: 0 }; } connect() { return this; } }
+  class FakeMerger { connect() { return this; } }
+  class FakeAudioCtx {
+    constructor() { this.currentTime = 0; this.destination = {}; }
+    createOscillator() { return new FakeOsc(); }
+    createGain() { return new FakeGain(); }
+    createChannelMerger() { return new FakeMerger(); }
+    close() {}
   }
-  global.window = {
-    COSMO_SETTINGS: { muteAudio: false },
-    AudioContext: class {
-      constructor(){ this.currentTime = 0; this.destination = {}; }
-      createOscillator(){ return new FakeOsc(); }
-      createGain(){ return new FakeGain(); }
-    }
-  };
-  assert.doesNotThrow(()=> soundscape.activate(null,'tesla'));
-  assert.equal(started,2);
-  soundscape.deactivate();
-  assert.doesNotThrow(()=> soundscape('tesla'));
-  assert.equal(started,2);
-      constructor() {
-        this.currentTime = 0;
-        this.destination = {};
-      }
-      createOscillator() {
-        return new FakeOsc();
-      }
-      createGain() {
-        return new FakeGain();
-      }
-      createChannelMerger() {
-        return new FakeMerger();
-      }
-    },
-  };
-      constructor() { this.currentTime = 0; this.destination = {}; }
-      createOscillator() { return new FakeOsc(); }
-      createGain() { return new FakeGain(); }
-    }
-  };
+  global.window = { COSMO_SETTINGS: { muteAudio: false }, AudioContext: FakeAudioCtx };
+  global.alert = () => {};
   assert.doesNotThrow(() => soundscape('tesla'));
   assert.equal(started, 2);
   cleanup();
 });
 
+test('soundscape handles missing AudioContext', () => {
+  global.window = { COSMO_SETTINGS: { muteAudio: false } };
+  const warnings = [];
+  console.warn = (msg) => warnings.push(msg);
+  assert.doesNotThrow(() => soundscape('hypatia'));
+  assert.ok(warnings.some((m) => /Web Audio API not supported/.test(m)));
+  cleanup();
+});


### PR DESCRIPTION
## Summary
- Introduce `ConfigError` with aggregated messages and stricter demo loading.
- Guard soundscape against unsupported Web Audio and runtime failures.
- Expand tests for configuration and audio handling edge cases.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b66cea077c8328b66e2932e606dff8