### PR TITLE
Expand rooms atlas with Ain Soph Grove

### DIFF
--- a/assets/js/engines/rooms-engine.js
+++ b/assets/js/engines/rooms-engine.js
@@ -1,3 +1,29 @@
 export function listRooms() {
-  return [{ id:'cosmogenesis', name:'Cosmogenesis', href:'./cosmogenesis/index.html' }];
+  return [
+    {
+      id: 'cosmogenesis',
+      name: 'Cosmogenesis',
+      href: './cosmogenesis/index.html',
+      description: 'Spiral Teacher • Plate Exports (PNG, JSON)',
+    },
+    {
+      id: 'circuitum99',
+      name: 'Circuitum 99',
+      href: './circuitum99/index.html',
+      description: 'Cymatic Circuit Grid',
+    },
+    {
+      id: 'egregore-sky',
+      name: 'Egregore Sky',
+      href: './stone-grimoire/chapels/egregore-sky/index.html',
+      description: 'Stone Grimoire Chapel Viewer',
+    },
+    {
+      id: 'ain-soph-grove',
+      name: 'Ain Soph Grove',
+      href: './openworld/index.html',
+      description:
+        'Nature sanctuary weaving Hermetic, Thelemic, Kabalistic, Pagan & Buddhist mythos of time',
+    },
+  ];
 }

