### PR TITLE
feat: lock codex configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "npm run dev",
     "preview": "http-server -p 8080 -c-1 .",
     "build": "echo \"Static app -- no bundling required. Use 'Export SVG/PNG' in-app.\"",
-    "test": "node --test test/plugin-registry.test.js test/progress-engine.test.js",
+    "test": "node --test test/codexConfig.test.js test/plugin-registry.test.js test/progress-engine.test.js",
     "fmt": "prettier -w .",
     "check": "prettier -c .",
     "generate:flame": "python3 scripts/generate_flame.py --out assets/flame/flame.png",
@@ -34,4 +34,3 @@
     "prettier": "^3.3.3"
   }
 }
-

--- a/src/codex.ext.js
+++ b/src/codex.ext.js
@@ -1,13 +1,7 @@
-let stylepacks = [];
-let angels = [];
-let angels72 = [];
-let egregores = [];
-let egregoresCore = [];
-let tarotMajors = [];
-let spiralMap = [];
+import { cfg, initCodex } from './codexConfig.js';
 
 async function load() {
-  const [sp, an, an72, eg, egc, tm, sm] = await Promise.all([
+  const [stylepacks, angels, angels72, egregores, egregoresCore, tarotMajors, spiralMap] = await Promise.all([
     fetch('./data/stylepacks/stylepacks.json').then(r => r.json()),
     fetch('./data/angels.json').then(r => r.json()),
     fetch('./data/angels.72.json').then(r => r.json()),
@@ -16,13 +10,18 @@ async function load() {
     fetch('./data/tarot.majors.json').then(r => r.json()),
     fetch('./data/spiral_map.json').then(r => r.json())
   ]);
-  stylepacks = sp;
-  angels = an;
-  angels72 = an72;
-  egregores = eg;
-  egregoresCore = egc;
-  tarotMajors = tm;
-  spiralMap = sm;
+
+  initCodex({
+    codex: '144:99',
+    stylepacks,
+    angels,
+    angels72,
+    egregores,
+    egregoresCore,
+    tarotMajors,
+    spiralMap
+  });
+
   document.documentElement.dataset.nd = 'safe';
   if (!localStorage.getItem('cosmo:v1:first')) {
     const banner = document.createElement('div');
@@ -41,11 +40,11 @@ async function load() {
 
 await load();
 
-export const cfg = {};
-export const getStylepacks = () => stylepacks;
-export const getAngels = () => angels;
-export const getAngels72 = () => angels72;
-export const getEgregores = () => egregores;
-export const getEgregoresCore = () => egregoresCore;
-export const getTarotMajors = () => tarotMajors;
-export const getSpiralMap = () => spiralMap;
+export { cfg };
+export const getStylepacks = () => cfg.stylepacks;
+export const getAngels = () => cfg.angels;
+export const getAngels72 = () => cfg.angels72;
+export const getEgregores = () => cfg.egregores;
+export const getEgregoresCore = () => cfg.egregoresCore;
+export const getTarotMajors = () => cfg.tarotMajors;
+export const getSpiralMap = () => cfg.spiralMap;

--- a/src/codexConfig.js
+++ b/src/codexConfig.js
@@ -1,0 +1,16 @@
+// Codex configuration with one-time initialization and lock
+let locked = false;
+export const cfg = {};
+
+export function initCodex(settings = {}) {
+  if (locked) {
+    throw new Error("Codex configuration is locked");
+  }
+  Object.assign(cfg, settings);
+  Object.freeze(cfg);
+  locked = true;
+}
+
+export function isLocked() {
+  return locked;
+}

--- a/test/codexConfig.test.js
+++ b/test/codexConfig.test.js
@@ -1,0 +1,14 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { cfg, initCodex, isLocked } from "../src/codexConfig.js";
+
+test("codex config locks after initialization", () => {
+  initCodex({ version: "144:99", nodes: { hero: 11 } });
+  assert.equal(cfg.version, "144:99");
+  assert.ok(isLocked());
+  assert.throws(() => initCodex({ version: "999" }));
+  assert.throws(() => {
+    // Attempt to mutate locked config
+    cfg.version = "changed";
+  });
+});


### PR DESCRIPTION
## Summary
- lock codex 144:99 configuration after first initialization
- expose helper to check lock state
- cover config lock with unit test

## Testing
- `npm test`
- `npm run check` *(fails: Unexpected token in several existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68b88c3e6fd48328aa5ec0b092e4be65