### PR TITLE
Add Solfeggio tone asset generator and fix progress tests

### DIFF
--- a/scripts/generate_solfeggio_assets.py
+++ b/scripts/generate_solfeggio_assets.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Generate lossless Solfeggio tone assets for all 144 nodes.
+
+This script reads the Codex node registry and synthesizes a pure sine wave
+for each node's Solfeggio frequency. The resulting files are written as
+48 kHz, 16-bit mono WAV assets under ``assets/generated/audio``.
+
+Usage:
+    python scripts/generate_solfeggio_assets.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+import wave
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Synthesis utilities
+# ---------------------------------------------------------------------------
+
+def synthesize_tone(freq: float, duration: float, sample_rate: int) -> np.ndarray:
+    """Return a normalized sine wave for ``freq`` Hz."""
+    t = np.linspace(0, duration, int(sample_rate * duration), False)
+    waveform = 0.5 * np.sin(2 * math.pi * freq * t)
+    return np.int16(waveform * 32767)
+
+
+# ---------------------------------------------------------------------------
+# Main generation routine
+# ---------------------------------------------------------------------------
+
+def generate_assets(nodes_file: Path, out_dir: Path, duration: float, sample_rate: int) -> None:
+    """Create one WAV file per node based on its Solfeggio frequency."""
+    nodes = json.loads(nodes_file.read_text())
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    for entry in nodes:
+        node_id = entry["node_id"]
+        freq_str = entry["solfeggio_freq"]  # e.g., "963 Hz"
+        freq = float(freq_str.split()[0])
+        data = synthesize_tone(freq, duration, sample_rate)
+        filename = out_dir / f"node_{node_id:03d}_{int(freq)}Hz.wav"
+        with wave.open(str(filename), "w") as wf:
+            wf.setnchannels(1)  # mono
+            wf.setsampwidth(2)  # 16-bit PCM
+            wf.setframerate(sample_rate)
+            wf.writeframes(data.tobytes())
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    """Parse arguments and generate assets."""
+    parser = argparse.ArgumentParser(description="Generate Solfeggio tone assets")
+    parser.add_argument(
+        "--nodes-file",
+        type=Path,
+        default=Path("codex-144-99/data/codex_nodes_full.json"),
+        help="Path to Codex node data",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("assets/generated/audio"),
+        help="Directory for WAV files",
+    )
+    parser.add_argument("--duration", type=float, default=5.0, help="Tone length in seconds")
+    parser.add_argument(
+        "--sample-rate", type=int, default=48000, help="Sampling rate in Hz"
+    )
+    args = parser.parse_args()
+
+    generate_assets(args.nodes_file, args.output_dir, args.duration, args.sample_rate)
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    main()
+

--- a/test/progress-engine.test.js
+++ b/test/progress-engine.test.js
@@ -1,15 +1,11 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { exportJSON } from '../src/engines/exporter.js';
+import { deepEqual } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+import { EventEmitter } from 'node:events';
 
-test('progress export JSON writes a file', () => {
-  const path = exportJSON({ ok: true }, 'progress.json');
-  assert.ok(typeof path === 'string' && path.endsWith('progress.json'));
-import { test } from "node:test";
-import { deepEqual } from "node:assert";
-import { readFileSync } from "node:fs";
-import vm from "node:vm";
-import { EventEmitter } from "node:events";
+import { exportJSON } from '../src/engines/exporter.js';
 
 function loadEngine() {
   const storage = {};
@@ -35,19 +31,25 @@ function loadEngine() {
     console,
   };
   vm.runInNewContext(
-    readFileSync("assets/js/engines/progress-engine.js", "utf8"),
+    readFileSync('assets/js/engines/progress-engine.js', 'utf8'),
     ctx,
   );
   return ctx;
 }
 
-test("records progress and resets", () => {
+test('progress export JSON writes a file', () => {
+  const path = exportJSON({ ok: true }, 'progress.json');
+  assert.ok(typeof path === 'string' && path.endsWith('progress.json'));
+});
+
+test('records progress and resets', () => {
   const ctx = loadEngine();
-  ctx.window.roomsProgress.markRoomEnter("agrippa");
-  ctx.window.roomsProgress.markQuestComplete("agrippa", "read");
+  ctx.window.roomsProgress.markRoomEnter('agrippa');
+  ctx.window.roomsProgress.markQuestComplete('agrippa', 'read');
   deepEqual(ctx.window.roomsProgress.state.rooms, {
     agrippa: { quests: { read: true }, entered: true },
   });
   ctx.window.roomsProgress.reset();
   deepEqual(ctx.window.roomsProgress.state.rooms, {});
 });
+


### PR DESCRIPTION
## Summary
- Add script to synthesize lossless Solfeggio tone WAV files for all 144 Codex nodes
- Repair progress engine test by consolidating imports and completing test blocks

## Testing
- `scripts/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ba4b948de88328ae220049ddd02c53