### PR TITLE
Expand rooms atlas

### DIFF
--- a/assets/js/engines/rooms-engine.js
+++ b/assets/js/engines/rooms-engine.js
@@ -1,3 +1,22 @@
 export function listRooms() {
-  return [{ id:'cosmogenesis', name:'Cosmogenesis', href:'./cosmogenesis/index.html' }];
+  return [
+    {
+      id: 'cosmogenesis',
+      name: 'Cosmogenesis',
+      href: './cosmogenesis/index.html',
+      description: 'Spiral Teacher • Plate Exports (PNG, JSON)',
+    },
+    {
+      id: 'circuitum99',
+      name: 'Circuitum 99',
+      href: './circuitum99/index.html',
+      description: 'Cymatic Circuit Grid',
+    },
+    {
+      id: 'egregore-sky',
+      name: 'Egregore Sky',
+      href: './stone-grimoire/chapels/egregore-sky/index.html',
+      description: 'Stone Grimoire Chapel Viewer',
+    },
+  ];
 }

--- a/chapels/rooms-atlas.html
+++ b/chapels/rooms-atlas.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>Cathedral Atlas</title>
+  <title>Rooms Atlas</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <style>
     body{margin:0;background:#0b0b0b;color:#e6e6e6;font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Inter,sans-serif;}
@@ -18,6 +18,14 @@
     <a class="tile" href="../cosmogenesis/index.html">
       <strong>Cosmogenesis</strong>
       <span class="cap">Spiral Teacher • Plate Exports (PNG, JSON)</span>
+    </a>
+    <a class="tile" href="../circuitum99/index.html">
+      <strong>Circuitum 99</strong>
+      <span class="cap">Cymatic Circuit Grid</span>
+    </a>
+    <a class="tile" href="../stone-grimoire/chapels/egregore-sky/index.html">
+      <strong>Egregore Sky</strong>
+      <span class="cap">Stone Grimoire Chapel Viewer</span>
     </a>
   </section>
 </body>

--- a/modules/rooms-atlas.html
+++ b/modules/rooms-atlas.html
@@ -1,40 +1,35 @@
 <!doctype html>
-<html>
-  <head>
-    <meta charset="utf-8" />
-    <title>Rooms Atlas</title>
-    <link rel="stylesheet" href="/assets/css/alchemy-plates.css" />
-  </head>
-  <body>
-    <div id="rooms"></div>
-    <script src="/assets/js/engines/progress-engine.js"></script>
-    <script src="/assets/js/engines/rooms-engine.js"></script>
-    <script src="/assets/js/engines/tesseract-bridge.js"></script>
-    <script src="/assets/js/engines/tesseract-hooks.js"></script>
-  </body>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>Rooms Atlas</title>
-  <link rel="stylesheet" href="../assets/css/alchemy-plates.css">
-</head>
-<body>
-  <main id="rooms-atlas"></main>
-  <section id="tesseract-stage" aria-label="Tesseract map"></section>
-  <script type="module" src="../assets/js/engines/rooms-engine.js"></script>
-  <script type="module" src="../assets/js/engines/tesseract-hooks.js"></script>
-  <script type="module" src="../assets/js/engines/tesseract-bridge.js"></script>
-</body>
-<html>
   <head>
     <meta charset="utf-8" />
     <title>Rooms Atlas</title>
-    <link rel="stylesheet" href="/assets/css/alchemy-plates.css" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      body{margin:0;background:#0b0b0b;color:#e6e6e6;font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Inter,sans-serif;}
+      .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:16px;padding:16px;}
+      .tile{background:#111;border:1px solid #262626;border-radius:12px;padding:14px;text-decoration:none;color:inherit;display:flex;flex-direction:column;gap:6px}
+      .tile:hover{border-color:#5e4ba8}
+      .cap{opacity:.75;font-size:14px}
+    </style>
   </head>
   <body>
-    <div id="rooms"></div>
-    <script src="/assets/js/engines/rooms-engine.js"></script>
-    <script src="/assets/js/engines/tesseract-bridge.js"></script>
-    <script src="/assets/js/engines/tesseract-hooks.js"></script>
+    <h1 style="padding:16px">Rooms Atlas</h1>
+    <main id="rooms-atlas" class="grid"></main>
+    <section id="tesseract-stage" aria-label="Tesseract map"></section>
+    <script type="module">
+      import { listRooms } from '../assets/js/engines/rooms-engine.js';
+
+      const mount = document.getElementById('rooms-atlas');
+      listRooms().forEach(r => {
+        const a = document.createElement('a');
+        a.className = 'tile';
+        a.href = r.href;
+        a.innerHTML = `<strong>${r.name}</strong><span class="cap">${r.description}</span>`;
+        mount.appendChild(a);
+      });
+    </script>
+    <script type="module" src="../assets/js/engines/tesseract-hooks.js"></script>
+    <script type="module" src="../assets/js/engines/tesseract-bridge.js"></script>
   </body>
 </html>
+


### PR DESCRIPTION
## Summary
- add detailed room listings including Circuitum 99 and Egregore Sky
- populate Rooms Atlas HTML with links to all rooms
- create dynamic module-based atlas page powered by rooms-engine

## Testing
- `npm test` *(fails: Identifier 'writeFileSync' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e5c220ec8328864cc2cc85050026