### PR TITLE
Add tarot-codex bridge generator

### DIFF
--- a/bridge/tarot-codex-bridge.json
+++ b/bridge/tarot-codex-bridge.json
@@ -1,0 +1,87 @@
+{
+  "The Fool": [
+    1,
+    3,
+    7
+  ],
+  "The Magician": [
+    2,
+    3,
+    7,
+    13
+  ],
+  "The High Priestess": [
+    3,
+    13
+  ],
+  "The Empress": [
+    4,
+    6,
+    8,
+    11,
+    16
+  ],
+  "The Emperor": [
+    5
+  ],
+  "The Hierophant": [
+    3,
+    6,
+    7,
+    13
+  ],
+  "The Lovers": [
+    7,
+    8
+  ],
+  "The Chariot": [
+    4,
+    5,
+    9,
+    14
+  ],
+  "Strength": [
+    4,
+    9,
+    11,
+    14,
+    15,
+    16
+  ],
+  "The Hermit": [
+    8,
+    10
+  ],
+  "The Wheel": [
+    10,
+    11
+  ],
+  "Justice": [
+    3,
+    12
+  ],
+  "The Hanged One": [
+    13
+  ],
+  "Death": [
+    9,
+    10,
+    14
+  ],
+  "Temperance": [
+    15,
+    16
+  ],
+  "The Devil": [
+    16
+  ],
+  "The Moon": [
+    9
+  ],
+  "The Sun": [
+    1,
+    8,
+    11,
+    16
+  ]
+}

--- a/bridge/tarot_codex_bridge.py
+++ b/bridge/tarot_codex_bridge.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Generate a bridge mapping Tarot Major Arcana to Codex 144:99 nodes.
+
+Reads the MAJOR_ARCANA_REGISTRY.md for card metadata and matches cards to
+Codex nodes via angels, demons, or deity names. The resulting mapping is written
+as JSON alongside this script.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Dict, List
+
+ROOT = Path(__file__).resolve().parents[1]
+TAROT_REGISTRY = ROOT / "MAJOR_ARCANA_REGISTRY.md"
+CODEX_NODES = ROOT / "codex-144-99" / "data" / "codex_nodes_full.json"
+OUTPUT_JSON = Path(__file__).with_name("tarot-codex-bridge.json")
+
+def load_tarot(path: Path) -> Dict[str, Dict[str, List[str]]]:
+    """Parse the Tarot registry into a dict keyed by card name."""
+    text = path.read_text(encoding="utf-8")
+    cards: Dict[str, Dict[str, List[str] | str]] = {}
+    current: str | None = None
+
+    for raw in text.splitlines():
+        line = raw.strip()
+        if line.startswith("## "):
+            left = line[3:].split("—")[0].strip()
+            if ". " in left:
+                _, name = left.split(". ", 1)
+            else:
+                name = left
+            current = name
+            cards[current] = {"angel": "", "demon": "", "deities": []}
+        elif current and line.startswith("- Angel/Demon:"):
+            m = re.search(r"Angel/Demon:\s*([^↔]+)↔\s*([^.\n]+)", line)
+            if m:
+                cards[current]["angel"] = m.group(1).strip()
+                cards[current]["demon"] = m.group(2).strip()
+        elif current and line.startswith("- Deities:"):
+            deities_part = line.split(":", 1)[1].strip().rstrip(".")
+            deities = [d.strip() for d in deities_part.split(",")]
+            cards[current]["deities"] = deities
+    return cards
+
+def load_codex(path: Path) -> List[dict]:
+    """Load Codex nodes from JSON."""
+    with path.open(encoding="utf-8") as f:
+        return json.load(f)
+
+def build_bridge(cards: Dict[str, Dict[str, List[str] | str]], nodes: List[dict]) -> Dict[str, List[int]]:
+    """Return mapping of card name to list of matching node IDs."""
+    bridge: Dict[str, List[int]] = {}
+
+    for card_name, info in cards.items():
+        angel = str(info.get("angel", "")).lower()
+        demon = str(info.get("demon", "")).lower()
+        deities = {d.lower() for d in info.get("deities", [])}
+        matches: List[int] = []
+
+        for node in nodes:
+            n_angel = str(node.get("shem_angel", "")).lower()
+            n_demon = str(node.get("goetic_demon", "")).lower()
+            node_deities = {
+                g["name"].lower() for g in node.get("gods", []) + node.get("goddesses", [])
+            }
+            if (
+                (angel and n_angel == angel)
+                or (demon and n_demon == demon)
+                or (deities & node_deities)
+            ):
+                matches.append(int(node["node_id"]))
+        if matches:
+            bridge[card_name] = sorted(matches)
+
+    return bridge
+
+def main() -> None:
+    cards = load_tarot(TAROT_REGISTRY)
+    nodes = load_codex(CODEX_NODES)
+    bridge = build_bridge(cards, nodes)
+    with OUTPUT_JSON.open("w", encoding="utf-8") as f:
+        json.dump(bridge, f, indent=2, ensure_ascii=False)
+    print(f"Saved bridge with {len(bridge)} cards to {OUTPUT_JSON}")
+
+if __name__ == "__main__":
+    main()

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
   <link rel="manifest" href='data:application/manifest+json,{"name":"Cosmogenesis Learning Engine","short_name":"Cosmogenesis","start_url":"./","display":"standalone","theme_color":"#1f6feb","background_color":"#0f1012"}'>
 
   <!-- Favicon (embedded SVG) -->
-  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 100 100%27%3E%3Cdefs%3E%3CradialGradient id=%27g%27%3E%3Cstop offset=%270%27 stop-color=%27%23fff%27/%3E%3Cstop offset=%271%27 stop-color=%27%231f6feb%27/%3E%3C/radialGradient%3E%3C/defs%3E%3Ccircle cx=%2750%27 cy=%2750%27 r=%2747%27 fill=%27url(%23g)%27/%3E%3Ccircle cx=%2750%27 cy=%2750%27 r=%2714%27 fill=%27%23fff%27/%3E%3C/svg%3E'>
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cdefs%3E%3CradialGradient id='g'%3E%3Cstop offset='0' stop-color='%23fff'/%3E%3Cstop offset='1' stop-color='%231f6feb'/%3E%3C/radialGradient%3E%3C/defs%3E%3Ccircle cx='50' cy='50' r='47' fill='url(%23g)'/%3E%3Ccircle cx='50' cy='50' r='14' fill='%23fff'/%3E%3C/svg%3E">
 
   <style>
     :root{


### PR DESCRIPTION
## Summary
- add script to cross-reference Major Arcana with Codex 144:99 nodes
- generate initial tarot-codex bridge mapping
- fix inline favicon data URL in index.html

## Testing
- `scripts/run-check.sh` (fails: code style issues in existing files)
- `scripts/run-tests.sh` (fails: progress-engine.test.js syntax error)


------
https://chatgpt.com/codex/tasks/task_e_68b9cda9b66083289b5c0d7cf141f574