### PR TITLE
Add Enochian and celestial overlays to HTML fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ npm i
 npm run dev     # serves at http://localhost:5173
 # open /cosmogenesis/index.html
 npm test        # node --test
+
+# Visionary Dream fallback
+When Python isn't available, open `visionary_dream.html` in a browser to render the Enochian grid and planetary sigils via p5.js.
 ```
 
 # User-provided custom instructions

--- a/visionary_dream.html
+++ b/visionary_dream.html
@@ -12,6 +12,29 @@
 const palette = ['#0a2fff','#ff00ff','#00f2c7','#ffb300','#a200ff'];
 let angle = 0, sculptureMode = 0;
 
+// === Planetary symbols and angelic counterparts ===
+const planetarySigils = [
+  {symbol:'\u2609', angel:'Michael'},  // Sun
+  {symbol:'\u263D', angel:'Gabriel'},  // Moon
+  {symbol:'\u263F', angel:'Raphael'},  // Mercury
+  {symbol:'\u2640', angel:'Anael'},    // Venus
+  {symbol:'\u2642', angel:'Samael'},   // Mars
+  {symbol:'\u2643', angel:'Zadkiel'},  // Jupiter
+  {symbol:'\u2644', angel:'Cassiel'},  // Saturn
+];
+
+// === Character names encircling the work ===
+const characters = [
+  'Rebecca Respawn',
+  'Virelai',
+  'Ezra Lux',
+  'Athena (Sophia7)',
+  'Thoth (Gnosis7)'
+];
+
+// === Enochian unicode letters ===
+const enochianLetters = Array.from({length:16}, (_,i)=>String.fromCodePoint(0x1F700+i));
+
 function setup() {
   // --- Full-HD 3D canvas ---
   createCanvas(1920,1080,WEBGL);
@@ -47,12 +70,84 @@ function draw() {
     pop();
   }
   angle += 0.01;
+
+  // --- Mystical overlays (2D) ---
+  hint(DISABLE_DEPTH_TEST);
+  drawEnochianGrid();
+  drawCelestialSigils();
+  labelCharacters();
+  hint(ENABLE_DEPTH_TEST);
 }
 
 // --- Switch modes & save visionary still ---
 function keyPressed(){
   if(key==='s'||key==='S') saveCanvas('Visionary_Dream','png');
   if(key==='f'||key==='F') sculptureMode = (sculptureMode+1)%3;
+}
+
+// === Overlay: translucent Enochian magic square ===
+function drawEnochianGrid(){
+  push();
+  resetMatrix();
+  translate(width/2,height/2);
+  const gridSize = Math.min(width,height)*0.6;
+  const cell = gridSize/4;
+  stroke(255,255,255,40);
+  noFill();
+  for(let i=0;i<=4;i++){
+    line(-gridSize/2 + i*cell, -gridSize/2, -gridSize/2 + i*cell, gridSize/2);
+    line(-gridSize/2, -gridSize/2 + i*cell, gridSize/2, -gridSize/2 + i*cell);
+  }
+  textAlign(CENTER,CENTER);
+  textSize(cell*0.5);
+  fill(255,255,255,60);
+  let idx=0;
+  for(let r=0;r<4;r++){
+    for(let c=0;c<4;c++){
+      text(enochianLetters[idx++], -gridSize/2 + c*cell + cell/2, -gridSize/2 + r*cell + cell/2);
+    }
+  }
+  pop();
+}
+
+// === Overlay: planetary sigils & angels ===
+function drawCelestialSigils(){
+  push();
+  resetMatrix();
+  translate(width/2,height/2);
+  textAlign(CENTER,CENTER);
+  const radius = Math.min(width,height)*0.25;
+  planetarySigils.forEach((p,i)=>{
+    const ang = TWO_PI * i / planetarySigils.length - HALF_PI;
+    const sx = Math.cos(ang) * radius;
+    const sy = Math.sin(ang) * radius;
+    fill(255);
+    textSize(80);
+    text(p.symbol, sx, sy);
+    const ax = Math.cos(ang) * (radius + 70);
+    const ay = Math.sin(ang) * (radius + 70);
+    textSize(24);
+    text(p.angel, ax, ay);
+  });
+  pop();
+}
+
+// === Overlay: character labels ===
+function labelCharacters(){
+  push();
+  resetMatrix();
+  translate(width/2,height/2);
+  textAlign(CENTER,CENTER);
+  textSize(16);
+  fill(255);
+  const radius = Math.min(width,height)*0.35;
+  characters.forEach((name,i)=>{
+    const ang = TWO_PI * i / characters.length;
+    const x = Math.cos(ang)*radius;
+    const y = Math.sin(ang)*radius;
+    text(name, x, y);
+  });
+  pop();
 }
 </script>
 </body>

--- a/visionary_dream.py
+++ b/visionary_dream.py
@@ -14,9 +14,21 @@ from __future__ import annotations
 from pathlib import Path
 import argparse
 import math
-from typing import List
+from typing import List, Tuple
 
 from PIL import Image, ImageDraw, ImageColor, ImageFont
+
+
+# Planetary symbols and their angelic counterparts ---------------------------
+PLANETARY_SIGILS: List[Tuple[str, str]] = [
+    ("\u2609", "Michael"),  # Sun
+    ("\u263D", "Gabriel"),  # Moon
+    ("\u263F", "Raphael"),  # Mercury
+    ("\u2640", "Anael"),    # Venus
+    ("\u2642", "Samael"),   # Mars
+    ("\u2643", "Zadkiel"),  # Jupiter
+    ("\u2644", "Cassiel"),  # Saturn
+]
 
 
 # Color palette inspired by Alex Grey ---------------------------------------
@@ -62,6 +74,75 @@ def draw_spiral(draw: ImageDraw.ImageDraw, width: int, height: int) -> None:
         draw.line([(cx, cy), (x, y)], fill=color, width=3)
 
 
+def draw_enochian_grid(draw: ImageDraw.ImageDraw, width: int, height: int) -> None:
+    """Overlay a translucent Enochian magic square."""
+
+    grid_size = min(width, height) * 0.6
+    cx, cy = width / 2, height / 2
+    top_left = (cx - grid_size / 2, cy - grid_size / 2)
+    cell = grid_size / 4
+    grid_color = hex_to_rgba("#FFFFFF", 40)
+
+    # Draw 4x4 grid
+    for i in range(5):
+        x = top_left[0] + i * cell
+        y = top_left[1] + i * cell
+        draw.line([(x, top_left[1]), (x, top_left[1] + grid_size)], fill=grid_color, width=2)
+        draw.line([(top_left[0], y), (top_left[0] + grid_size, y)], fill=grid_color, width=2)
+
+    # Populate with Enochian letters (Unicode range U+1F700)
+    try:
+        font = ImageFont.truetype("DejaVuSans.ttf", int(cell * 0.5))
+    except OSError:
+        font = ImageFont.load_default()
+
+    letters = [chr(cp) for cp in range(0x1F700, 0x1F700 + 16)]
+    idx = 0
+    for row in range(4):
+        for col in range(4):
+            x = top_left[0] + col * cell + cell / 2
+            y = top_left[1] + row * cell + cell / 2
+            glyph = letters[idx % len(letters)]
+            bbox = draw.textbbox((0, 0), glyph, font=font)
+            w = bbox[2] - bbox[0]
+            h = bbox[3] - bbox[1]
+            draw.text((x - w / 2, y - h / 2), glyph, fill=grid_color, font=font)
+            idx += 1
+
+
+def draw_celestial_sigils(draw: ImageDraw.ImageDraw, width: int, height: int) -> None:
+    """Draw planetary symbols with their angelic counterparts."""
+
+    try:
+        planet_font = ImageFont.truetype("DejaVuSans.ttf", 80)
+        angel_font = ImageFont.truetype("DejaVuSans.ttf", 32)
+    except OSError:
+        planet_font = ImageFont.load_default()
+        angel_font = ImageFont.load_default()
+
+    cx, cy = width / 2, height / 2
+    radius = min(cx, cy) * 0.65
+
+    for idx, (symbol, angel) in enumerate(PLANETARY_SIGILS):
+        angle = (idx / len(PLANETARY_SIGILS)) * 2 * math.pi - math.pi / 2
+        sx = cx + math.cos(angle) * radius
+        sy = cy + math.sin(angle) * radius
+
+        # Draw planetary symbol
+        bbox = draw.textbbox((0, 0), symbol, font=planet_font)
+        w = bbox[2] - bbox[0]
+        h = bbox[3] - bbox[1]
+        draw.text((sx - w / 2, sy - h / 2), symbol, fill="white", font=planet_font)
+
+        # Label with angelic name slightly outward
+        ax = cx + math.cos(angle) * (radius + h)
+        ay = cy + math.sin(angle) * (radius + h)
+        bbox = draw.textbbox((0, 0), angel, font=angel_font)
+        w = bbox[2] - bbox[0]
+        h = bbox[3] - bbox[1]
+        draw.text((ax - w / 2, ay - h / 2), angel, fill="white", font=angel_font)
+
+
 def label_characters(draw: ImageDraw.ImageDraw, width: int, height: int) -> None:
     """Place character names around the spiral."""
 
@@ -93,7 +174,14 @@ def generate_art(width: int, height: int) -> Image.Image:
     image = Image.new("RGBA", (width, height), "black")
     draw = ImageDraw.Draw(image, "RGBA")
 
+    # Core spiral
     draw_spiral(draw, width, height)
+
+    # Mystical overlays
+    draw_enochian_grid(draw, width, height)
+    draw_celestial_sigils(draw, width, height)
+
+    # Character labels
     label_characters(draw, width, height)
 
     return image
@@ -108,13 +196,13 @@ def main() -> None:
     )
     parser.add_argument("--width", type=int, default=2048, help="image width")
     parser.add_argument("--height", type=int, default=2048, help="image height")
+    parser.add_argument("--output", type=Path, default=Path("Visionary_Dream.png"), help="output image path")
     args = parser.parse_args()
 
     art = generate_art(args.width, args.height)
 
-    output = Path("Visionary_Dream.png")
-    art.save(output)
-    print(f"Art saved to {output.resolve()}")
+    art.save(args.output)
+    print(f"Art saved to {args.output.resolve()}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend `visionary_dream.html` with planetary sigils, angel labels, Enochian grid, and character names
- document HTML fallback when Python is unavailable for tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b801c8228883289f7063e84c5094d1