### PR TITLE
feat: add visionary palette and art bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,6 @@ Visionary_Dream.png
 # OS files
 .DS_Store
 /data/correspondences-2.json
+
+!stone-grimoire/core/build/
+!stone-grimoire/core/build/update-art.js

--- a/bridge/c99-bridge.js
+++ b/bridge/c99-bridge.js
@@ -1,0 +1,1 @@
+module.exports = require('./c99-bridge.json');

--- a/bridge/c99-bridge.json
+++ b/bridge/c99-bridge.json
@@ -1,0 +1,108 @@
+{
+  "meta": {
+    "project": "Circuitum99 × Stone Grimoire",
+    "updated": "2025-09-02T23:00:39.115Z",
+    "nd_safe": true,
+    "generator": "update-art.js (manual)"
+  },
+  "tokens": {
+    "css": "/assets/css/perm-style.css",
+    "json": "/assets/tokens/perm-style.json",
+    "palette": {
+      "void": "#0B0B0B",
+      "ink": "#141414",
+      "bone": "#F8F5EF",
+      "indigo": "#280050",
+      "violet": "#460082",
+      "blue": "#0080FF",
+      "green": "#00FF80",
+      "amber": "#FFC800",
+      "light": "#FFFFFF",
+      "crimson": "#B7410E",
+      "gold": "#C9A227",
+      "obsidian": "#0B0B0B",
+      "rose_quartz": "#FFB6C1",
+      "teal_glow": "#00CED1",
+      "violet_alt": "#8A2BE2",
+      "gonz_0": "#0b0b0b",
+      "gonz_1": "#16121b",
+      "gonz_2": "#2a2140",
+      "gonz_3": "#5e4ba8",
+      "gonz_4": "#e6e6e6",
+      "obsidian_glass": "#0f1014",
+      "obsidian_sheen": "#191b22",
+      "obsidian_rainbow": "#33214e",
+      "shungite_ink": "#0a0b0c",
+      "tourmaline_ridge": "#121318",
+      "basalt_ash": "#2b2f36",
+      "glint_silver": "#d9e0e7",
+      "lava_ember": "#ff4b1f",
+      "lava_core": "#ff7a00",
+      "raku_copper": "#b87333",
+      "raku_charcoal": "#1a1a1a",
+      "raku_violet": "#6E00FF",
+      "raku_azure": "#1F7AF3",
+      "smoke_gray": "#6b6f76",
+      "bg_legacy": "#0e0e12",
+      "ink_legacy": "#e9e7e1",
+      "gold_legacy": "#d4af37",
+      "rose_legacy": "#b4435d",
+      "lapis_legacy": "#2f5a9e",
+      "ash_legacy": "#6b6f76",
+      "line_legacy": "#22242a",
+      "muted_legacy": "#b9b6ad",
+      "accent_legacy": "#7fd8b3"
+    },
+    "secondary": {
+      "bg": "#0d0e14",
+      "ink": "#ECE7DE",
+      "edge": "#1D2028",
+      "sun": "#F2C14E",
+      "sea": "#3FA7D6",
+      "fern": "#24D6A9",
+      "rose": "#D65A8A",
+      "amethyst": "#7B5DD6"
+    },
+    "layers": {
+      "visionary": {
+        "name": "AlexGreyGrid",
+        "alpha": 0.22,
+        "scale": 1,
+        "line": "#4a4f63",
+        "highlight": "#aab3ff",
+        "pattern": "sacred-grid"
+      },
+      "patina": {
+        "name": "RakuBloom",
+        "alpha": 0.18,
+        "copper": "raku_copper",
+        "violet": "raku_violet",
+        "azure": "raku_azure"
+      }
+    }
+  },
+  "routes": {
+    "stone_grimoire": {
+      "base": "/",
+      "chapels": "/chapels/",
+      "assets": "/assets/",
+      "bridge": "/bridge/c99-bridge.json"
+    },
+    "cosmogenesis": {
+      "tokens": "/c99/tokens/perm-style.json",
+      "css": "/c99/css/perm-style.css",
+      "public": "/c99/",
+      "bridge": "/bridge/c99-bridge.json"
+    }
+  },
+  "rooms": [],
+  "angels": [],
+  "creatures": {
+    "dragons": [],
+    "daimons": []
+  },
+  "visionary": {
+    "overlays": []
+  },
+  "assets": []
+}

