### PR TITLE
Add Cathedral Annex README for unified reference

### DIFF
--- a/README_ANNEX.md
+++ b/README_ANNEX.md
@@ -1,0 +1,89 @@
+🜍 Circuitum 99 — Cathedral Annex (Unified)
+
+A living codex of art standards, chapel schematics, and archive references.
+For use in Stone Grimoire / Codex 144:99 (museum-grade, ND-friendly).
+
+⸻
+
+I. Open Source Art Index (Approved Archive)
+
+Purpose: All visual and symbolic resources used in the Codex must come from safe, public-domain, or explicitly licensed sources.
+This guarantees museum-grade provenance, sponsor safety, and neurodivergent-safe alignment.
+
+Categories:
+• ✦ PD Engravings → Fludd, Dürer, Ripley Scroll fragments.
+• ✦ Visionary Abstraction → Hilma af Klint, Emma Kunz (patterns + spirals).
+• ✦ Occult Geometry → Villard de Honnecourt sketchbook, Book of Soyga grids.
+• ✦ Sacred Textures → Rosslyn carvings, Gothic tracery, alchemical marginalia.
+• ✦ Color Archives → Munsell spectral wheels, medieval pigment studies.
+
+Integration:
+• /docs/open_source_art_index.md holds the canonical list.
+• Each plaque or chapel page cites which archive entry it derives from.
+• Index is linked to the museum checklist for auditing.
+
+⸻
+
+II. Apprentice Pillar Chapel (Rosslyn Integration)
+
+Page: /chapels/apprentice-pillar.html
+Theme: Rosslyn’s Apprentice Pillar as a living ladder.
+• Geometry: Helix vine = Prima Materia ascent.
+• Numerology: Mapped to Jacob’s Ladder and the 33-vertebrae spine.
+• Hermetic Role: Entry point for the alchemical journey (Nigredo → Albedo → Citrinitas → Rubedo).
+• Plaque Note: “The Apprentice Pillar is not failure — it is the beginning. Its spiral holds the prima materia of all further ascent.”
+
+Style:
+• Museum-grade parchment layout.
+• Hilma spiral overlays + subtle neon tracery.
+• ND-safe: high contrast skins available; tone gated on gesture.
+
+⸻
+
+III. Cathedral Code Annex
+
+Document: /registry/Cathedral_Code_Annex.html
+(Exported also as PDF for sponsor review.)
+
+Function: Master annex connecting rooms, plaques, and schema.
+• Routes (structure.json) → index, cathedral, chapels.
+• Plaques (room-plaque.js) → glyphs, tones, lineage notes.
+• Stylepacks (stylepacks.json) → Hilma spiral, sun_solaris, druidic greenman.
+• Engines (cathedral-engine.js) → applies overlays, tones, curator voice.
+
+Current Anchors:
+• Frontispiece → “Open the cosmogram.”
+• Nave → “Boaz | Apprentice | Jachin.”
+• Pillars (Boaz, Jachin) → Strength / Mercy.
+• Choir → “Jacob’s Ladder resonance.”
+• Codex Node → liber-codex99.md (fusion text).
+
+Accessibility:
+• ND-safe sound → gated, gentle cathedral pad.
+• No strobe.
+• ARIA roles + narrated glyphs.
+• Cymatic blooms planned for non-hearing inclusion.
+
+⸻
+
+IV. Integration Summary
+• /docs/open_source_art_index.md → reference archive.
+• /chapels/apprentice-pillar.html → first chapel node, tied to Jacob’s Ladder.
+• /registry/Cathedral_Code_Annex.html → annex manifest, binding routes + plaques.
+
+All three are now fused into one annex entry.
+
+⸻
+
+📍 Save this document as:
+README_ANNEX.md in your repo root.
+
+It gives your codebot one unified reference, with provenance, chapel detail, and system routing in place.
+
+⸻
+
+Do you want me to expand this annex into a template so every new chapel, pillar, or realm page automatically has:
+1. Museum checklist
+2. Plaque note
+3. Stylepack reference
+4. Provenance citat


### PR DESCRIPTION
## Summary
- Add `README_ANNEX.md` describing open-source art index, Apprentice Pillar chapel, and Cathedral Code Annex integration.

## Testing
- `npm test` *(fails: SyntaxError in test files)*

------
https://chatgpt.com/codex/tasks/task_e_68b921a2d4a88328ab3bbf6a4b464253