--- a/chapels/rooms-atlas.html
+++ b/chapels/rooms-atlas.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>Cathedral Atlas</title>
+  <title>Rooms Atlas</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <style>
     body{margin:0;background:#0b0b0b;color:#e6e6e6;font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Inter,sans-serif;}
@@ -18,6 +18,18 @@
     <a class="tile" href="../cosmogenesis/index.html">
       <strong>Cosmogenesis</strong>
       <span class="cap">Spiral Teacher • Plate Exports (PNG, JSON)</span>
+    </a>
+    <a class="tile" href="../circuitum99/index.html">
+      <strong>Circuitum 99</strong>
+      <span class="cap">Cymatic Circuit Grid</span>
+    </a>
+    <a class="tile" href="../stone-grimoire/chapels/egregore-sky/index.html">
+      <strong>Egregore Sky</strong>
+      <span class="cap">Stone Grimoire Chapel Viewer</span>
+    </a>
+    <a class="tile" href="../openworld/index.html">
+      <strong>Ain Soph Grove</strong>
+      <span class="cap">Nature sanctuary weaving Hermetic, Thelemic, Kabalistic, Pagan &amp; Buddhist mythos of time</span>
     </a>
   </section>
 </body>

--- a/modules/rooms-atlas.html
+++ b/modules/rooms-atlas.html
@@ -1,40 +1,35 @@
 <!doctype html>
-<html>
-  <head>
-    <meta charset="utf-8" />
-    <title>Rooms Atlas</title>
-    <link rel="stylesheet" href="/assets/css/alchemy-plates.css" />
-  </head>
-  <body>
-    <div id="rooms"></div>
-    <script src="/assets/js/engines/progress-engine.js"></script>
-    <script src="/assets/js/engines/rooms-engine.js"></script>
-    <script src="/assets/js/engines/tesseract-bridge.js"></script>
-    <script src="/assets/js/engines/tesseract-hooks.js"></script>
-  </body>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>Rooms Atlas</title>
-  <link rel="stylesheet" href="../assets/css/alchemy-plates.css">
-</head>
-<body>
-  <main id="rooms-atlas"></main>
-  <section id="tesseract-stage" aria-label="Tesseract map"></section>
-  <script type="module" src="../assets/js/engines/rooms-engine.js"></script>
-  <script type="module" src="../assets/js/engines/tesseract-hooks.js"></script>
-  <script type="module" src="../assets/js/engines/tesseract-bridge.js"></script>
-</body>
-<html>
   <head>
     <meta charset="utf-8" />
     <title>Rooms Atlas</title>
-    <link rel="stylesheet" href="/assets/css/alchemy-plates.css" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      body{margin:0;background:#0b0b0b;color:#e6e6e6;font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Inter,sans-serif;}
+      .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:16px;padding:16px;}
+      .tile{background:#111;border:1px solid #262626;border-radius:12px;padding:14px;text-decoration:none;color:inherit;display:flex;flex-direction:column;gap:6px}
+      .tile:hover{border-color:#5e4ba8}
+      .cap{opacity:.75;font-size:14px}
+    </style>
   </head>
   <body>
-    <div id="rooms"></div>
-    <script src="/assets/js/engines/rooms-engine.js"></script>
-    <script src="/assets/js/engines/tesseract-bridge.js"></script>
-    <script src="/assets/js/engines/tesseract-hooks.js"></script>
+    <h1 style="padding:16px">Rooms Atlas</h1>
+    <main id="rooms-atlas" class="grid"></main>
+    <section id="tesseract-stage" aria-label="Tesseract map"></section>
+    <script type="module">
+      import { listRooms } from '../assets/js/engines/rooms-engine.js';
+
+      const mount = document.getElementById('rooms-atlas');
+      listRooms().forEach(room => {
+        const a = document.createElement('a');
+        a.className = 'tile';
+        a.href = room.href;
+        a.innerHTML = `<strong>${room.name}</strong><span class="cap">${room.description}</span>`;
+        mount.appendChild(a);
+      });
+    </script>
+    <script type="module" src="../assets/js/engines/tesseract-hooks.js"></script>
+    <script type="module" src="../assets/js/engines/tesseract-bridge.js"></script>
   </body>
 </html>
+

--- a/openworld/index.html
+++ b/openworld/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Ain Soph Grove</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    body{margin:0;background:#0b0b0b;color:#e6e6e6;font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Inter,sans-serif;padding:16px;}
+    .mandala{width:200px;height:200px;margin:0 auto;border-radius:50%;position:relative;background:conic-gradient(#5e4ba8,#e6e6e6 90deg,#5e4ba8 180deg,#e6e6e6 270deg,#5e4ba8 360deg);box-shadow:0 0 12px #5e4ba8,inset 0 0 8px #262626;}
+    .mandala::before,.mandala::after{content:"";position:absolute;top:50%;left:50%;width:90%;height:2px;background:#111;transform:translate(-50%,-50%);}
+    .mandala::after{transform:translate(-50%,-50%) rotate(90deg);}
+    .mandala span{position:absolute;top:50%;left:50%;width:90%;height:2px;background:#111;transform:translate(-50%,-50%) rotate(45deg);}
+    .mandala span.diag2{transform:translate(-50%,-50%) rotate(-45deg);}
+  </style>
+</head>
+<body>
+  <h1>Ain Soph Grove</h1>
+  <p>Open world sanctuary of animals, plants, and crystals. Aeons weave theosophic harmony, echoing the grimoires of Dr. Skinner.</p>
+  <p>Hermetic seals meet Thelemic will, Kabalistic sefirot, Pagan seasons, and the Buddhist wheel of time in the whispering leaves.</p>
+  <figure>
+    <div class="mandala"><span></span><span class="diag2"></span></div>
+    <figcaption>Mandala of time uniting alchemical, thelemic, sefirotic, pagan, and dharmic cycles.</figcaption>
+  </figure>
+</body>
+</html>

--- a/test/plugin-registry.test.js
+++ b/test/plugin-registry.test.js
@@ -1,14 +1,11 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { writeFileSync, rmSync, mkdirSync } from 'fs';
 import { writeFileSync, rmSync, mkdtempSync } from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
 import { load, getByType } from '../src/pluginRegistry.js';
 
 test('load registers plugins by type', async () => {
-  const fixturesDir = path.resolve('test/fixtures');
-  mkdirSync(fixturesDir, { recursive: true });
   // create isolated temp directory for plugin fixtures
   const fixturesDir = mkdtempSync(path.join(tmpdir(), 'plugin-test-'));
   const pluginFile = path.join(fixturesDir, 'testPlugin.js');


### PR DESCRIPTION
## Summary
- add Ain Soph Grove room with nature-themed placeholder page
- fix plugin registry test to avoid duplicate imports
- improve rooms atlas module variable naming
- infuse Ain Soph Grove with Hermetic, Thelemic, Kabalistic, Pagan, and Buddhist mythos of time
- render Ain Soph Grove mandala via CSS sacred geometry instead of SVG

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7e5c220ec8328864cc2cc85050026