--- a/public/c99/css/perm-style.css
+++ b/public/c99/css/perm-style.css
@@ -1,0 +1,75 @@
+:root{
+  /* primary palette */
+  --void:#0B0B0B; --ink:#141414; --bone:#F8F5EF; --indigo:#280050; --violet:#460082; --blue:#0080FF; --green:#00FF80; --amber:#FFC800; --light:#FFFFFF; --crimson:#B7410E; --gold:#C9A227; --obsidian:#0B0B0B;
+  --gonz-0:#0b0b0b; --gonz-1:#16121b; --gonz-2:#2a2140; --gonz-3:#5e4ba8; --gonz-4:#e6e6e6;
+  /* volcanic + raku */
+  --obsidian-glass:#0f1014; --obsidian-sheen:#191b22; --obsidian-rainbow:#33214e; --shungite-ink:#0a0b0c; --tourmaline-ridge:#121318; --basalt-ash:#2b2f36; --glint-silver:#d9e0e7; --lava-ember:#ff4b1f; --lava-core:#ff7a00; --raku-copper:#b87333; --raku-charcoal:#1a1a1a; --raku-violet:#6E00FF; --raku-azure:#1F7AF3; --smoke-gray:#6b6f76;
+  /* legacy aliases preserved */
+  --bg:#0e0e12; --ink-legacy:#e9e7e1; --gold-legacy:#d4af37; --rose-legacy:#b4435d; --lapis-legacy:#2f5a9e; --ash-legacy:#6b6f76; --line-legacy:#22242a; --muted-legacy:#b9b6ad; --accent-legacy:#7fd8b3;
+  /* harmonized */
+  --surface-bg:var(--bg); --text-ink:var(--bone,var(--ink-legacy)); --line:var(--line-legacy); --muted:var(--muted-legacy); --accent:var(--teal_glow,var(--accent-legacy)); --goldy:var(--gold,var(--gold-legacy)); --rosy:var(--rose_quartz,var(--rose-legacy)); --lapis:var(--blue,var(--lapis-legacy));
+  /* secondary scheme */
+  --sec-bg:#0d0e14; --sec-ink:#ECE7DE; --sec-edge:#1D2028; --sec-sun:#F2C14E; --sec-sea:#3FA7D6; --sec-fern:#24D6A9; --sec-rose:#D65A8A; --sec-amethyst:#7B5DD6;
+  /* type + lines */
+  --line-hair:1px; --line-primary:2px; --line-pillar:3px; --font-display:"EB Garamond","Junicode",serif; --font-gothic:"Cinzel",serif; --font-ui:"Inter",system-ui,sans-serif; --scale-h1:1.6rem; --scale-h2:1.2rem; --scale-h3:1rem; --scale-body:1rem; --scale-small:.9rem; --min-contrast:4.5;
+}
+/* base SG vibe */
+html{color-scheme:light dark}
+html,body{margin:0;padding:0;background:var(--surface-bg);color:var(--text-ink);font:16px/1.5 ui-serif,Georgia,serif;-webkit-font-smoothing:antialiased}
+a{color:var(--text-ink);text-decoration:underline wavy var(--ash-legacy)}
+h1,h2,h3{font-family:ui-serif,Georgia,serif;letter-spacing:.02em}
+h1{font-weight:800;font-size:var(--scale-h1);margin:.3rem 0 1rem} h2{font-weight:700;font-size:var(--scale-h2);margin:1rem 0 .5rem} h3{font-size:var(--scale-h3);margin:.6rem 0 .3rem}
+small{color:var(--muted)}
+.container{max-width:1100px;margin:0 auto;padding:18px}
+.banner{display:grid;grid-template-columns:1fr 1fr 1.2fr;gap:12px;align-items:stretch}
+.tower,.temple,.stair{border:1px solid var(--line);border-radius:12px;padding:14px;background:linear-gradient(180deg,#12131a,#0c0d12)}
+.tower{position:relative} .tower h2{margin-top:0}
+.badge{display:inline-block;background:var(--line);padding:3px 8px;border-radius:999px;font-size:.8rem;color:var(--muted)}
+.hr,hr{height:1px;border:0;background:linear-gradient(90deg,transparent,var(--line),transparent);margin:10px 0}
+.btn{background:var(--line);color:var(--text-ink);border:1px solid #000;border-radius:8px;padding:6px 10px;cursor:pointer}
+.btn.gold{background:linear-gradient(180deg,#3b2b00,#231a00);border-color:#5b4300;color:#f5e6b2}
+.btn.rose{background:#3a1a22;border-color:#5c2431;color:#ffd9e3}
+.btn.lapis{background:#14243e;border-color:#1e3a70}
+input,select,textarea{width:100%;background:#0b0c10;color:var(--text-ink);border:1px solid var(--line);border-radius:8px;padding:8px;font:inherit}
+textarea{min-height:90px;resize:vertical}
+.grid{display:grid;gap:12px}
+@media(min-width:900px){.grid.two{grid-template-columns:1fr 1fr}.grid.three{grid-template-columns:1fr 1fr 1fr}}
+.kv{display:grid;grid-template-columns:120px 1fr;gap:8px;align-items:center}
+.tag{display:inline-block;border:1px solid var(--line);padding:2px 6px;border-radius:6px;margin:2px 6px 2px 0;font-size:.85rem;color:var(--muted)}
+.step{display:flex;gap:12px;align-items:flex-start;padding:8px;border:1px solid var(--line);border-radius:10px;background:#0b0c10}
+.step .num{width:28px;height:28px;display:inline-grid;place-items:center;border-radius:50%;background:#161821;border:1px solid var(--line);color:#ccc;font-weight:700}
+.stage-nigredo{box-shadow:inset 0 0 0 2px #1a1a1a} .stage-albedo{box-shadow:inset 0 0 0 2px #445566} .stage-citrinitas{box-shadow:inset 0 0 0 2px #7d6d2e} .stage-rubedo{box-shadow:inset 0 0 0 2px #6a1b2b}
+table{width:100%;border-collapse:collapse} td,th{border-bottom:1px solid var(--line);padding:6px;text-align:left;font-size:.95rem}
+footer{margin:20px 0 40px;color:var(--muted)}
+.note{border-left:3px solid var(--rose_quartz);padding-left:10px;color:#f0dbe1}
+.ok{color:var(--teal_glow)} .warn{color:#ffd68a} .danger{color:#ff9a9a}
+code{background:#0b0c10;border:1px solid var(--line);padding:2px 5px;border-radius:5px}
+/* ND-safe guard */
+@media (prefers-reduced-motion:reduce){*{animation:none!important;transition:none!important}}
+
+/* ——— Volcanic sculpture set ——— */
+.obsidian-sculpt{--edge:rgba(255,255,255,.06);background:linear-gradient(180deg,rgba(255,255,255,.03),rgba(0,0,0,.08)) padding-box,radial-gradient(1000px 600px at 30% 0%,rgba(255,255,255,.04),transparent 60%) border-box,linear-gradient(180deg,var(--obsidian-sheen),var(--obsidian));border:1px solid var(--edge);border-radius:14px;padding:14px;box-shadow:inset 0 1px 0 rgba(255,255,255,.05),inset 0 -120px 140px -120px rgba(255,255,255,.08),0 8px 22px rgba(0,0,0,.55)}
+.obsidian-facets{background:repeating-linear-gradient(125deg,rgba(255,255,255,.05) 0 1px,transparent 1px 9px),linear-gradient(180deg,transparent,rgba(255,255,255,.04));-webkit-mask-image:radial-gradient(280px 160px at 20% -10%,#000 40%,transparent 72%);mask-image:radial-gradient(280px 160px at 20% -10%,#000 40%,transparent 72%);border-radius:12px}
+.obsidian-glint{position:relative;background:linear-gradient(180deg,var(--tourmaline-ridge),var(--shungite-ink));overflow:hidden;border-radius:12px;border:1px solid rgba(255,255,255,.05)}
+.obsidian-glint::before{content:"";position:absolute;inset:0;background:radial-gradient(2px 2px at 14% 22%,var(--glint-silver) 30%,transparent 32%),radial-gradient(1.6px 1.6px at 44% 62%,var(--glint-silver) 30%,transparent 32%),radial-gradient(2px 2px at 70% 38%,var(--glint-silver) 30%,transparent 32%),radial-gradient(220px 120px at 10% -5%, rgba(110,0,255,.12), transparent 60%),radial-gradient(240px 160px at 100% -10%, rgba(31,122,243,.10), transparent 60%)}
+.raku-seal{--ring:conic-gradient(from 20deg,rgba(184,115,51,.92) 0 16%,rgba(110,0,255,.65) 16% 28%,rgba(31,122,243,.55) 28% 40%,rgba(184,115,51,.92) 40% 100%);width:140px;height:140px;border-radius:50%;background:radial-gradient(circle at 50% 52%,rgba(0,0,0,.0) 55%,rgba(0,0,0,.22) 62%,rgba(0,0,0,.38) 74%,rgba(0,0,0,.52) 100%),var(--ring);box-shadow:inset 0 0 2px rgba(255,255,255,.35),0 0 24px rgba(184,115,51,.18);border:1px solid rgba(255,255,255,.08)}
+.lava-brim{border:1px solid rgba(255,255,255,.06);border-radius:14px;padding:12px;background:linear-gradient(180deg,rgba(255,255,255,.03),rgba(0,0,0,.06)),radial-gradient(600px 220px at 50% 0%,rgba(255,75,31,.06),transparent 60%),linear-gradient(180deg,var(--basalt-ash),var(--obsidian));box-shadow:0 0 0 1px rgba(255,75,31,.12) inset,0 18px 44px rgba(0,0,0,.6)}
+
+/* ——— Visionary (Alex Grey) layer ———  no image files, just CSS pattern */
+.visionary-grid{
+  position:relative; border-radius:12px; overflow:hidden;
+  background:
+    radial-gradient(140px 60px at 25% 0%, rgba(170,179,255,.10), transparent 60%),
+    linear-gradient(180deg, rgba(255,255,255,.02), rgba(0,0,0,.06)),
+    repeating-conic-gradient(from 0deg, transparent 0 10deg, rgba(74,79,99,.12) 10deg 11deg);
+  outline:1px solid rgba(170,179,255,.18);
+}
+.visionary-grid::after{
+  content:""; position:absolute; inset:0; pointer-events:none; mix-blend-mode:screen; opacity:.22;
+  background:
+    radial-gradient(500px 180px at 50% -10%, rgba(170,179,255,.18), transparent 70%),
+    repeating-linear-gradient(120deg, transparent 0 22px, rgba(170,179,255,.12) 22px 23px);
+}
+/* Secondary palette helpers */
+.use-secondary{ background:var(--sec-bg); color:var(--sec-ink); border-color:var(--sec-edge)!important }
+.tag.sun{ color:var(--sec-sun) } .tag.sea{ color:var(--sec-sea) } .tag.fern{ color:var(--sec-fern) } .tag.rose{ color:var(--sec-rose) } .tag.amethyst{ color:var(--sec-amethyst) }

--- a/public/c99/filters/_filters.html
+++ b/public/c99/filters/_filters.html
@@ -1,0 +1,14 @@
+<svg width="0" height="0" style="position:absolute" aria-hidden="true" focusable="false"><defs>
+  <filter id="obsidianSheen" x="-20%" y="-20%" width="140%" height="140%">
+    <feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="1" seed="7" result="noise"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 .8 0" in="noise" result="mask"/>
+    <feSpecularLighting in="mask" surfaceScale="2" specularConstant=".55" specularExponent="20" lighting-color="#d9e0e7" result="spec"><fePointLight x="-80" y="-120" z="120"/></feSpecularLighting>
+    <feComposite in="spec" in2="mask" operator="in" result="specMasked"/><feBlend in="SourceGraphic" in2="specMasked" mode="screen"/>
+  </filter>
+  <filter id="rakuCopperIridescence" x="-20%" y="-20%" width="140%" height="140%">
+    <feTurbulence type="turbulence" baseFrequency="0.005 0.02" numOctaves="2" seed="33" result="n"/>
+    <feColorMatrix in="n" type="matrix" values="1 0 0 0 0  0 .65 0 0 0  0 0 .85 0 0  0 0 0 1 0" result="nm"/>
+    <feSpecularLighting in="nm" surfaceScale="3" specularConstant=".4" specularExponent="18" lighting-color="#b87333" result="copper"><fePointLight x="140" y="-160" z="220"/></feSpecularLighting>
+    <feBlend in="SourceGraphic" in2="copper" mode="screen"/>
+  </filter>
+</defs></svg>

--- a/public/c99/tokens/perm-style.json
+++ b/public/c99/tokens/perm-style.json
@@ -1,0 +1,60 @@
+{
+  "meta": {
+    "name": "Circuitum99 — Perm Style",
+    "version": "2.1.0",
+    "author": "Virelai Ezra Lux",
+    "materials_version": "obsidian-volcanic-1.0",
+    "nd_safe": true,
+    "notes": "Legacy SG + Secondary palette + Volcanic Obsidian + Raku Reiki + Visionary (Alex Grey) layer."
+  },
+  "palette": {
+    "void":"#0B0B0B","ink":"#141414","bone":"#F8F5EF",
+    "indigo":"#280050","violet":"#460082","blue":"#0080FF","green":"#00FF80","amber":"#FFC800","light":"#FFFFFF",
+    "crimson":"#B7410E","gold":"#C9A227","obsidian":"#0B0B0B",
+    "rose_quartz":"#FFB6C1","teal_glow":"#00CED1","violet_alt":"#8A2BE2",
+    "gonz_0":"#0b0b0b","gonz_1":"#16121b","gonz_2":"#2a2140","gonz_3":"#5e4ba8","gonz_4":"#e6e6e6",
+
+    "obsidian_glass":"#0f1014","obsidian_sheen":"#191b22","obsidian_rainbow":"#33214e",
+    "shungite_ink":"#0a0b0c","tourmaline_ridge":"#121318","basalt_ash":"#2b2f36","glint_silver":"#d9e0e7",
+    "lava_ember":"#ff4b1f","lava_core":"#ff7a00",
+    "raku_copper":"#b87333","raku_charcoal":"#1a1a1a","raku_violet":"#6E00FF","raku_azure":"#1F7AF3","smoke_gray":"#6b6f76",
+
+    "bg_legacy":"#0e0e12","ink_legacy":"#e9e7e1","gold_legacy":"#d4af37","rose_legacy":"#b4435d","lapis_legacy":"#2f5a9e",
+    "ash_legacy":"#6b6f76","line_legacy":"#22242a","muted_legacy":"#b9b6ad","accent_legacy":"#7fd8b3"
+  },
+  "secondary": {
+    "bg":"#0d0e14","ink":"#ECE7DE","edge":"#1D2028",
+    "sun":"#F2C14E","sea":"#3FA7D6","fern":"#24D6A9","rose":"#D65A8A","amethyst":"#7B5DD6"
+  },
+  "layers": {
+    "visionary": {
+      "name": "AlexGreyGrid",
+      "alpha": 0.22,
+      "scale": 1.0,
+      "line": "#4a4f63",
+      "highlight": "#aab3ff",
+      "pattern": "sacred-grid"      // consumed by CSS classes below (no new files required)
+    },
+    "patina": {
+      "name": "RakuBloom",
+      "alpha": 0.18,
+      "copper": "raku_copper",
+      "violet": "raku_violet",
+      "azure": "raku_azure"
+    }
+  },
+  "line": { "hair": 1, "primary": 2, "pillar": 3 },
+  "typography": {
+    "display": "'EB Garamond','Junicode',serif",
+    "gothic": "'Cinzel',serif",
+    "ui": "'Inter',system-ui,sans-serif",
+    "scale": { "h1": 1.6, "h2": 1.2, "h3": 1.0, "body": 1.0, "small": 0.9 }
+  },
+  "geometry": { "vesica_ratio": 1.732, "spine_33": true, "pillars_21": true, "gates_99": true },
+  "materials": {
+    "volcanic_obsidian": { "roughness": 0.33, "specular": 0.58, "ior": 1.53, "anisotropy": 0.28, "microfracture_density": 0.24, "conchoidal": 0.4, "inclusions": { "graphitic": 0.20, "pyritic": 0.07, "iridescence": 0.18 } },
+    "shungite": { "carbon_load": 0.85, "flake_scale": 0.18, "matte_ratio": 0.35, "silver_glint": 0.08 },
+    "raku_lineage": { "copper_bloom": 0.62, "charcoal_halo": 0.42, "violet_kiln": 0.22, "smoke_vignette": 0.18 }
+  },
+  "a11y": { "min_contrast": 4.5, "motion": "reduce", "autoplay": false, "strobe": false }
+}

--- a/stone-grimoire/assets/css/perm-style.css
+++ b/stone-grimoire/assets/css/perm-style.css
@@ -1,0 +1,75 @@
+:root{
+  /* primary palette */
+  --void:#0B0B0B; --ink:#141414; --bone:#F8F5EF; --indigo:#280050; --violet:#460082; --blue:#0080FF; --green:#00FF80; --amber:#FFC800; --light:#FFFFFF; --crimson:#B7410E; --gold:#C9A227; --obsidian:#0B0B0B;
+  --gonz-0:#0b0b0b; --gonz-1:#16121b; --gonz-2:#2a2140; --gonz-3:#5e4ba8; --gonz-4:#e6e6e6;
+  /* volcanic + raku */
+  --obsidian-glass:#0f1014; --obsidian-sheen:#191b22; --obsidian-rainbow:#33214e; --shungite-ink:#0a0b0c; --tourmaline-ridge:#121318; --basalt-ash:#2b2f36; --glint-silver:#d9e0e7; --lava-ember:#ff4b1f; --lava-core:#ff7a00; --raku-copper:#b87333; --raku-charcoal:#1a1a1a; --raku-violet:#6E00FF; --raku-azure:#1F7AF3; --smoke-gray:#6b6f76;
+  /* legacy aliases preserved */
+  --bg:#0e0e12; --ink-legacy:#e9e7e1; --gold-legacy:#d4af37; --rose-legacy:#b4435d; --lapis-legacy:#2f5a9e; --ash-legacy:#6b6f76; --line-legacy:#22242a; --muted-legacy:#b9b6ad; --accent-legacy:#7fd8b3;
+  /* harmonized */
+  --surface-bg:var(--bg); --text-ink:var(--bone,var(--ink-legacy)); --line:var(--line-legacy); --muted:var(--muted-legacy); --accent:var(--teal_glow,var(--accent-legacy)); --goldy:var(--gold,var(--gold-legacy)); --rosy:var(--rose_quartz,var(--rose-legacy)); --lapis:var(--blue,var(--lapis-legacy));
+  /* secondary scheme */
+  --sec-bg:#0d0e14; --sec-ink:#ECE7DE; --sec-edge:#1D2028; --sec-sun:#F2C14E; --sec-sea:#3FA7D6; --sec-fern:#24D6A9; --sec-rose:#D65A8A; --sec-amethyst:#7B5DD6;
+  /* type + lines */
+  --line-hair:1px; --line-primary:2px; --line-pillar:3px; --font-display:"EB Garamond","Junicode",serif; --font-gothic:"Cinzel",serif; --font-ui:"Inter",system-ui,sans-serif; --scale-h1:1.6rem; --scale-h2:1.2rem; --scale-h3:1rem; --scale-body:1rem; --scale-small:.9rem; --min-contrast:4.5;
+}
+/* base SG vibe */
+html{color-scheme:light dark}
+html,body{margin:0;padding:0;background:var(--surface-bg);color:var(--text-ink);font:16px/1.5 ui-serif,Georgia,serif;-webkit-font-smoothing:antialiased}
+a{color:var(--text-ink);text-decoration:underline wavy var(--ash-legacy)}
+h1,h2,h3{font-family:ui-serif,Georgia,serif;letter-spacing:.02em}
+h1{font-weight:800;font-size:var(--scale-h1);margin:.3rem 0 1rem} h2{font-weight:700;font-size:var(--scale-h2);margin:1rem 0 .5rem} h3{font-size:var(--scale-h3);margin:.6rem 0 .3rem}
+small{color:var(--muted)}
+.container{max-width:1100px;margin:0 auto;padding:18px}
+.banner{display:grid;grid-template-columns:1fr 1fr 1.2fr;gap:12px;align-items:stretch}
+.tower,.temple,.stair{border:1px solid var(--line);border-radius:12px;padding:14px;background:linear-gradient(180deg,#12131a,#0c0d12)}
+.tower{position:relative} .tower h2{margin-top:0}
+.badge{display:inline-block;background:var(--line);padding:3px 8px;border-radius:999px;font-size:.8rem;color:var(--muted)}
+.hr,hr{height:1px;border:0;background:linear-gradient(90deg,transparent,var(--line),transparent);margin:10px 0}
+.btn{background:var(--line);color:var(--text-ink);border:1px solid #000;border-radius:8px;padding:6px 10px;cursor:pointer}
+.btn.gold{background:linear-gradient(180deg,#3b2b00,#231a00);border-color:#5b4300;color:#f5e6b2}
+.btn.rose{background:#3a1a22;border-color:#5c2431;color:#ffd9e3}
+.btn.lapis{background:#14243e;border-color:#1e3a70}
+input,select,textarea{width:100%;background:#0b0c10;color:var(--text-ink);border:1px solid var(--line);border-radius:8px;padding:8px;font:inherit}
+textarea{min-height:90px;resize:vertical}
+.grid{display:grid;gap:12px}
+@media(min-width:900px){.grid.two{grid-template-columns:1fr 1fr}.grid.three{grid-template-columns:1fr 1fr 1fr}}
+.kv{display:grid;grid-template-columns:120px 1fr;gap:8px;align-items:center}
+.tag{display:inline-block;border:1px solid var(--line);padding:2px 6px;border-radius:6px;margin:2px 6px 2px 0;font-size:.85rem;color:var(--muted)}
+.step{display:flex;gap:12px;align-items:flex-start;padding:8px;border:1px solid var(--line);border-radius:10px;background:#0b0c10}
+.step .num{width:28px;height:28px;display:inline-grid;place-items:center;border-radius:50%;background:#161821;border:1px solid var(--line);color:#ccc;font-weight:700}
+.stage-nigredo{box-shadow:inset 0 0 0 2px #1a1a1a} .stage-albedo{box-shadow:inset 0 0 0 2px #445566} .stage-citrinitas{box-shadow:inset 0 0 0 2px #7d6d2e} .stage-rubedo{box-shadow:inset 0 0 0 2px #6a1b2b}
+table{width:100%;border-collapse:collapse} td,th{border-bottom:1px solid var(--line);padding:6px;text-align:left;font-size:.95rem}
+footer{margin:20px 0 40px;color:var(--muted)}
+.note{border-left:3px solid var(--rose_quartz);padding-left:10px;color:#f0dbe1}
+.ok{color:var(--teal_glow)} .warn{color:#ffd68a} .danger{color:#ff9a9a}
+code{background:#0b0c10;border:1px solid var(--line);padding:2px 5px;border-radius:5px}
+/* ND-safe guard */
+@media (prefers-reduced-motion:reduce){*{animation:none!important;transition:none!important}}
+
+/* ——— Volcanic sculpture set ——— */
+.obsidian-sculpt{--edge:rgba(255,255,255,.06);background:linear-gradient(180deg,rgba(255,255,255,.03),rgba(0,0,0,.08)) padding-box,radial-gradient(1000px 600px at 30% 0%,rgba(255,255,255,.04),transparent 60%) border-box,linear-gradient(180deg,var(--obsidian-sheen),var(--obsidian));border:1px solid var(--edge);border-radius:14px;padding:14px;box-shadow:inset 0 1px 0 rgba(255,255,255,.05),inset 0 -120px 140px -120px rgba(255,255,255,.08),0 8px 22px rgba(0,0,0,.55)}
+.obsidian-facets{background:repeating-linear-gradient(125deg,rgba(255,255,255,.05) 0 1px,transparent 1px 9px),linear-gradient(180deg,transparent,rgba(255,255,255,.04));-webkit-mask-image:radial-gradient(280px 160px at 20% -10%,#000 40%,transparent 72%);mask-image:radial-gradient(280px 160px at 20% -10%,#000 40%,transparent 72%);border-radius:12px}
+.obsidian-glint{position:relative;background:linear-gradient(180deg,var(--tourmaline-ridge),var(--shungite-ink));overflow:hidden;border-radius:12px;border:1px solid rgba(255,255,255,.05)}
+.obsidian-glint::before{content:"";position:absolute;inset:0;background:radial-gradient(2px 2px at 14% 22%,var(--glint-silver) 30%,transparent 32%),radial-gradient(1.6px 1.6px at 44% 62%,var(--glint-silver) 30%,transparent 32%),radial-gradient(2px 2px at 70% 38%,var(--glint-silver) 30%,transparent 32%),radial-gradient(220px 120px at 10% -5%, rgba(110,0,255,.12), transparent 60%),radial-gradient(240px 160px at 100% -10%, rgba(31,122,243,.10), transparent 60%)}
+.raku-seal{--ring:conic-gradient(from 20deg,rgba(184,115,51,.92) 0 16%,rgba(110,0,255,.65) 16% 28%,rgba(31,122,243,.55) 28% 40%,rgba(184,115,51,.92) 40% 100%);width:140px;height:140px;border-radius:50%;background:radial-gradient(circle at 50% 52%,rgba(0,0,0,.0) 55%,rgba(0,0,0,.22) 62%,rgba(0,0,0,.38) 74%,rgba(0,0,0,.52) 100%),var(--ring);box-shadow:inset 0 0 2px rgba(255,255,255,.35),0 0 24px rgba(184,115,51,.18);border:1px solid rgba(255,255,255,.08)}
+.lava-brim{border:1px solid rgba(255,255,255,.06);border-radius:14px;padding:12px;background:linear-gradient(180deg,rgba(255,255,255,.03),rgba(0,0,0,.06)),radial-gradient(600px 220px at 50% 0%,rgba(255,75,31,.06),transparent 60%),linear-gradient(180deg,var(--basalt-ash),var(--obsidian));box-shadow:0 0 0 1px rgba(255,75,31,.12) inset,0 18px 44px rgba(0,0,0,.6)}
+
+/* ——— Visionary (Alex Grey) layer ———  no image files, just CSS pattern */
+.visionary-grid{
+  position:relative; border-radius:12px; overflow:hidden;
+  background:
+    radial-gradient(140px 60px at 25% 0%, rgba(170,179,255,.10), transparent 60%),
+    linear-gradient(180deg, rgba(255,255,255,.02), rgba(0,0,0,.06)),
+    repeating-conic-gradient(from 0deg, transparent 0 10deg, rgba(74,79,99,.12) 10deg 11deg);
+  outline:1px solid rgba(170,179,255,.18);
+}
+.visionary-grid::after{
+  content:""; position:absolute; inset:0; pointer-events:none; mix-blend-mode:screen; opacity:.22;
+  background:
+    radial-gradient(500px 180px at 50% -10%, rgba(170,179,255,.18), transparent 70%),
+    repeating-linear-gradient(120deg, transparent 0 22px, rgba(170,179,255,.12) 22px 23px);
+}
+/* Secondary palette helpers */
+.use-secondary{ background:var(--sec-bg); color:var(--sec-ink); border-color:var(--sec-edge)!important }
+.tag.sun{ color:var(--sec-sun) } .tag.sea{ color:var(--sec-sea) } .tag.fern{ color:var(--sec-fern) } .tag.rose{ color:var(--sec-rose) } .tag.amethyst{ color:var(--sec-amethyst) }

--- a/stone-grimoire/assets/tokens/perm-style.json
+++ b/stone-grimoire/assets/tokens/perm-style.json
@@ -1,0 +1,60 @@
+{
+  "meta": {
+    "name": "Circuitum99 — Perm Style",
+    "version": "2.1.0",
+    "author": "Virelai Ezra Lux",
+    "materials_version": "obsidian-volcanic-1.0",
+    "nd_safe": true,
+    "notes": "Legacy SG + Secondary palette + Volcanic Obsidian + Raku Reiki + Visionary (Alex Grey) layer."
+  },
+  "palette": {
+    "void":"#0B0B0B","ink":"#141414","bone":"#F8F5EF",
+    "indigo":"#280050","violet":"#460082","blue":"#0080FF","green":"#00FF80","amber":"#FFC800","light":"#FFFFFF",
+    "crimson":"#B7410E","gold":"#C9A227","obsidian":"#0B0B0B",
+    "rose_quartz":"#FFB6C1","teal_glow":"#00CED1","violet_alt":"#8A2BE2",
+    "gonz_0":"#0b0b0b","gonz_1":"#16121b","gonz_2":"#2a2140","gonz_3":"#5e4ba8","gonz_4":"#e6e6e6",
+
+    "obsidian_glass":"#0f1014","obsidian_sheen":"#191b22","obsidian_rainbow":"#33214e",
+    "shungite_ink":"#0a0b0c","tourmaline_ridge":"#121318","basalt_ash":"#2b2f36","glint_silver":"#d9e0e7",
+    "lava_ember":"#ff4b1f","lava_core":"#ff7a00",
+    "raku_copper":"#b87333","raku_charcoal":"#1a1a1a","raku_violet":"#6E00FF","raku_azure":"#1F7AF3","smoke_gray":"#6b6f76",
+
+    "bg_legacy":"#0e0e12","ink_legacy":"#e9e7e1","gold_legacy":"#d4af37","rose_legacy":"#b4435d","lapis_legacy":"#2f5a9e",
+    "ash_legacy":"#6b6f76","line_legacy":"#22242a","muted_legacy":"#b9b6ad","accent_legacy":"#7fd8b3"
+  },
+  "secondary": {
+    "bg":"#0d0e14","ink":"#ECE7DE","edge":"#1D2028",
+    "sun":"#F2C14E","sea":"#3FA7D6","fern":"#24D6A9","rose":"#D65A8A","amethyst":"#7B5DD6"
+  },
+  "layers": {
+    "visionary": {
+      "name": "AlexGreyGrid",
+      "alpha": 0.22,
+      "scale": 1.0,
+      "line": "#4a4f63",
+      "highlight": "#aab3ff",
+      "pattern": "sacred-grid"      // consumed by CSS classes below (no new files required)
+    },
+    "patina": {
+      "name": "RakuBloom",
+      "alpha": 0.18,
+      "copper": "raku_copper",
+      "violet": "raku_violet",
+      "azure": "raku_azure"
+    }
+  },
+  "line": { "hair": 1, "primary": 2, "pillar": 3 },
+  "typography": {
+    "display": "'EB Garamond','Junicode',serif",
+    "gothic": "'Cinzel',serif",
+    "ui": "'Inter',system-ui,sans-serif",
+    "scale": { "h1": 1.6, "h2": 1.2, "h3": 1.0, "body": 1.0, "small": 0.9 }
+  },
+  "geometry": { "vesica_ratio": 1.732, "spine_33": true, "pillars_21": true, "gates_99": true },
+  "materials": {
+    "volcanic_obsidian": { "roughness": 0.33, "specular": 0.58, "ior": 1.53, "anisotropy": 0.28, "microfracture_density": 0.24, "conchoidal": 0.4, "inclusions": { "graphitic": 0.20, "pyritic": 0.07, "iridescence": 0.18 } },
+    "shungite": { "carbon_load": 0.85, "flake_scale": 0.18, "matte_ratio": 0.35, "silver_glint": 0.08 },
+    "raku_lineage": { "copper_bloom": 0.62, "charcoal_halo": 0.42, "violet_kiln": 0.22, "smoke_vignette": 0.18 }
+  },
+  "a11y": { "min_contrast": 4.5, "motion": "reduce", "autoplay": false, "strobe": false }
+}

--- a/stone-grimoire/chapels/_filters.html
+++ b/stone-grimoire/chapels/_filters.html
@@ -1,0 +1,14 @@
+<svg width="0" height="0" style="position:absolute" aria-hidden="true" focusable="false"><defs>
+  <filter id="obsidianSheen" x="-20%" y="-20%" width="140%" height="140%">
+    <feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="1" seed="7" result="noise"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 .8 0" in="noise" result="mask"/>
+    <feSpecularLighting in="mask" surfaceScale="2" specularConstant=".55" specularExponent="20" lighting-color="#d9e0e7" result="spec"><fePointLight x="-80" y="-120" z="120"/></feSpecularLighting>
+    <feComposite in="spec" in2="mask" operator="in" result="specMasked"/><feBlend in="SourceGraphic" in2="specMasked" mode="screen"/>
+  </filter>
+  <filter id="rakuCopperIridescence" x="-20%" y="-20%" width="140%" height="140%">
+    <feTurbulence type="turbulence" baseFrequency="0.005 0.02" numOctaves="2" seed="33" result="n"/>
+    <feColorMatrix in="n" type="matrix" values="1 0 0 0 0  0 .65 0 0 0  0 0 .85 0 0  0 0 0 1 0" result="nm"/>
+    <feSpecularLighting in="nm" surfaceScale="3" specularConstant=".4" specularExponent="18" lighting-color="#b87333" result="copper"><fePointLight x="140" y="-160" z="220"/></feSpecularLighting>
+    <feBlend in="SourceGraphic" in2="copper" mode="screen"/>
+  </filter>
+</defs></svg>

--- a/stone-grimoire/core/build/update-art.js
+++ b/stone-grimoire/core/build/update-art.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+const fs=require('fs'); const path=require('path');
+const root=path.resolve(__dirname,'../../');
+const ART=path.join(root,'assets','art');
+const inbox=path.join(ART,'inbox'), originals=path.join(ART,'originals'), processed=path.join(ART,'processed'), thumbs=path.join(ART,'thumbs'), webp=path.join(ART,'webp');
+[originals,processed,thumbs,webp].forEach(p=>fs.mkdirSync(p,{recursive:true}));
+let sharp=null; try{ sharp=require('sharp'); }catch{ console.log('sharp not found — skipping webp/thumbs'); }
+const allowed=new Set(['.png','.jpg','.jpeg','.webp','.svg']);
+const list=fs.existsSync(inbox)?fs.readdirSync(inbox):[];
+const assets=[];
+for(const file of list){
+  const src=path.join(inbox,file); const ext=path.extname(file).toLowerCase();
+  if(!allowed.has(ext)) continue;
+  const safe=file.toLowerCase().replace(/\s+/g,'-').replace(/[^a-z0-9._-]/g,'').replace(/-+/g,'-');
+  const orig=path.join(originals,safe); fs.renameSync(src,orig);
+  const proc=path.join(processed,safe); fs.copyFileSync(orig,proc);
+  const isRaster=['.png','.jpg','.jpeg','.webp'].includes(ext);
+  let thumbPath='', webpPath='';
+  if(sharp&&isRaster){
+    const base=safe.replace(ext,'');
+    thumbPath=`assets/art/thumbs/${base}-512.jpg`; webpPath=`assets/art/webp/${base}.webp`;
+    try{ await sharp(orig).removeAlpha().resize({width:512,withoutEnlargement:true}).jpeg({quality:82}).toFile(path.join(thumbs,`${base}-512.jpg`)); }catch{}
+    try{ await sharp(orig).webp({quality:82}).toFile(path.join(webp,`${base}.webp`)); }catch{}
+  }
+  assets.push({ name:safe, type:ext.slice(1), original:`assets/art/originals/${safe}`, processed:`assets/art/processed/${safe}`, thumb:thumbPath, webp:webpPath, nd_safe:true });
+}
+
+function safeReadJSON(p){ try{ return JSON.parse(fs.readFileSync(p,'utf8')); }catch{ return null; } }
+
+const sgStruct = safeReadJSON(path.resolve(root,'structure.json')) || safeReadJSON(path.resolve(root,'../structure.json'));
+const angels72 = safeReadJSON(path.resolve(root,'../cosmogenesis_learning_engine/registry/datasets/angels72.json')) || safeReadJSON(path.resolve(root,'../cosmogenesis_learning_engine/registry/datasets/shem72.json'));
+const styleTokens = safeReadJSON(path.resolve(root,'assets/tokens/perm-style.json')) || { palette:{}, secondary:{}, layers:{} };
+
+const defaultRooms = [
+  { id:"crypt", title:"The Crypt", element:"earth", stylepack:"Rosicrucian Black", tone:110, geometry:"vesica" },
+  { id:"nave", title:"The Nave", element:"air", stylepack:"Angelic Chorus", tone:222, geometry:"rose-window" },
+  { id:"apprentice_pillar", title:"Apprentice Pillar", element:"water", stylepack:"Hilma Spiral", tone:333, geometry:"fibonacci" },
+  { id:"respawn_gate", title:"Respawn Gate", element:"fire", stylepack:"Alchemical Bloom", tone:432, geometry:"merkaba" }
+];
+const rooms = Array.isArray(sgStruct?.rooms)&&sgStruct.rooms.length?sgStruct.rooms:defaultRooms;
+
+function tagFor(a){ if(/crypt/.test(a.name)) return 'crypt'; if(/nave/.test(a.name)) return 'nave'; if(/apprentice|pillar/.test(a.name)) return 'apprentice_pillar'; if(/respawn|gate/.test(a.name)) return 'respawn_gate'; return 'misc'; }
+const assetsByRoom={}; for(const a of assets){ const t=tagFor(a); (assetsByRoom[t] ||= []).push(a); }
+
+let angels=[]; if(Array.isArray(angels72)){ angels=angels72.slice(0,12).map((x,i)=>({ id:x.id||`angel-${i+1}`, name:x.name||x.shem||`Shem-${i+1}`, virtue:x.virtue||x.keyword||'', seal:(assets.find(a=>a.name.includes((x.id||`${i+1}`).toString().padStart(2,'0')))||{}).processed||'', gate:x.gate||(i+1) })); }
+
+const creatures={ dragons:[], daimons:[] };
+for(const a of assets){
+  if(/dragon/.test(a.name)) creatures.dragons.push({ id:a.name.replace(/\..+$/,''), title:"Dragon", frame_class:"lava-brim obsidian-sculpt obsidian-glint obsidian-facets visionary-grid", seal_filter:"obsidianSheen", src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'' });
+  if(/daimon/.test(a.name)) creatures.daimons.push({ id:a.name.replace(/\..+$/,''), title:"Daimon", frame_class:"raku-seal obsidian-sculpt visionary-grid", seal_filter:"rakuCopperIridescence", src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'' });
+}
+const visionaryAssets = assets.filter(a=>/alex[-_ ]?grey|visionary|sacred|grid/.test(a.name));
+
+const manifest={
+  meta:{ project:"Circuitum99 × Stone Grimoire", updated:new Date().toISOString(), nd_safe:true, generator:"update-art.js (manual)" },
+  tokens:{ css:"/assets/css/perm-style.css", json:"/assets/tokens/perm-style.json", palette:styleTokens.palette||{}, secondary:styleTokens.secondary||{}, layers:styleTokens.layers||{} },
+  routes:{ stone_grimoire:{ base:"/", chapels:"/chapels/", assets:"/assets/", bridge:"/bridge/c99-bridge.json" }, cosmogenesis:{ tokens:"/c99/tokens/perm-style.json", css:"/c99/css/perm-style.css", public:"/c99/", bridge:"/bridge/c99-bridge.json" } },
+  rooms: rooms.map(r=>({ id:r.id, title:r.title, element:r.element, tone:r.tone, geometry:r.geometry, stylepack:r.stylepack, assets:(assetsByRoom[r.id]||[]).map(a=>({name:a.name,thumb:`/${a.thumb}`,webp:a.webp?`/${a.webp}`:'',src:`/${a.processed}`,type:a.type})) })),
+  angels, creatures,
+  visionary: { overlays: visionaryAssets.map(a=>({ name:a.name, src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'' })) },
+  assets: assets.map(a=>({ name:a.name, src:`/${a.processed}`, thumb:a.thumb?`/${a.thumb}`:'', webp:a.webp?`/${a.webp}`:'', type:a.type }))
+};
+
+const bridgeRoot=path.resolve(root,'../../bridge'); fs.mkdirSync(bridgeRoot,{recursive:true});
+fs.writeFileSync(path.join(bridgeRoot,'c99-bridge.json'), JSON.stringify(manifest,null,2));
+console.log("Bridge manifest written: /bridge/c99-bridge.json");
+
+try{
+  const c99=path.resolve(root,'../../cosmogenesis_learning_engine/public/c99');
+  if(fs.existsSync(c99)){
+    fs.mkdirSync(path.join(c99,'tokens'),{recursive:true});
+    fs.mkdirSync(path.join(c99,'css'),{recursive:true});
+    fs.copyFileSync(path.resolve(root,'assets','tokens','perm-style.json'), path.join(c99,'tokens','perm-style.json'));
+    fs.copyFileSync(path.resolve(root,'assets','css','perm-style.css'), path.join(c99,'css','perm-style.css'));
+    console.log("Mirrored tokens+css to C99/public.");
+  }
+}catch(e){ console.warn("Mirror step skipped:", e.message); }
+console.log("Art ingest complete. ND-safe ✓");


### PR DESCRIPTION
## Summary
- add perm-style tokens with secondary palette and visionary layers
- introduce CSS for volcanic obsidian, Raku reiki, and Alex Grey grid
- provide art ingest script and bridge manifest

## Testing
- ⚠️ `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b77616786483288801588fcbfe4b7f