### PR TITLE
feat: add repository trinity mapping

### DIFF
--- a/data/system_parts.json
+++ b/data/system_parts.json
@@ -1,0 +1,18 @@
+{
+  "mind": {
+    "repo": "cosmogenesis-learning-engine",
+    "function": "144 spiral nodes with sound, geometry, and color"
+  },
+  "soul": {
+    "repo": "circuitum99",
+    "function": "33-chapter Tree-of-Life storybook and ritual engine"
+  },
+  "body": {
+    "repo": "stone-cathedral",
+    "function": "Immersive visionary environments and sacred geometry atelier"
+  },
+  "companion": {
+    "repo": "liber-arcanae",
+    "function": "Tarot egregores with angels, daemons, and Taras"
+  }
+}

--- a/src/systemParts.js
+++ b/src/systemParts.js
@@ -1,0 +1,13 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+
+let cache = null;
+
+export function loadSystemParts(relativePath = 'data/system_parts.json') {
+  if (!cache) {
+    const file = path.resolve(process.cwd(), relativePath);
+    const raw = readFileSync(file, 'utf8');
+    cache = JSON.parse(raw);
+  }
+  return cache;
+}

--- a/test/system-parts.test.js
+++ b/test/system-parts.test.js
@@ -1,0 +1,11 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { loadSystemParts } from '../src/systemParts.js';
+
+test('loadSystemParts exposes repository trinity', () => {
+  const parts = loadSystemParts();
+  assert.equal(parts.mind.repo, 'cosmogenesis-learning-engine');
+  assert.equal(parts.soul.repo, 'circuitum99');
+  assert.equal(parts.body.repo, 'stone-cathedral');
+  assert.equal(parts.companion.repo, 'liber-arcanae');
+});


### PR DESCRIPTION
## Summary
- map mind, soul, body, and companion repos
- load repository trinity data in app
- test system parts loader

## Testing
- `npm test` *(fails: SyntaxError in existing tests)*
- `npm run check` *(fails: SyntaxError in index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e63410848328a5223b42cd76b56d