### PR TITLE
Add Meta Realms styles and Cathedral seals

### DIFF
--- a/assets/css/cathedral_icon.css
+++ b/assets/css/cathedral_icon.css
@@ -1,0 +1,19 @@
+.icon-seal {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  background-size: contain;
+  background-repeat: no-repeat;
+}
+
+.icon-seal--temple {
+  background-image: url('../svg/cathedral_seal_temple.svg');
+}
+
+.icon-seal--garden {
+  background-image: url('../svg/cathedral_seal_garden.svg');
+}
+
+.icon-seal--tavern {
+  background-image: url('../svg/cathedral_seal_tavern.svg');
+}

--- a/assets/css/meta_realms.css
+++ b/assets/css/meta_realms.css
@@ -1,0 +1,28 @@
+/* Realm-specific styles */
+.realm--temple {
+  background: radial-gradient(circle at center, gold 0%, #0ff 100%);
+  color: #000;
+}
+
+.realm--garden {
+  background: linear-gradient(135deg, violet, #50c878);
+  color: #fff;
+}
+
+.realm--tavern {
+  background: linear-gradient(135deg, #222, #555);
+  color: #ffbf00;
+}
+
+/* ND-safe tone cues */
+.ndsafe--temple {
+  --hz: 261.63;
+}
+
+.ndsafe--garden {
+  --hz: 639;
+}
+
+.ndsafe--tavern {
+  --hz: 417;
+}

--- a/assets/svg/cathedral_seal.svg
+++ b/assets/svg/cathedral_seal.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <style>
+    :root {
+      --seal-primary: #ffd700;
+      --seal-accent: #00ffff;
+    }
+    .ring { fill: none; stroke: var(--seal-primary); stroke-width: 4; }
+    .eye { fill: none; stroke: var(--seal-accent); stroke-width: 3; }
+    .vine { fill: none; stroke: var(--seal-accent); stroke-width: 2; }
+    .text { fill: var(--seal-primary); font-family: 'Georgia', serif; font-size: 12px; letter-spacing: 3px; }
+  </style>
+  <defs>
+    <path id="textcircle" d="M100,10 A90,90 0 1,1 99.9,10" />
+  </defs>
+  <circle class="ring" cx="100" cy="100" r="90" />
+  <ellipse class="eye" cx="100" cy="100" rx="40" ry="60" />
+  <path class="vine" d="M100 40 C120 70 80 130 100 160" />
+  <text class="text">
+    <textPath href="#textcircle">CATHEDRAL • OF • CIRCUITS • 144:99 ☿ ♄ ♇</textPath>
+  </text>
+</svg>

--- a/assets/svg/cathedral_seal_garden.svg
+++ b/assets/svg/cathedral_seal_garden.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <style>
+    :root {
+      --seal-primary: #50c878;
+      --seal-accent: #8a2be2;
+    }
+    .ring { fill: none; stroke: var(--seal-primary); stroke-width: 4; }
+    .eye { fill: none; stroke: var(--seal-accent); stroke-width: 3; }
+    .vine { fill: none; stroke: var(--seal-accent); stroke-width: 2; }
+    .text { fill: var(--seal-primary); font-family: 'Georgia', serif; font-size: 12px; letter-spacing: 3px; }
+  </style>
+  <defs>
+    <path id="textcircle" d="M100,10 A90,90 0 1,1 99.9,10" />
+  </defs>
+  <circle class="ring" cx="100" cy="100" r="90" />
+  <ellipse class="eye" cx="100" cy="100" rx="40" ry="60" />
+  <path class="vine" d="M100 40 C120 70 80 130 100 160" />
+  <text class="text">
+    <textPath href="#textcircle">CATHEDRAL • OF • CIRCUITS • 144:99 ☿ ♄ ♇</textPath>
+  </text>
+</svg>

--- a/assets/svg/cathedral_seal_tavern.svg
+++ b/assets/svg/cathedral_seal_tavern.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <style>
+    :root {
+      --seal-primary: #ffbf00;
+      --seal-accent: #444444;
+    }
+    .ring { fill: none; stroke: var(--seal-primary); stroke-width: 4; }
+    .eye { fill: none; stroke: var(--seal-accent); stroke-width: 3; }
+    .vine { fill: none; stroke: var(--seal-accent); stroke-width: 2; }
+    .text { fill: var(--seal-primary); font-family: 'Georgia', serif; font-size: 12px; letter-spacing: 3px; }
+  </style>
+  <defs>
+    <path id="textcircle" d="M100,10 A90,90 0 1,1 99.9,10" />
+  </defs>
+  <circle class="ring" cx="100" cy="100" r="90" />
+  <ellipse class="eye" cx="100" cy="100" rx="40" ry="60" />
+  <path class="vine" d="M100 40 C120 70 80 130 100 160" />
+  <text class="text">
+    <textPath href="#textcircle">CATHEDRAL • OF • CIRCUITS • 144:99 ☿ ♄ ♇</textPath>
+  </text>
+</svg>

--- a/assets/svg/cathedral_seal_temple.svg
+++ b/assets/svg/cathedral_seal_temple.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <style>
+    :root {
+      --seal-primary: #ffd700;
+      --seal-accent: #00ffff;
+    }
+    .ring { fill: none; stroke: var(--seal-primary); stroke-width: 4; }
+    .eye { fill: none; stroke: var(--seal-accent); stroke-width: 3; }
+    .vine { fill: none; stroke: var(--seal-accent); stroke-width: 2; }
+    .text { fill: var(--seal-primary); font-family: 'Georgia', serif; font-size: 12px; letter-spacing: 3px; }
+  </style>
+  <defs>
+    <path id="textcircle" d="M100,10 A90,90 0 1,1 99.9,10" />
+  </defs>
+  <circle class="ring" cx="100" cy="100" r="90" />
+  <ellipse class="eye" cx="100" cy="100" rx="40" ry="60" />
+  <path class="vine" d="M100 40 C120 70 80 130 100 160" />
+  <text class="text">
+    <textPath href="#textcircle">CATHEDRAL • OF • CIRCUITS • 144:99 ☿ ♄ ♇</textPath>
+  </text>
+</svg>


### PR DESCRIPTION
## Summary
- add Meta Realms CSS with ND-safe tones
- add Cathedral seal icons and realm variants

## Testing
- `npm test` (fails: SyntaxError in existing tests)
- `npm run check` (fails: code style issues in existing files)


------
https://chatgpt.com/codex/tasks/task_e_68b91db5fa8083288109afe5da7c5f2e