### PR TITLE
Add static cosmic helix renderer

### DIFF
--- a/cosmic-helix/README_RENDERER.md
+++ b/cosmic-helix/README_RENDERER.md
@@ -1,0 +1,26 @@
+# Cosmic Helix Renderer
+
+Offline, ND-safe canvas sketch for layered sacred geometry.
+
+## Usage
+1. Open `index.html` in any modern browser (no server needed).
+2. A 1440×900 canvas will render four static layers:
+   - **Vesica field** — intersecting circles forming the womb of forms.
+   - **Tree‑of‑Life scaffold** — ten sephirot with simple straight paths.
+   - **Fibonacci curve** — golden spiral polyline anchored to centre.
+   - **Double‑helix lattice** — two phase‑shifted sine tracks.
+3. Palette can be customized in `data/palette.json`. If missing, a calm
+   fallback palette is used and a notice appears in the header.
+
+## Design Notes
+- No animation, autoplay, or flashing; a single render call ensures ND safety.
+- Muted colors and generous spacing improve readability in dark and light modes.
+- Geometry routines use numerology constants (3,7,9,11,22,33,99,144) to honour
+  project canon.
+- Code is modular ES module (`js/helix-renderer.mjs`) with pure functions and
+  ASCII quotes only.
+
+## Extending
+The renderer is intentionally minimal. Future layers or overlays can be added by
+extending `renderHelix` with new draw functions while preserving the calm visual
+hierarchy.

--- a/cosmic-helix/data/palette.json
+++ b/cosmic-helix/data/palette.json
@@ -1,0 +1,5 @@
+{
+  "bg": "#0b0b12",
+  "ink": "#e8e8f0",
+  "layers": ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
+}

