### PR TITLE
Expand demos and fix progress tests

### DIFF
--- a/data/demos.json
+++ b/data/demos.json
@@ -1,33 +1,210 @@
 [
   {
-    "title": "Art \u2022 7 Colors (Basic Design)",
+    "title": "Art • 7 Colors (Basic Design)",
     "config": {
       "layout": "wheel",
       "mode": 7,
       "labels": ["Red", "Orange", "Yellow", "Green", "Cyan", "Blue", "Violet"]
-      "labels": [
-         "labels": [
-        "Red",
-        "Orange",
-        "Yellow",
-        "Green",
-        "Cyan",
-        "Blue",
-        "Violet"
-      ]
-      "labels": ["Red", "Orange", "Yellow", "Green", "Cyan", "Blue", "Violet"]
-Green", "Cyan", "Blue", "Violet"]
->>>>>>> Stashed changes
-      "labels": ["Red", "Orange", "Yellow", "Green", "Cyan", "Blue", "Violet"]
->>>>>>> upstream/codex/improve-creative-learning-engine-design
->>>>>>> main-upstream-upstream-upstream-upstream
->>>>>>> codex/improve-creative-learning-engine-design
->>>>>>> origin/codex/update-package-for-code-bot
->>>>>>> codex/enhance-aesthetic-designs-and-environments
     }
   },
   {
-    "title": "Art \u2022 Visionary Dream",
+    "title": "STEM • 12 Cranial Nerves",
+    "config": {
+      "layout": "grid",
+      "mode": 12,
+      "labels": [
+        "I Olfactory",
+        "II Optic",
+        "III Oculomotor",
+        "IV Trochlear",
+        "V Trigeminal",
+        "VI Abducens",
+        "VII Facial",
+        "VIII Vestibulocochlear",
+        "IX Glossopharyngeal",
+        "X Vagus",
+        "XI Accessory",
+        "XII Hypoglossal"
+      ]
+    }
+  },
+  {
+    "title": "UX • 22 Research Prompts",
+    "config": {
+      "layout": "spiral",
+      "mode": 22,
+      "labels": [
+        "Prompt 1",
+        "Prompt 2",
+        "Prompt 3",
+        "Prompt 4",
+        "Prompt 5",
+        "Prompt 6",
+        "Prompt 7",
+        "Prompt 8",
+        "Prompt 9",
+        "Prompt 10",
+        "Prompt 11",
+        "Prompt 12",
+        "Prompt 13",
+        "Prompt 14",
+        "Prompt 15",
+        "Prompt 16",
+        "Prompt 17",
+        "Prompt 18",
+        "Prompt 19",
+        "Prompt 20",
+        "Prompt 21",
+        "Prompt 22"
+      ]
+    }
+  },
+  {
+    "title": "Poetry • 33 Lines in a Cycle",
+    "config": {
+      "layout": "spiral",
+      "mode": 33,
+      "labels": [
+        "Line 1",
+        "Line 2",
+        "Line 3",
+        "Line 4",
+        "Line 5",
+        "Line 6",
+        "Line 7",
+        "Line 8",
+        "Line 9",
+        "Line 10",
+        "Line 11",
+        "Line 12",
+        "Line 13",
+        "Line 14",
+        "Line 15",
+        "Line 16",
+        "Line 17",
+        "Line 18",
+        "Line 19",
+        "Line 20",
+        "Line 21",
+        "Line 22",
+        "Line 23",
+        "Line 24",
+        "Line 25",
+        "Line 26",
+        "Line 27",
+        "Line 28",
+        "Line 29",
+        "Line 30",
+        "Line 31",
+        "Line 32",
+        "Line 33"
+      ]
+    }
+  },
+  {
+    "title": "Sacred • 72 Names (Study Plate)",
+    "config": {
+      "layout": "spiral",
+      "mode": 72,
+      "labels": [
+        "Name 1",
+        "Name 2",
+        "Name 3",
+        "Name 4",
+        "Name 5",
+        "Name 6",
+        "Name 7",
+        "Name 8",
+        "Name 9",
+        "Name 10",
+        "Name 11",
+        "Name 12",
+        "Name 13",
+        "Name 14",
+        "Name 15",
+        "Name 16",
+        "Name 17",
+        "Name 18",
+        "Name 19",
+        "Name 20",
+        "Name 21",
+        "Name 22",
+        "Name 23",
+        "Name 24",
+        "Name 25",
+        "Name 26",
+        "Name 27",
+        "Name 28",
+        "Name 29",
+        "Name 30",
+        "Name 31",
+        "Name 32",
+        "Name 33",
+        "Name 34",
+        "Name 35",
+        "Name 36",
+        "Name 37",
+        "Name 38",
+        "Name 39",
+        "Name 40",
+        "Name 41",
+        "Name 42",
+        "Name 43",
+        "Name 44",
+        "Name 45",
+        "Name 46",
+        "Name 47",
+        "Name 48",
+        "Name 49",
+        "Name 50",
+        "Name 51",
+        "Name 52",
+        "Name 53",
+        "Name 54",
+        "Name 55",
+        "Name 56",
+        "Name 57",
+        "Name 58",
+        "Name 59",
+        "Name 60",
+        "Name 61",
+        "Name 62",
+        "Name 63",
+        "Name 64",
+        "Name 65",
+        "Name 66",
+        "Name 67",
+        "Name 68",
+        "Name 69",
+        "Name 70",
+        "Name 71",
+        "Name 72"
+      ]
+    }
+  },
+  {
+    "title": "Yeats • Twin Cones (Oppositions)",
+    "config": {
+      "layout": "twin_cones",
+      "mode": 12,
+      "labels": [
+        "Logic",
+        "Imagination",
+        "Discipline",
+        "Inspiration",
+        "Analysis",
+        "Synthesis",
+        "Form",
+        "Flow",
+        "Silence",
+        "Voice",
+        "Structure",
+        "Wildness"
+      ]
+    }
+  },
+  {
+    "title": "Art • Visionary Dream",
     "config": {
       "layout": "spiral",
       "mode": 3,
@@ -39,4 +216,3 @@ Green", "Cyan", "Blue", "Violet"]
     }
   }
 ]
-

--- a/docs/demo_guide.md
+++ b/docs/demo_guide.md
@@ -1,30 +1,35 @@
- # ✦ Cosmogenesis Learning Engine — Demo Guide
- 
- *A spiral teacher for pattern literacy, creative practice, and living archives.*
- 
- —
- 
- ## ✦ How This Guide Works
--This is not a linear manual.  
--It is a **spiral walk-through**: each turn revisits the same engine with deeper complexity.  
-This is not a linear manual.
-It is a **spiral walk-through**: each turn revisits the same engine with deeper complexity.
- 
--- **First Spiral** → learn the surface (layout, labels, export).  
--- **Second Spiral** → weave correspondences (datasets, traditions).  
--- **Third Spiral** → fuse art, archive, and provenance into living plates.  
+# ✦ Cosmogenesis Learning Engine — Demo Guide
+
+_A spiral teacher for pattern literacy, creative practice, and living archives._
+
+---
+
+## ✦ How This Guide Works
+
+This is not a linear manual. It is a **spiral walk-through**: each turn revisits the same engine with deeper complexity.
+
 - **First Spiral** → learn the surface (layout, labels, export).
 - **Second Spiral** → weave correspondences (datasets, traditions).
 - **Third Spiral** → fuse art, archive, and provenance into living plates.
- 
- Each spiral is a *return* — not a reset.
- 
- —
- 
- ## ✦ First Spiral — The Basics
--1. Open the [engine](../index.html).  
--2. Choose **Layout** = Spiral.  
--3. Enter 7 labels (colors work well):  
+
+Each spiral is a _return_ — not a reset.
+
+## ✦ Sample Demos
+
+Use the **Demos** tab or load `data/demos.json` to explore built-in presets:
+
+- Art • 7 Colors (Basic Design)
+- STEM • 12 Cranial Nerves
+- UX • 22 Research Prompts
+- Poetry • 33 Lines in a Cycle
+- Sacred • 72 Names (Study Plate)
+- Yeats • Twin Cones (Oppositions)
+- Art • Visionary Dream
+
+---
+
+## ✦ First Spiral — The Basics
+
 1. Open the [engine](../index.html).
 2. Choose **Layout** = Spiral.
 3. Enter 7 labels (colors work well):
@@ -33,18 +38,21 @@ It is a **spiral walk-through**: each turn revisits the same engine with deeper 
 5. Use **Export → PNG** to save your first spiral.
 
 ### Reset
+
 Hit **Reset** to clear the plate and try new labels or layouts.
 
 ## ✦ Second Spiral — Correspondences
-1. Load a dataset from `data/rooms.json` such as *Agrippa*.
+
+1. Load a dataset from `data/rooms.json` such as _Agrippa_.
 2. Notice how the same geometry now expresses a different tradition.
 3. Toggle **Style** to switch palettes or themes.
 
 ## ✦ Third Spiral — Art & Provenance
+
 1. Combine a dataset with an egregore card from `data/egregores.json`.
 2. Add a provenance note in the **Border** field.
 3. Export and share the JSON config with a friend for collaborative return.
 
-—
+---
 
 Each spiral builds upon the last. Revisit earlier steps as new ideas emerge.

--- a/package.json
+++ b/package.json
@@ -8,19 +8,9 @@
     "start": "npm run dev",
     "preview": "http-server -p 8080 -c-1 .",
     "build": "echo \"Static app -- no bundling required. Use 'Export SVG/PNG' in-app.\"",
-<<<<<<< codex/add-art-assets-for-study
     "test": "./scripts/run-tests.sh",
-    "test": "node --test test/codexConfig.test.js test/plugin-registry.test.js test/progress-engine.test.js",
-    "fmt": "prettier -w .",
-=======
-    "test": "node --test && python3 -m py_compile $(git ls-files '*.py')",
     "fmt": "npx prettier -w .",
-    "format": "prettier -w .",
->>>>>>> origin/codex/update-perm-style-with-new-palettes-and-layers
-    "check": "prettier -c .",
-    "test": "node --test",
     "format": "prettier -w src/configLoader.js src/renderPlate.js plugins/soundscape.js test/*.js data/demos.json",
-    "check": "prettier -c src/configLoader.js src/renderPlate.js plugins/soundscape.js test/*.js data/demos.json",
     "check": "./scripts/run-check.sh",
     "generate:flame": "python3 scripts/generate_flame.py --out assets/flame/flame.png",
     "generate:atlas": "python3 scripts/pillow_atlas.py --in assets/flame --out assets/flame/atlas.png",
@@ -45,4 +35,3 @@
     "prettier": "^3.3.3"
   }
 }
