### PR TITLE
Share Enochian overlays across Python art generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ npm run dev     # serves at http://localhost:5173
 npm test        # node --test
 ```
 
+When Python isn't available, open `visionary_dream.html` in a browser to render the Enochian grid and planetary sigils via p5.js.
+
+### Shared Python overlays
+All Python art generators now reuse a common `enochian_layers` module that draws the Enochian grid and planetary sigils so mystical features stay consistent across scripts. This includes `visionary_dream.py`, `visionary_golden_geometry.py`, and `visionary_codex.py`.
+
 # User-provided custom instructions
 
 Codex-style” prompt template for visionary art

--- a/enochian_layers.py
+++ b/enochian_layers.py
@@ -1,0 +1,95 @@
+"""Reusable Enochian grid and planetary sigil overlays."""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+from PIL import ImageDraw, ImageFont, ImageColor
+import math
+
+# Planetary symbols and their angelic counterparts
+PLANETARY_SIGILS: List[Tuple[str, str]] = [
+    ("\u2609", "Michael"),  # Sun
+    ("\u263D", "Gabriel"),  # Moon
+    ("\u263F", "Raphael"),  # Mercury
+    ("\u2640", "Anael"),    # Venus
+    ("\u2642", "Samael"),   # Mars
+    ("\u2643", "Zadkiel"),  # Jupiter
+    ("\u2644", "Cassiel"),  # Saturn
+]
+
+
+def hex_to_rgba(color: str, alpha: int = 255) -> tuple[int, int, int, int]:
+    """Convert a hex color to an RGBA tuple."""
+
+    r, g, b = ImageColor.getrgb(color)
+    return (r, g, b, alpha)
+
+
+def draw_enochian_grid(draw: ImageDraw.ImageDraw, width: int, height: int) -> None:
+    """Overlay a translucent Enochian magic square."""
+
+    grid_size = min(width, height) * 0.6
+    cx, cy = width / 2, height / 2
+    top_left = (cx - grid_size / 2, cy - grid_size / 2)
+    cell = grid_size / 4
+    grid_color = hex_to_rgba("#FFFFFF", 40)
+
+    # Draw 4x4 grid
+    for i in range(5):
+        x = top_left[0] + i * cell
+        y = top_left[1] + i * cell
+        draw.line([(x, top_left[1]), (x, top_left[1] + grid_size)], fill=grid_color, width=2)
+        draw.line([(top_left[0], y), (top_left[0] + grid_size, y)], fill=grid_color, width=2)
+
+    # Populate with Enochian letters (Unicode range U+1F700)
+    try:
+        font = ImageFont.truetype("DejaVuSans.ttf", int(cell * 0.5))
+    except OSError:
+        font = ImageFont.load_default()
+
+    letters = [chr(cp) for cp in range(0x1F700, 0x1F700 + 16)]
+    idx = 0
+    for row in range(4):
+        for col in range(4):
+            x = top_left[0] + col * cell + cell / 2
+            y = top_left[1] + row * cell + cell / 2
+            glyph = letters[idx % len(letters)]
+            bbox = draw.textbbox((0, 0), glyph, font=font)
+            w = bbox[2] - bbox[0]
+            h = bbox[3] - bbox[1]
+            draw.text((x - w / 2, y - h / 2), glyph, fill=grid_color, font=font)
+            idx += 1
+
+
+def draw_celestial_sigils(draw: ImageDraw.ImageDraw, width: int, height: int) -> None:
+    """Draw planetary symbols with their angelic counterparts."""
+
+    try:
+        planet_font = ImageFont.truetype("DejaVuSans.ttf", 80)
+        angel_font = ImageFont.truetype("DejaVuSans.ttf", 32)
+    except OSError:
+        planet_font = ImageFont.load_default()
+        angel_font = ImageFont.load_default()
+
+    cx, cy = width / 2, height / 2
+    radius = min(cx, cy) * 0.65
+
+    for idx, (symbol, angel) in enumerate(PLANETARY_SIGILS):
+        angle = (idx / len(PLANETARY_SIGILS)) * 2 * math.pi - math.pi / 2
+        sx = cx + math.cos(angle) * radius
+        sy = cy + math.sin(angle) * radius
+
+        # Draw planetary symbol
+        bbox = draw.textbbox((0, 0), symbol, font=planet_font)
+        w = bbox[2] - bbox[0]
+        h = bbox[3] - bbox[1]
+        draw.text((sx - w / 2, sy - h / 2), symbol, fill="white", font=planet_font)
+
+        # Label with angelic name slightly outward
+        ax = cx + math.cos(angle) * (radius + h)
+        ay = cy + math.sin(angle) * (radius + h)
+        bbox = draw.textbbox((0, 0), angel, font=angel_font)
+        w = bbox[2] - bbox[0]
+        h = bbox[3] - bbox[1]
+        draw.text((ax - w / 2, ay - h / 2), angel, fill="white", font=angel_font)
+

--- a/visionary_codex.py
+++ b/visionary_codex.py
@@ -1,19 +1,19 @@
-"""Visionary Codex: museum-quality kaleidoscopic mandala."""
+"""Visionary Codex: museum-quality kaleidoscopic mandala with Enochian overlays."""
 
-# — Imports and sacred setup —
+from __future__ import annotations
+
+import argparse
 import math
 import random
 from pathlib import Path
+from typing import List
 
-from PIL import Image, ImageDraw
+from PIL import Image, ImageDraw, ImageColor
 
-# — Canvas dimensions and center —
-WIDTH, HEIGHT = 1920, 1080
-CENTER = (WIDTH // 2, HEIGHT // 2)
-MAX_RADIUS = min(CENTER)
+from enochian_layers import draw_enochian_grid, draw_celestial_sigils
 
-# — Color palette inspired by Alex Grey —
-PALETTE = [
+# Color palette inspired by Alex Grey
+PALETTE: List[str] = [
     "#280050",  # Deep Indigo
     "#460082",  # Electric Violet
     "#0080FF",  # Luminous Blue
@@ -24,54 +24,84 @@ PALETTE = [
     "#FFD700",  # Alchemical Gold
 ]
 
-# — Seed the randomness for repeatable dreams —
-random.seed(108)
 
-# — Birth the canvas with a vertical gradient —
-image = Image.new("RGB", (WIDTH, HEIGHT), PALETTE[0])
-draw = ImageDraw.Draw(image)
-for y in range(HEIGHT):
-    ratio = y / HEIGHT
+def generate_art(width: int, height: int) -> Image.Image:
+    """Render the codex mandala and return the image."""
+
+    random.seed(108)
+    image = Image.new("RGBA", (width, height), PALETTE[0])
+    draw = ImageDraw.Draw(image, "RGBA")
+
+    # Vertical gradient background
     top = (40, 0, 80)
     bottom = (255, 200, 255)
-    r = int(top[0] * (1 - ratio) + bottom[0] * ratio)
-    g = int(top[1] * (1 - ratio) + bottom[1] * ratio)
-    b = int(top[2] * (1 - ratio) + bottom[2] * ratio)
-    draw.line([(0, y), (WIDTH, y)], fill=(r, g, b))
+    for y in range(height):
+        ratio = y / height
+        r = int(top[0] * (1 - ratio) + bottom[0] * ratio)
+        g = int(top[1] * (1 - ratio) + bottom[1] * ratio)
+        b = int(top[2] * (1 - ratio) + bottom[2] * ratio)
+        draw.line([(0, y), (width, y)], fill=(r, g, b))
 
-# — Radiate spiral constellations —
-for step in range(720):
-    angle = math.radians(step * 5)
-    radius = (step / 720) * MAX_RADIUS
-    x = CENTER[0] + radius * math.cos(angle)
-    y = CENTER[1] + radius * math.sin(angle)
-    color = random.choice(PALETTE)
-    draw.ellipse([x - 3, y - 3, x + 3, y + 3], fill=color)
+    cx, cy = width / 2, height / 2
+    max_radius = min(cx, cy)
 
-# — Enfold concentric auric rings —
-for r in range(80, MAX_RADIUS, 100):
-    bbox = [CENTER[0] - r, CENTER[1] - r, CENTER[0] + r, CENTER[1] + r]
-    draw.ellipse(bbox, outline=random.choice(PALETTE), width=4)
+    # Radiate spiral constellations
+    for step in range(720):
+        angle = math.radians(step * 5)
+        radius = (step / 720) * max_radius
+        x = cx + radius * math.cos(angle)
+        y = cy + radius * math.sin(angle)
+        color = ImageColor.getrgb(random.choice(PALETTE)) + (255,)
+        draw.ellipse([x - 3, y - 3, x + 3, y + 3], fill=color)
 
-# — Imprint sacred star polygons —
-for sides in range(5, 10):
-    radius = MAX_RADIUS * (sides / 12)
-    points = []
-    for i in range(sides * 2):
-        angle = (math.pi * 2 / (sides * 2)) * i
-        rad = radius if i % 2 == 0 else radius * 0.4
-        x = CENTER[0] + rad * math.cos(angle)
-        y = CENTER[1] + rad * math.sin(angle)
-        points.append((x, y))
-    draw.polygon(points, outline=random.choice(PALETTE), width=2)
+    # Enfold concentric auric rings
+    for r in range(80, int(max_radius), 100):
+        bbox = [cx - r, cy - r, cx + r, cy + r]
+        draw.ellipse(bbox, outline=random.choice(PALETTE), width=4)
 
-# — Cast cross-quarter light beams —
-for axis in range(8):
-    angle = math.pi / 4 * axis
-    x = CENTER[0] + MAX_RADIUS * math.cos(angle)
-    y = CENTER[1] + MAX_RADIUS * math.sin(angle)
-    draw.line([CENTER, (x, y)], fill=random.choice(PALETTE), width=3)
+    # Imprint sacred star polygons
+    for sides in range(5, 10):
+        radius = max_radius * (sides / 12)
+        points: List[tuple[float, float]] = []
+        for i in range(sides * 2):
+            angle = (math.pi * 2 / (sides * 2)) * i
+            rad = radius if i % 2 == 0 else radius * 0.4
+            x = cx + rad * math.cos(angle)
+            y = cy + rad * math.sin(angle)
+            points.append((x, y))
+        draw.polygon(points, outline=random.choice(PALETTE), width=2)
 
-# — Save the visionary dream —
-image.save(Path("Visionary_Dream.png"))
+    # Cast cross-quarter light beams
+    for axis in range(8):
+        angle = math.pi / 4 * axis
+        x = cx + max_radius * math.cos(angle)
+        y = cy + max_radius * math.sin(angle)
+        draw.line([(cx, cy), (x, y)], fill=random.choice(PALETTE), width=3)
 
+    # Mystical overlays
+    draw_enochian_grid(draw, width, height)
+    draw_celestial_sigils(draw, width, height)
+
+    return image
+
+
+def main() -> None:
+    """CLI entry point for rendering the codex art."""
+
+    parser = argparse.ArgumentParser(
+        description="Render Codex 144:99 mandala with Enochian overlays."
+    )
+    parser.add_argument("--width", type=int, default=1920, help="image width")
+    parser.add_argument("--height", type=int, default=1080, help="image height")
+    parser.add_argument(
+        "--output", type=Path, default=Path("Visionary_Dream.png"), help="output image path"
+    )
+    args = parser.parse_args()
+
+    art = generate_art(args.width, args.height)
+    art.save(args.output)
+    print(f"Art saved to {args.output.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/visionary_dream.html
+++ b/visionary_dream.html
@@ -12,6 +12,29 @@
 const palette = ['#0a2fff','#ff00ff','#00f2c7','#ffb300','#a200ff'];
 let angle = 0, sculptureMode = 0;
 
+// === Planetary symbols and angelic counterparts ===
+const planetarySigils = [
+  {symbol:'\u2609', angel:'Michael'},  // Sun
+  {symbol:'\u263D', angel:'Gabriel'},  // Moon
+  {symbol:'\u263F', angel:'Raphael'},  // Mercury
+  {symbol:'\u2640', angel:'Anael'},    // Venus
+  {symbol:'\u2642', angel:'Samael'},   // Mars
+  {symbol:'\u2643', angel:'Zadkiel'},  // Jupiter
+  {symbol:'\u2644', angel:'Cassiel'},  // Saturn
+];
+
+// === Character names encircling the work ===
+const characters = [
+  'Rebecca Respawn',
+  'Virelai',
+  'Ezra Lux',
+  'Athena (Sophia7)',
+  'Thoth (Gnosis7)'
+];
+
+// === Enochian unicode letters ===
+const enochianLetters = Array.from({length:16}, (_,i)=>String.fromCodePoint(0x1F700+i));
+
 function setup() {
   // --- Full-HD 3D canvas ---
   createCanvas(1920,1080,WEBGL);
@@ -47,12 +70,84 @@ function draw() {
     pop();
   }
   angle += 0.01;
+
+  // --- Mystical overlays (2D) ---
+  hint(DISABLE_DEPTH_TEST);
+  drawEnochianGrid();
+  drawCelestialSigils();
+  labelCharacters();
+  hint(ENABLE_DEPTH_TEST);
 }
 
 // --- Switch modes & save visionary still ---
 function keyPressed(){
   if(key==='s'||key==='S') saveCanvas('Visionary_Dream','png');
   if(key==='f'||key==='F') sculptureMode = (sculptureMode+1)%3;
+}
+
+// === Overlay: translucent Enochian magic square ===
+function drawEnochianGrid(){
+  push();
+  resetMatrix();
+  translate(width/2,height/2);
+  const gridSize = Math.min(width,height)*0.6;
+  const cell = gridSize/4;
+  stroke(255,255,255,40);
+  noFill();
+  for(let i=0;i<=4;i++){
+    line(-gridSize/2 + i*cell, -gridSize/2, -gridSize/2 + i*cell, gridSize/2);
+    line(-gridSize/2, -gridSize/2 + i*cell, gridSize/2, -gridSize/2 + i*cell);
+  }
+  textAlign(CENTER,CENTER);
+  textSize(cell*0.5);
+  fill(255,255,255,60);
+  let idx=0;
+  for(let r=0;r<4;r++){
+    for(let c=0;c<4;c++){
+      text(enochianLetters[idx++], -gridSize/2 + c*cell + cell/2, -gridSize/2 + r*cell + cell/2);
+    }
+  }
+  pop();
+}
+
+// === Overlay: planetary sigils & angels ===
+function drawCelestialSigils(){
+  push();
+  resetMatrix();
+  translate(width/2,height/2);
+  textAlign(CENTER,CENTER);
+  const radius = Math.min(width,height)*0.25;
+  planetarySigils.forEach((p,i)=>{
+    const ang = TWO_PI * i / planetarySigils.length - HALF_PI;
+    const sx = Math.cos(ang) * radius;
+    const sy = Math.sin(ang) * radius;
+    fill(255);
+    textSize(80);
+    text(p.symbol, sx, sy);
+    const ax = Math.cos(ang) * (radius + 70);
+    const ay = Math.sin(ang) * (radius + 70);
+    textSize(24);
+    text(p.angel, ax, ay);
+  });
+  pop();
+}
+
+// === Overlay: character labels ===
+function labelCharacters(){
+  push();
+  resetMatrix();
+  translate(width/2,height/2);
+  textAlign(CENTER,CENTER);
+  textSize(16);
+  fill(255);
+  const radius = Math.min(width,height)*0.35;
+  characters.forEach((name,i)=>{
+    const ang = TWO_PI * i / characters.length;
+    const x = Math.cos(ang)*radius;
+    const y = Math.sin(ang)*radius;
+    text(name, x, y);
+  });
+  pop();
 }
 </script>
 </body>

--- a/visionary_dream.py
+++ b/visionary_dream.py
@@ -18,6 +18,8 @@ from typing import List
 
 from PIL import Image, ImageDraw, ImageColor, ImageFont
 
+from enochian_layers import draw_enochian_grid, draw_celestial_sigils
+
 
 # Color palette inspired by Alex Grey ---------------------------------------
 PALETTE: List[str] = [
@@ -93,7 +95,14 @@ def generate_art(width: int, height: int) -> Image.Image:
     image = Image.new("RGBA", (width, height), "black")
     draw = ImageDraw.Draw(image, "RGBA")
 
+    # Core spiral
     draw_spiral(draw, width, height)
+
+    # Mystical overlays
+    draw_enochian_grid(draw, width, height)
+    draw_celestial_sigils(draw, width, height)
+
+    # Character labels
     label_characters(draw, width, height)
 
     return image
@@ -108,13 +117,13 @@ def main() -> None:
     )
     parser.add_argument("--width", type=int, default=2048, help="image width")
     parser.add_argument("--height", type=int, default=2048, help="image height")
+    parser.add_argument("--output", type=Path, default=Path("Visionary_Dream.png"), help="output image path")
     args = parser.parse_args()
 
     art = generate_art(args.width, args.height)
 
-    output = Path("Visionary_Dream.png")
-    art.save(output)
-    print(f"Art saved to {output.resolve()}")
+    art.save(args.output)
+    print(f"Art saved to {args.output.resolve()}")
 
 
 if __name__ == "__main__":

--- a/visionary_golden_geometry.py
+++ b/visionary_golden_geometry.py
@@ -10,6 +10,8 @@ import math
 from pathlib import Path
 from PIL import Image, ImageDraw, ImageColor
 
+from enochian_layers import draw_enochian_grid, draw_celestial_sigils
+
 # Color palette inspired by visionary artists
 PALETTE = {
     "background": "#0e0d0d",
@@ -109,6 +111,10 @@ def draw_elemental_glyphs(draw: ImageDraw.ImageDraw, center: tuple[int, int], si
             (earth_center[0] - half, earth_center[1] + half),
             (earth_center[0] + half, earth_center[1] + half),
         ],
+        fill=PALETTE["earth"],
+        width=3,
+    )
+
     # Earth – square with a cross
     left = center[0] - size
     top = center[1] - half
@@ -152,6 +158,10 @@ def main() -> None:
     draw_golden_spiral(draw, center, PALETTE["spiral"])
     glyph_size = int(min(args.width, args.height) / (PHI * 3))
     draw_elemental_glyphs(draw, center, glyph_size)
+
+    # Mystical overlays reused across Python generators
+    draw_enochian_grid(draw, args.width, args.height)
+    draw_celestial_sigils(draw, args.width, args.height)
 
     img.save(args.output)
     print(f"Artwork saved to {Path(args.output).resolve()}")


### PR DESCRIPTION
## Summary
- extract Enochian grid and planetary sigil rendering into reusable `enochian_layers` module
- update `visionary_dream.py` and `visionary_golden_geometry.py` to apply the shared overlays
- document the new shared module in the README
- extend `visionary_codex.py` to render the shared Enochian grid and sigils, connecting Codex 144:99 to the living grid

## Testing
- `pytest`
- `python visionary_dream.py --width 512 --height 512 --output Visionary_Dream_test.png`
- `python visionary_golden_geometry.py --width 512 --height 512 --output Golden_test.png`
- `python visionary_codex.py --width 512 --height 512 --output Visionary_Codex_test.png`


------
https://chatgpt.com/codex/tasks/task_e_68b801c8228883289f7063e84c5094d1