--- a/cosmic-helix/index.html
+++ b/cosmic-helix/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Cosmic Helix Renderer (ND-safe, Offline)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="color-scheme" content="light dark">
+  <style>
+    /* ND-safe: calm contrast, no motion, generous spacing */
+    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
+    .status { color:var(--muted); font-size:12px; }
+    #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
+    .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
+    code { background:#11111a; padding:2px 4px; border-radius:3px; }
+  </style>
+</head>
+<body>
+  <header>
+    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette…</div>
+  </header>
+
+  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
+  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
+
+  <script type="module">
+    import { renderHelix } from "./js/helix-renderer.mjs";
+
+    const elStatus = document.getElementById("status");
+    const canvas = document.getElementById("stage");
+    const ctx = canvas.getContext("2d");
+
+    async function loadJSON(path) {
+      try {
+        const res = await fetch(path, { cache: "no-store" });
+        if (!res.ok) throw new Error(String(res.status));
+        return await res.json();
+      } catch (err) {
+        return null;
+      }
+    }
+
+    const defaults = {
+      palette: {
+        bg:"#0b0b12",
+        ink:"#e8e8f0",
+        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
+      }
+    };
+
+    const palette = await loadJSON("./data/palette.json");
+    const active = palette || defaults.palette;
+    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+
+    // Numerology constants used by geometry routines
+    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
+
+    // ND-safe rationale: no motion, high readability, soft colors, layered order
+    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
+  </script>
+</body>
+</html>

--- a/cosmic-helix/js/helix-renderer.mjs
+++ b/cosmic-helix/js/helix-renderer.mjs
@@ -1,0 +1,105 @@
+/*
+  helix-renderer.mjs
+  ND-safe static renderer for layered sacred geometry.
+
+  Layers:
+    1) Vesica field (intersecting circles)
+    2) Tree-of-Life scaffold (10 sephirot + 22 paths; simplified layout)
+    3) Fibonacci curve (log spiral polyline; static)
+    4) Double-helix lattice (two phase-shifted sine curves)
+
+  Rationale:
+    - no motion or flashing; everything rendered once
+    - muted palette for calm contrast
+    - numerology constants wire geometry to 3/7/9/11/22/33/99/144
+*/
+
+export function renderHelix(ctx, opts) {
+  const { width, height, palette, NUM } = opts;
+  ctx.fillStyle = palette.bg;
+  ctx.fillRect(0, 0, width, height);
+
+  drawVesicaField(ctx, width, height, palette.layers[0], NUM);
+  drawTreeOfLife(ctx, width, height, palette.layers[1], palette.layers[2], NUM);
+  drawFibonacci(ctx, width, height, palette.layers[3], NUM);
+  drawHelix(ctx, width, height, palette.layers[4], palette.layers[5], NUM);
+}
+
+function drawVesicaField(ctx, w, h, color, NUM) {
+  ctx.strokeStyle = color;
+  const radius = Math.min(w, h) / NUM.THREE; // ensures soft overlap
+  const step = radius / NUM.SEVEN; // grid density tuned by 7
+  for (let y = radius; y <= h - radius; y += step) {
+    for (let x = radius; x <= w - radius; x += step) {
+      ctx.beginPath();
+      ctx.arc(x, y, radius, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+  }
+}
+
+function drawTreeOfLife(ctx, w, h, nodeColor, pathColor, NUM) {
+  ctx.strokeStyle = pathColor;
+  ctx.lineWidth = 2;
+  const nodes = [];
+  const centerX = w / 2;
+  const topY = h / NUM.ELEVEN; // proportioned via 11
+  const verticalStep = (h - topY * 2) / NUM.NINE;
+  for (let i = 0; i < 10; i++) {
+    nodes.push({ x: centerX, y: topY + i * verticalStep });
+  }
+  // Draw paths (simple straight connections for ND-safety clarity)
+  nodes.forEach((a, i) => {
+    for (let j = i + 1; j < nodes.length; j++) {
+      if ((j - i) % NUM.THREE === 0 || (j - i) === 1) {
+        ctx.beginPath();
+        ctx.moveTo(a.x, a.y);
+        ctx.lineTo(nodes[j].x, nodes[j].y);
+        ctx.stroke();
+      }
+    }
+  });
+  // Nodes
+  ctx.fillStyle = nodeColor;
+  nodes.forEach((n) => {
+    ctx.beginPath();
+    ctx.arc(n.x, n.y, NUM.NINE / 3, 0, Math.PI * 2);
+    ctx.fill();
+  });
+}
+
+function drawFibonacci(ctx, w, h, color, NUM) {
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 2;
+  const fib = [1, 1];
+  while (fib.length < NUM.NINE) fib.push(fib[fib.length - 1] + fib[fib.length - 2]);
+  const scale = Math.min(w, h) / NUM.ONEFORTYFOUR; // golden curve size
+  let angle = 0;
+  let x = w / 2;
+  let y = h / 2;
+  ctx.beginPath();
+  ctx.moveTo(x, y);
+  fib.forEach((f) => {
+    angle += Math.PI / 2;
+    x += Math.cos(angle) * f * scale;
+    y += Math.sin(angle) * f * scale;
+    ctx.lineTo(x, y);
+  });
+  ctx.stroke();
+}
+
+function drawHelix(ctx, w, h, colorA, colorB, NUM) {
+  const midY = h / 2;
+  const amplitude = h / NUM.NINETYNINE * NUM.ELEVEN; // gentle vertical spread
+  const stepX = w / NUM.ONEFORTYFOUR;
+  ctx.lineWidth = 2;
+  for (let phase = 0; phase < 2; phase++) {
+    ctx.strokeStyle = phase === 0 ? colorA : colorB;
+    ctx.beginPath();
+    for (let x = 0; x <= w; x += stepX) {
+      const y = midY + amplitude * Math.sin((x / w) * NUM.THIRTYTHREE * Math.PI + phase * Math.PI);
+      if (x === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+    }
+    ctx.stroke();
+  }
+}


### PR DESCRIPTION
## Summary
- add standalone cosmic helix renderer with vesica, tree of life, fibonacci curve, and double helix layers
- document ND-safe offline usage and customizable palette

## Testing
- `/bin/sh scripts/run-check.sh` *(fails: Neither Node.js nor Deno is installed. Cannot run formatting checks.)*
- `/bin/sh scripts/run-tests.sh` *(fails: Neither Node.js nor Deno is installed. Please install one of them to run tests.)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8d49f874832885856f837288f22d