-

--- a/test/progress-engine.test.js
+++ b/test/progress-engine.test.js
@@ -1,15 +1,9 @@
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
-import { exportJSON } from '../src/engines/exporter.js';
-
-test('progress export JSON writes a file', () => {
-  const path = exportJSON({ ok: true }, 'progress.json');
-  assert.ok(typeof path === 'string' && path.endsWith('progress.json'));
 import { test } from "node:test";
-import { deepEqual } from "node:assert";
+import assert, { deepEqual } from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import vm from "node:vm";
 import { EventEmitter } from "node:events";
+import { exportJSON } from "../src/engines/exporter.js";
 
 function loadEngine() {
   const storage = {};
@@ -41,13 +35,24 @@ function loadEngine() {
   return ctx;
 }
 
+test("progress export JSON writes a file", () => {
+  const path = exportJSON({ ok: true }, "progress.json");
+  assert.ok(typeof path === "string" && path.endsWith("progress.json"));
+});
+
 test("records progress and resets", () => {
   const ctx = loadEngine();
   ctx.window.roomsProgress.markRoomEnter("agrippa");
   ctx.window.roomsProgress.markQuestComplete("agrippa", "read");
-  deepEqual(ctx.window.roomsProgress.state.rooms, {
+  const state = JSON.parse(
+    JSON.stringify(ctx.window.roomsProgress.state.rooms),
+  );
+  deepEqual(state, {
     agrippa: { quests: { read: true }, entered: true },
   });
   ctx.window.roomsProgress.reset();
-  deepEqual(ctx.window.roomsProgress.state.rooms, {});
+  const reset = JSON.parse(
+    JSON.stringify(ctx.window.roomsProgress.state.rooms),
+  );
+  deepEqual(reset, {});
 });


### PR DESCRIPTION
## Summary
- add multiple demo presets for art, STEM, UX, poetry, sacred study, Yeats, and visionary planning
- clean demo guide and list available presets
- resolve package scripts and repair progress-engine test

## Testing
- `npm test`
- `npx prettier -c package.json data/demos.json docs/demo_guide.md test/progress-engine.test.js --ignore-path ''`
- `npm run check` *(fails: Code style issues found in 14 files)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4dbe330883289d9f2a418dd25e97