### PR TITLE
docs: add dependency workaround guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ npm test        # node --test
 ```
 
 When Python isn't available, open `visionary_dream.html` in a browser to render the Enochian grid and planetary sigils via p5.js.
+For additional fallback strategies, see `docs/dependency_workarounds.md`.
 
 ### Shared Python overlays
 All Python art generators now reuse a common `enochian_layers` module that draws the Enochian grid and planetary sigils so mystical features stay consistent across scripts.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,3 +4,4 @@ This folder collects guides for the Cosmogenesis Learning Engine. Key references
 - `provenance.md` – provenance schema and hashing notes
 - `neurodivergent_learning.md` – accessibility guidelines
 - `SCIENCE_REFERENCES.md` – supporting research
+- `dependency_workarounds.md` – tips when runtimes or optional packages are missing

--- a/docs/dependency_workarounds.md
+++ b/docs/dependency_workarounds.md
@@ -1,0 +1,13 @@
+# Dependency Workarounds
+
+These tips help run the Cosmogenesis Learning Engine when certain runtimes or libraries are unavailable.
+
+## When Node.js is missing
+- Install [Deno](https://deno.com/) and run `npm test`. The script checks for Node.js first and falls back to Deno automatically.
+- `npm run check` also detects Deno and uses `deno fmt --check` to verify formatting when Node.js isn't present.
+
+## When Python or Pillow is missing
+- If Python isn't available, open `visionary_dream.html` in a browser to render the Enochian grid and planetary sigils via p5.js.
+- Image generation scripts rely on Pillow and NumPy. Install them with `pip install pillow numpy` or skip those features.
+
+Share this document with other repositories to keep cross-platform setups running smoothly.


### PR DESCRIPTION
## Summary
- add dependency_workarounds.md with tips for missing Node.js, Python, or Pillow
- reference the guide from README and docs index

## Testing
- `npm test` (fails: test code failures)
- `npm run check` (fails: error occurred when checking code style)


------
https://chatgpt.com/codex/tasks/task_e_68ba03576ca48328a93680f32617b581