### PR TITLE
Add Solfeggio harmony layers to IndraNet

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,19 @@ Cosmogenesis is a portable plate engine for your Cathedral of Circuits. It rende
 - **META export** with provenance (SHA-256 of config)
 - **Reduced-motion respect** (no wobble when OS requests it)
 
+### IndraNet Engine
+New in this release, the **IndraNet Engine** projects the Codex 144:99 lattice as a 12×12 holographic web. The shared
+`bridge.json` now ships an `indraNet` block so any app can load the 144 jewel nodes and 99 gate clusters and render its own
+network without coupling to this repo's UI. `harmony_map.json` extends the net with optional Soyga, Tarot, I Ching, Tree of
+Life, planetary and numerology rings colored by Solfeggio tones.
+
+```javascript
+import { IndraNet } from './app/engines/IndraNet.js';
+const net = new IndraNet();
+await net.load('/c99/bridge.json');
+net.mount(document.getElementById('viz')).render();
+```
+
 ## Quickstart
 ```bash
 npm i

--- a/app/engines/IndraNet.js
+++ b/app/engines/IndraNet.js
@@ -1,0 +1,166 @@
+/**
+ * ✦ Codex 144:99 — IndraNet Engine (holographic web)
+ * Simple SVG renderer that maps the Codex lattice as Indra's net.
+ * Works stand-alone in any app; load bridge.json for shared data.
+ */
+
+export class IndraNet {
+  constructor(config = {}) {
+    this.config = Object.assign(this.defaults(), config);
+    this.network = null;
+    this.svg = null;
+    this._container = null;
+  }
+
+  // default configuration
+  defaults() {
+    return {
+      radius: 420,
+      nodeSize: 8,
+      showLinks: true,
+      palette: { bg: '#000000', node: '#ffffff', link: '#888888' },
+      layers: {
+        soyga: true,
+        tarot: true,
+        iching: true,
+        tree: true,
+        planets: true,
+        numerology: true
+      }
+    };
+  }
+
+  // load indraNet data from bridge.json
+  async load(url, { path = 'indraNet' } = {}) {
+    const res = await fetch(url, { cache: 'no-store' });
+    const data = await res.json();
+    this.network = data[path] || data.indraNet || null;
+    return this;
+  }
+
+  // mount to a DOM container
+  mount(container) {
+    if (!container) throw new Error('IndraNet.mount: container is required');
+    this._container = container;
+    container.innerHTML = '';
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', '-512 -512 1024 1024');
+    svg.style.width = '100%';
+    svg.style.height = '100%';
+    svg.style.display = 'block';
+    svg.style.background = this.config.palette.bg;
+    this.svg = svg;
+    container.appendChild(svg);
+    return this;
+  }
+
+  // render nodes and links
+  render() {
+    if (!this.svg) throw new Error('IndraNet.render: call mount() first');
+    while (this.svg.firstChild) this.svg.removeChild(this.svg.firstChild);
+    const cfg = this.config;
+    const lattice = this.network?.lattice || { rings: 12, nodes_per_ring: 12 };
+    const rings = lattice.rings;
+    const perRing = lattice.nodes_per_ring;
+    const stepR = cfg.radius / rings;
+    const nodes = [];
+    for (let r = 0; r < rings; r++) {
+      const rad = stepR * (r + 1);
+      for (let i = 0; i < perRing; i++) {
+        const angle = (2 * Math.PI * i) / perRing;
+        const x = Math.cos(angle) * rad;
+        const y = Math.sin(angle) * rad;
+        const node = this._circle(x, y, cfg.nodeSize, { fill: cfg.palette.node });
+        this.svg.appendChild(node);
+        nodes.push({ x, y, ring: r, index: i });
+      }
+    }
+    if (cfg.showLinks) {
+      nodes.forEach(n => {
+        const ni = (n.index + 1) % perRing;
+        const neighbor = nodes.find(o => o.ring === n.ring && o.index === ni);
+        if (neighbor) this._link(n, neighbor, cfg.palette.link);
+        if (n.ring + 1 < rings) {
+          const radial = nodes.find(o => o.ring === n.ring + 1 && o.index === n.index);
+          if (radial) this._link(n, radial, cfg.palette.link);
+        }
+      });
+    }
+    if (this.network?.harmony) this._renderHarmony();
+    return this;
+  }
+
+  // helper to draw a circle
+  _circle(cx, cy, r, attrs = {}) {
+    const c = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+    c.setAttribute('cx', cx);
+    c.setAttribute('cy', cy);
+    c.setAttribute('r', r);
+    for (const k in attrs) c.setAttribute(k, attrs[k]);
+    return c;
+  }
+
+  // render correspondence layers
+  _renderHarmony() {
+    const h = this.network.harmony;
+    const cfg = this.config;
+    const categories = ['soyga','tarot','iching','tree','planets','numerology'];
+    const count = h.solfeggio?.length || 0;
+    const step = 40;
+    categories.forEach((cat, idx) => {
+      if (!cfg.layers[cat] || !h[cat]) return;
+      const radius = cfg.radius + (idx + 1) * step;
+      const items = h[cat];
+      for (let i = 0; i < count; i++) {
+        const angle = (2 * Math.PI * i) / count;
+        const x = Math.cos(angle) * radius;
+        const y = Math.sin(angle) * radius;
+        const label = items[i % items.length];
+        const freq = h.solfeggio[i % count];
+        const color = this._solfeggioColor(freq);
+        const dot = this._circle(x, y, 4, { fill: color });
+        this.svg.appendChild(dot);
+        const t = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+        t.setAttribute('x', x);
+        t.setAttribute('y', y - 6);
+        t.setAttribute('fill', color);
+        t.setAttribute('font-size', '10');
+        t.setAttribute('text-anchor', 'middle');
+        t.textContent = label;
+        this.svg.appendChild(t);
+      }
+    });
+  }
+
+  // map solfeggio frequency to color
+  _solfeggioColor(freq) {
+    const map = {
+      396: '#ff0000',
+      417: '#ff7f00',
+      528: '#ffff00',
+      639: '#00ff00',
+      741: '#0000ff',
+      852: '#4b0082',
+      963: '#ee82ee'
+    };
+    return map[freq] || '#ffffff';
+  }
+
+  // helper to draw a link
+  _link(a, b, color) {
+    const l = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+    l.setAttribute('x1', a.x);
+    l.setAttribute('y1', a.y);
+    l.setAttribute('x2', b.x);
+    l.setAttribute('y2', b.y);
+    l.setAttribute('stroke', color);
+    l.setAttribute('stroke-width', '1');
+    this.svg.appendChild(l);
+  }
+
+  // merge configuration changes
+  setConfig(next = {}) {
+    this.config = Object.assign({}, this.config, next);
+    return this;
+  }
+}

--- a/assets/data/harmony_map.json
+++ b/assets/data/harmony_map.json
@@ -1,0 +1,9 @@
+{
+  "soyga": ["A1", "B2", "C3", "D4"],
+  "tarot": ["Fool", "Magician", "High Priestess", "Empress"],
+  "iching": ["Qian", "Kun", "Zhen", "Xun"],
+  "tree": ["Kether", "Chokmah", "Binah", "Chesed"],
+  "planets": ["Sun", "Moon", "Mercury", "Venus"],
+  "numerology": ["1", "2", "3", "4"],
+  "solfeggio": [396, 417, 528, 639]
+}

--- a/assets/data/indra_net.144_99.json
+++ b/assets/data/indra_net.144_99.json
@@ -1,0 +1,13 @@
+{
+  "meta": {
+    "name": "Indra's Net",
+    "codex": "144:99",
+    "nd_safe": true
+  },
+  "lattice": {
+    "rings": 12,
+    "nodes_per_ring": 12,
+    "gates": 99
+  },
+  "description": "144 jewel nodes woven by 99 gate clusters; each node mirrors the whole."
+}

--- a/docs/INDRA_NET_PLAN.md
+++ b/docs/INDRA_NET_PLAN.md
@@ -1,0 +1,15 @@
+# ✦ Indra Net Plan — Codex 144:99 Holographic Web
+
+- **Purpose**: harmonize every app and node through a shared fractal lattice.
+- **Data**: `assets/data/indra_net.144_99.json` describes 12 rings × 12 nodes and 99 gate clusters.
+- **Bridge**: `tools/build-bridge.js` now exports the `indraNet` block into `/public/c99/bridge.json` so external apps can fetch it.
+- **Engine**: `app/engines/IndraNet.js` renders the lattice as SVG with optional links.
+- **Harmony layers**: `assets/data/harmony_map.json` bridges Soyga, Tarot, I Ching, Tree of Life, planets and numerology using Solfeggio color bands.
+- **Usage**:
+  ```javascript
+  import { IndraNet } from './app/engines/IndraNet.js';
+  const net = new IndraNet({ showLinks: true });
+  await net.load('/c99/bridge.json');
+  net.mount(document.getElementById('viz')).render();
+  ```
+- Each jewel node mirrors the whole codex, forming an akashic web across modules and servitors.

--- a/public/c99/bridge.json
+++ b/public/c99/bridge.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "project": "Cosmogenesis Learning Engine",
-    "updated": "2025-09-03T02:32:07.709Z",
+    "updated": "2025-09-03T08:39:58.786Z",
     "nd_safe": true
   },
   "routes": {
@@ -30,6 +30,63 @@
       "etz_chayyim": true,
       "theosophy": true,
       "violet_respawn_alias": true
+    }
+  },
+  "indraNet": {
+    "meta": {
+      "name": "Indra's Net",
+      "codex": "144:99",
+      "nd_safe": true
+    },
+    "lattice": {
+      "rings": 12,
+      "nodes_per_ring": 12,
+      "gates": 99
+    },
+    "description": "144 jewel nodes woven by 99 gate clusters; each node mirrors the whole.",
+    "harmony": {
+      "soyga": [
+        "A1",
+        "B2",
+        "C3",
+        "D4"
+      ],
+      "tarot": [
+        "Fool",
+        "Magician",
+        "High Priestess",
+        "Empress"
+      ],
+      "iching": [
+        "Qian",
+        "Kun",
+        "Zhen",
+        "Xun"
+      ],
+      "tree": [
+        "Kether",
+        "Chokmah",
+        "Binah",
+        "Chesed"
+      ],
+      "planets": [
+        "Sun",
+        "Moon",
+        "Mercury",
+        "Venus"
+      ],
+      "numerology": [
+        "1",
+        "2",
+        "3",
+        "4"
+      ],
+      "solfeggio": [
+        396,
+        417,
+        528,
+        639
+      ]
     }
   },
   "witch": {

--- a/test/plugin-registry.test.js
+++ b/test/plugin-registry.test.js
@@ -1,34 +1,12 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { writeFileSync, rmSync, mkdirSync } from 'fs';
 import { writeFileSync, rmSync, mkdtempSync } from 'fs';
 import { tmpdir } from 'os';
-import { writeFileSync, rmSync, mkdtempSync } from 'fs';
-import { tmpdir } from 'os';
-import { writeFileSync, rmSync, mkdirSync } from 'fs';
-import { writeFileSync, rmSync, mkdtempSync } from 'fs';
-import { tmpdir } from 'os';
-import { writeFileSync, rmSync, mkdtempSync } from 'fs';
-import { tmpdir } from 'os';
-import { writeFileSync, rmSync, mkdirSync } from 'fs';
 import path from 'path';
 import { load, getByType } from '../src/pluginRegistry.js';
 
 test('load registers plugins by type', async () => {
-  const fixturesDir = path.resolve('test/fixtures');
-  mkdirSync(fixturesDir, { recursive: true });
-  // create isolated temp directory for plugin fixtures
   const fixturesDir = mkdtempSync(path.join(tmpdir(), 'plugin-test-'));
-  // create isolated temp directory for plugin fixtures
-  const fixturesDir = mkdtempSync(path.join(tmpdir(), 'plugin-test-'));
-  const fixturesDir = path.resolve('test/fixtures');
-  mkdirSync(fixturesDir, { recursive: true });
-  // create isolated temp directory for plugin fixtures
-  const fixturesDir = mkdtempSync(path.join(tmpdir(), 'plugin-test-'));
-  // create isolated temp directory for plugin fixtures
-  const fixturesDir = mkdtempSync(path.join(tmpdir(), 'plugin-test-'));
-  const fixturesDir = path.resolve('test/fixtures');
-  mkdirSync(fixturesDir, { recursive: true });
   const pluginFile = path.join(fixturesDir, 'testPlugin.js');
   writeFileSync(pluginFile, 'export default { id: "testPlugin", activate(){} };');
   const descFile = path.join(fixturesDir, 'plugins.json');
@@ -39,6 +17,5 @@ test('load registers plugins by type', async () => {
   const layouts = getByType('layout');
   assert.equal(layouts.length, 1);
 
-  // clean up temporary fixtures directory
   rmSync(fixturesDir, { recursive: true, force: true });
 });

--- a/tools/build-bridge.js
+++ b/tools/build-bridge.js
@@ -8,6 +8,8 @@ const data=p=>path.join(root,'assets','data',p);
 const outDir=path.join(root,'public','c99'); fs.mkdirSync(outDir,{recursive:true});
 const read=p=>{try{return JSON.parse(fs.readFileSync(p,'utf8'))}catch{return null}};
 const codex=read(data('codex.144_99.json'))||{};
+const indra=read(data('indra_net.144_99.json'))||{};
+const harmony=read(data('harmony_map.json'))||{};
 const witch=read(data('profiles/default.witch.json'))||{};
 const coven=read(data('covens/default.coven.json'))||{};
 const pack=read(data('packs/sample-world.pack.json'))||{};
@@ -16,7 +18,7 @@ const cssPath=path.join(outDir,'css','perm-style.css');
 const manifest={
 meta:{project:"Cosmogenesis Learning Engine", updated:new Date().toISOString(), nd_safe:true},
 routes:{ tokens:"/c99/tokens/perm-style.json", css:"/c99/css/perm-style.css" },
-codex, witch, coven, pack,
+codex, indraNet: Object.assign(indra,{ harmony }), witch, coven, pack,
 style:{ tokens: fs.existsSync(tokensPath)?"/c99/tokens/perm-style.json":"", css: fs.existsSync(cssPath)?"/c99/css/perm-style.css":"" }
 };
 fs.writeFileSync(path.join(outDir,'bridge.json'), JSON.stringify(manifest,null,2));


### PR DESCRIPTION
## Summary
- map Soyga, Tarot, I Ching, Tree of Life, planets and numerology through new `harmony_map.json`
- extend IndraNet engine with optional correspondence rings colored by Solfeggio tones
- expose harmony data via bridge build script and docs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7ea49cd3c8328826a17f30398b00e