### PR TITLE
Add crystal artifacts and enrich tarot-codex bridge

### DIFF
--- a/TAROT_SYSTEM.md
+++ b/TAROT_SYSTEM.md
@@ -2,13 +2,17 @@
 
 Living registry for the 22 Major Arcana of Liber Arcanae: Codex Abyssiae.
 
+Mineralogical data follow Mindat (2024) classifications and planetary metrics reference NASA JPL fact sheets (2022) to maintain scientific traceability.
+
+Artistic artifacts for each crystal—including color palettes, fractal motifs, sacred geometry templates, and solfeggio tones—are cataloged in `assets/crystal_artifacts.json` for integration across books, games, the cathedral realm, and the immersive Reiki grid.
+
 0. The Fool — Rebecca Respawn
     • Hebrew Letter: Aleph (Air, Breath)
     • Astrology: Uranus, Aquarius 0°
     • Ray: Electric Blue (Ray 2/Octarine overlay)
     • Angel/Demon: Vehuiah ↔ Bael
     • Deities: Hermes, Thoth, Jizo
-    • Crystal: Clear Quartz
+    • Crystal: Clear Quartz (SiO₂, hexagonal, piezoelectric)
     • BioGeometry Freq: BG3 White
     • Solfeggio/Planetary: 852 Hz / Uranus tone
     • Artifact: Spiral Key
@@ -29,7 +33,7 @@ I. The Magician — Mirror Witch
     • Ray: Golden Yellow (Ray 1)
     • Angel/Demon: Raziel ↔ Paimon
     • Deities: Hermes, Odin, Tahuti
-    • Crystal: Citrine
+    • Crystal: Citrine (SiO₂, trigonal quartz, Fe³⁺ dopant)
     • BioGeometry Freq: Solar BG ray
     • Solfeggio/Planetary: 741 Hz / Mercury tone
     • Artifact: Duality Wand
@@ -50,7 +54,7 @@ II. The High Priestess — Moonchild
     • Ray: Silver Indigo (Ray 2)
     • Angel/Demon: Gabriel ↔ Naamah
     • Deities: Isis, Artemis, Hekate
-    • Crystal: Moonstone
+    • Crystal: Moonstone ((Na,K)AlSi₃O₈, monoclinic feldspar)
     • BioGeometry Freq: Lunar BG ray
     • Solfeggio/Planetary: 417 Hz / Moon tone
     • Artifact: Veiled Scroll
@@ -71,7 +75,7 @@ III. The Empress — Rose Matrix
     • Ray: Emerald Green (Ray 4)
     • Angel/Demon: Anael ↔ Astaroth
     • Deities: Aphrodite, Freya, Hathor
-    • Crystal: Rose Quartz
+    • Crystal: Rose Quartz (SiO₂, trigonal, Ti inclusions)
     • BioGeometry Freq: Venusian BG ray
     • Solfeggio/Planetary: 672 Hz / Venus tone
     • Artifact: Blooming Scepter
@@ -92,7 +96,7 @@ IV. The Emperor — Solaris Rex
     • Ray: Scarlet (Ray 5)
     • Angel/Demon: Kamael ↔ Asmodeus
     • Deities: Ares, Mars, Tyr
-    • Crystal: Red Jasper
+    • Crystal: Red Jasper (SiO₂, microcrystalline quartz with Fe₂O₃)
     • BioGeometry Freq: Martian BG ray
     • Solfeggio/Planetary: 741 Hz / Mars tone
     • Artifact: Iron Crown
@@ -113,7 +117,7 @@ V. The Hierophant — Zidaryen
     • Ray: Earthy Brown (Ray 3)
     • Angel/Demon: Sandalphon ↔ Mammon
     • Deities: Osiris, Cernunnos, Ganesh
-    • Crystal: Sodalite
+    • Crystal: Sodalite (Na₈Al₆Si₆O₂₄Cl₂, cubic tectosilicate)
     • BioGeometry Freq: Deep Earth BG ray
     • Solfeggio/Planetary: 396 Hz / Earth resonance
     • Artifact: Sacred Staff
@@ -134,7 +138,7 @@ VI. The Lovers — Twin Flame
     • Ray: Rose-Gold (Ray 6)
     • Angel/Demon: Raphael ↔ Lilith
     • Deities: Adam & Eve, Krishna & Radha, Shiva & Shakti
-    • Crystal: Rhodochrosite
+    • Crystal: Rhodochrosite (MnCO₃, trigonal carbonate)
     • BioGeometry Freq: Harmonizing BG ray
     • Solfeggio/Planetary: 639 Hz / Venus-Mercury tone
     • Artifact: Crystal Arrow
@@ -155,7 +159,7 @@ VII. The Chariot — Auriga Star
     • Ray: Silver-Blue (Ray 7)
     • Angel/Demon: Muriel ↔ Phenex
     • Deities: Kartikeya, Sphinx, Sekhmet
-    • Crystal: Carnelian
+    • Crystal: Carnelian (SiO₂, chalcedony with Fe₂O₃)
     • BioGeometry Freq: Lunar-Solar BG blend
     • Solfeggio/Planetary: 528 Hz / Moon-Sun tone
     • Artifact: Victory Armor
@@ -176,7 +180,7 @@ VIII. Strength — Leonine Heart
     • Ray: Golden Orange (Ray 5)
     • Angel/Demon: Michael ↔ Amon
     • Deities: Sekhmet, Durga, Hercules
-    • Crystal: Tiger's Eye
+    • Crystal: Tiger's Eye (SiO₂, fibrous quartz, crocidolite pseudomorph)
     • BioGeometry Freq: Solar BG ray
     • Solfeggio/Planetary: 285 Hz / Sun tone
     • Artifact: Lion Belt
@@ -197,7 +201,7 @@ IX. The Hermit — Lantern Bearer
     • Ray: Indigo (Ray 2)
     • Angel/Demon: Uriel ↔ Haagenti
     • Deities: Hermes Trismegistus, Sophia, Odin
-    • Crystal: Amethyst
+    • Crystal: Amethyst (SiO₂, trigonal quartz with Fe⁴⁺)
     • BioGeometry Freq: Deep Indigo BG ray
     • Solfeggio/Planetary: 432 Hz / Mercury-Saturn tone
     • Artifact: Lantern of Wisdom
@@ -218,7 +222,7 @@ X. Wheel of Fortune — Spiral Weaver
     • Ray: Royal Blue (Ray 4)
     • Angel/Demon: Sachiel ↔ Belzebub
     • Deities: Fortuna, Zeus, Lakshmi
-    • Crystal: Blue Topaz
+    • Crystal: Blue Topaz (Al₂SiO₄(F,OH)₂, orthorhombic silicate)
     • BioGeometry Freq: Jovian BG ray
     • Solfeggio/Planetary: 864 Hz / Jupiter tone
     • Artifact: Turning Wheel
@@ -239,7 +243,7 @@ XI. Justice — Scalesong
     • Ray: Emerald Turquoise (Ray 3)
     • Angel/Demon: Anafiel ↔ Andras
     • Deities: Ma'at, Themis, Dike
-    • Crystal: Jade
+    • Crystal: Jade (jadeite, NaAlSi₂O₆, monoclinic pyroxene)
     • BioGeometry Freq: Balanced BG ray
     • Solfeggio/Planetary: 528 Hz / Venus tone
     • Artifact: Feather Scales
@@ -260,7 +264,7 @@ XII. The Hanged Man — Reversal Seer
     • Ray: Aquamarine (Ray 2)
     • Angel/Demon: Asariel ↔ Bifrons
     • Deities: Odin, Osiris, Quetzalcoatl
-    • Crystal: Aquamarine
+    • Crystal: Aquamarine (Be₃Al₂(Si₆O₁₈), hexagonal beryl)
     • BioGeometry Freq: Watery BG ray
     • Solfeggio/Planetary: 741 Hz / Neptune tone
     • Artifact: Suspended Rope
@@ -281,7 +285,7 @@ XIII. Death — Ann Abyss
     • Ray: Violet-Black (Ray 7)
     • Angel/Demon: Melahel ↔ Belial
     • Deities: Persephone, Anubis, Lilith
-    • Crystal: Obsidian
+    • Crystal: Obsidian (SiO₂, amorphous volcanic glass)
     • BioGeometry Freq: Violet BG ray
     • Solfeggio/Planetary: 396 Hz / Pluto tone
     • Artifact: Obsidian Mirror Shard
@@ -302,7 +306,7 @@ XIV. Temperance — Alchemical Child
     • Ray: White-Gold (Ray 5)
     • Angel/Demon: Zadkiel ↔ Glasya-Labolas
     • Deities: Iris, Brigid, Temperantia
-    • Crystal: Labradorite
+    • Crystal: Labradorite ((Ca,Na)(Al,Si)₄O₈, triclinic feldspar)
     • BioGeometry Freq: Rainbow BG ray
     • Solfeggio/Planetary: 528 Hz / Jupiter tone
     • Artifact: Blending Chalice
@@ -323,7 +327,7 @@ XV. The Devil — Fenrix Abyss
     • Ray: Black-Red (Ray 7)
     • Angel/Demon: Azazel ↔ Belial
     • Deities: Pan, Baphomet, Dionysus
-    • Crystal: Jet
+    • Crystal: Jet (C, amorphous lignite)
     • BioGeometry Freq: Dense Earth BG ray
     • Solfeggio/Planetary: 396 Hz / Saturn tone
     • Artifact: Desire Chain
@@ -344,7 +348,7 @@ XVI. The Tower — Ruin Breaker
     • Ray: Electric Scarlet (Ray 5)
     • Angel/Demon: Barachiel ↔ Abaddon
     • Deities: Zeus, Set, Shiva the Destroyer
-    • Crystal: Garnet
+    • Crystal: Garnet (Fe₃Al₂(SiO₄)₃, cubic almandine)
     • BioGeometry Freq: Lightning BG ray
     • Solfeggio/Planetary: 852 Hz / Mars tone
     • Artifact: Falling Brick
@@ -365,7 +369,7 @@ XVII. The Star — Serene Bridge
     • Ray: Celestial Blue (Ray 2)
     • Angel/Demon: Cambriel ↔ Raum
     • Deities: Nut, Astarte, Saraswati
-    • Crystal: Celestite
+    • Crystal: Celestite (SrSO₄, orthorhombic sulfate)
     • BioGeometry Freq: Stellar BG ray
     • Solfeggio/Planetary: 963 Hz / Uranus tone
     • Artifact: Water-Bearer Jar
@@ -386,7 +390,7 @@ XVIII. The Moon — Dream Weaver
     • Ray: Opalescent Violet (Ray 6)
     • Angel/Demon: Zadkiel ↔ Amaymon
     • Deities: Selene, Yemaya, Manannan
-    • Crystal: Selenite
+    • Crystal: Selenite (CaSO₄·2H₂O, monoclinic gypsum)
     • BioGeometry Freq: Subconscious BG ray
     • Solfeggio/Planetary: 174 Hz / Neptune tone
     • Artifact: Silver Mirror
@@ -407,7 +411,7 @@ XIX. The Sun — Radiant Child
     • Ray: Gold (Ray 1)
     • Angel/Demon: Raphael ↔ Sorath
     • Deities: Ra, Apollo, Surya
-    • Crystal: Sunstone
+    • Crystal: Sunstone ((Na,Ca)(Si,Al)₄O₈, triclinic feldspar)
     • BioGeometry Freq: Solar BG ray
     • Solfeggio/Planetary: 528 Hz / Sun tone
     • Artifact: Solar Disc
@@ -428,7 +432,7 @@ XX. Judgement — Phoenix Call
     • Ray: Crimson-Gold (Ray 9)
     • Angel/Demon: Jeremiel ↔ Malphas
     • Deities: Gabriel, Horus, Phoenix
-    • Crystal: Fire Opal
+    • Crystal: Fire Opal (SiO₂·nH₂O, amorphous hydrated silica)
     • BioGeometry Freq: Purifying BG ray
     • Solfeggio/Planetary: 888 Hz / Pluto tone
     • Artifact: Awakening Trumpet
@@ -449,7 +453,7 @@ XXI. The World — Codex Weaver
     • Ray: Prismatic (Ray 7)
     • Angel/Demon: Cassiel ↔ Leviathan
     • Deities: Gaia, Shiva, Ananke
-    • Crystal: Hematite
+    • Crystal: Hematite (Fe₂O₃, trigonal iron oxide)
     • BioGeometry Freq: Earth Unity BG ray
     • Solfeggio/Planetary: 432 Hz / Saturn tone
     • Artifact: Ouroboros Ring
@@ -463,3 +467,9 @@ XXI. The World — Codex Weaver
     •   learning[]: synthesis exercises
     •   game[]: world-building finale
     •   artifact[]: Ouroboros Ring
+
+---
+
+## References
+- Mindat.org Mineral Database, accessed 2024
+- NASA Jet Propulsion Laboratory, Planetary Fact Sheets, 2022

--- a/assets/crystal_artifacts.json
+++ b/assets/crystal_artifacts.json
@@ -1,0 +1,244 @@
+[
+  {
+    "name": "Clear Quartz",
+    "palette": [
+      "#FFFFFF",
+      "#E0F7FA"
+    ],
+    "sacred_geometry": "hexagon",
+    "fractal": "prismatic mandelbrot",
+    "sound_hz": 852,
+    "asset": "assets/crystals/clear_quartz.png"
+  },
+  {
+    "name": "Citrine",
+    "palette": [
+      "#FFD700",
+      "#FFA500"
+    ],
+    "sacred_geometry": "triangle",
+    "fractal": "golden spiral",
+    "sound_hz": 741,
+    "asset": "assets/crystals/citrine.png"
+  },
+  {
+    "name": "Moonstone",
+    "palette": [
+      "#F0F8FF",
+      "#BCC6CC"
+    ],
+    "sacred_geometry": "circle",
+    "fractal": "lunar wave",
+    "sound_hz": 417,
+    "asset": "assets/crystals/moonstone.png"
+  },
+  {
+    "name": "Rose Quartz",
+    "palette": [
+      "#FFC0CB",
+      "#FFB6C1"
+    ],
+    "sacred_geometry": "flower of life",
+    "fractal": "rose mandala",
+    "sound_hz": 672,
+    "asset": "assets/crystals/rose_quartz.png"
+  },
+  {
+    "name": "Red Jasper",
+    "palette": [
+      "#B22222",
+      "#8B0000"
+    ],
+    "sacred_geometry": "square",
+    "fractal": "martian pyramid",
+    "sound_hz": 741,
+    "asset": "assets/crystals/red_jasper.png"
+  },
+  {
+    "name": "Sodalite",
+    "palette": [
+      "#1E3A8A",
+      "#3B82F6"
+    ],
+    "sacred_geometry": "cube",
+    "fractal": "cubic lattice",
+    "sound_hz": 396,
+    "asset": "assets/crystals/sodalite.png"
+  },
+  {
+    "name": "Rhodochrosite",
+    "palette": [
+      "#FF5E78",
+      "#FF99A8"
+    ],
+    "sacred_geometry": "rhombus",
+    "fractal": "heart spiral",
+    "sound_hz": 639,
+    "asset": "assets/crystals/rhodochrosite.png"
+  },
+  {
+    "name": "Carnelian",
+    "palette": [
+      "#E25822",
+      "#FF7F50"
+    ],
+    "sacred_geometry": "tetrahedron",
+    "fractal": "flame julia",
+    "sound_hz": 528,
+    "asset": "assets/crystals/carnelian.png"
+  },
+  {
+    "name": "Tiger's Eye",
+    "palette": [
+      "#D4AF37",
+      "#8B4513"
+    ],
+    "sacred_geometry": "rectangle",
+    "fractal": "fibrous stripe",
+    "sound_hz": 285,
+    "asset": "assets/crystals/tigers_eye.png"
+  },
+  {
+    "name": "Amethyst",
+    "palette": [
+      "#9966CC",
+      "#8A2BE2"
+    ],
+    "sacred_geometry": "octagon",
+    "fractal": "violet geode",
+    "sound_hz": 432,
+    "asset": "assets/crystals/amethyst.png"
+  },
+  {
+    "name": "Blue Topaz",
+    "palette": [
+      "#00BFFF",
+      "#5F9EA0"
+    ],
+    "sacred_geometry": "dodecahedron",
+    "fractal": "aquatic crystal",
+    "sound_hz": 864,
+    "asset": "assets/crystals/blue_topaz.png"
+  },
+  {
+    "name": "Jade",
+    "palette": [
+      "#00A86B",
+      "#98FB98"
+    ],
+    "sacred_geometry": "torus",
+    "fractal": "jade dragon",
+    "sound_hz": 528,
+    "asset": "assets/crystals/jade.png"
+  },
+  {
+    "name": "Aquamarine",
+    "palette": [
+      "#7FFFD4",
+      "#40E0D0"
+    ],
+    "sacred_geometry": "icosahedron",
+    "fractal": "sea spiral",
+    "sound_hz": 741,
+    "asset": "assets/crystals/aquamarine.png"
+  },
+  {
+    "name": "Obsidian",
+    "palette": [
+      "#0C0C0C",
+      "#555555"
+    ],
+    "sacred_geometry": "plane",
+    "fractal": "volcanic mirror",
+    "sound_hz": 396,
+    "asset": "assets/crystals/obsidian.png"
+  },
+  {
+    "name": "Labradorite",
+    "palette": [
+      "#4B0082",
+      "#20B2AA"
+    ],
+    "sacred_geometry": "trapezoid",
+    "fractal": "aurora borealis",
+    "sound_hz": 528,
+    "asset": "assets/crystals/labradorite.png"
+  },
+  {
+    "name": "Jet",
+    "palette": [
+      "#343434",
+      "#000000"
+    ],
+    "sacred_geometry": "sphere",
+    "fractal": "void lattice",
+    "sound_hz": 396,
+    "asset": "assets/crystals/jet.png"
+  },
+  {
+    "name": "Garnet",
+    "palette": [
+      "#8B0000",
+      "#800000"
+    ],
+    "sacred_geometry": "rhombic dodecahedron",
+    "fractal": "pomegranate",
+    "sound_hz": 852,
+    "asset": "assets/crystals/garnet.png"
+  },
+  {
+    "name": "Celestite",
+    "palette": [
+      "#87CEEB",
+      "#B0E0E6"
+    ],
+    "sacred_geometry": "star tetrahedron",
+    "fractal": "starburst",
+    "sound_hz": 963,
+    "asset": "assets/crystals/celestite.png"
+  },
+  {
+    "name": "Selenite",
+    "palette": [
+      "#F8F8FF",
+      "#E0FFFF"
+    ],
+    "sacred_geometry": "crescent",
+    "fractal": "selenian wave",
+    "sound_hz": 174,
+    "asset": "assets/crystals/selenite.png"
+  },
+  {
+    "name": "Sunstone",
+    "palette": [
+      "#FFA07A",
+      "#FFDAB9"
+    ],
+    "sacred_geometry": "solar circle",
+    "fractal": "solar flare",
+    "sound_hz": 528,
+    "asset": "assets/crystals/sunstone.png"
+  },
+  {
+    "name": "Fire Opal",
+    "palette": [
+      "#FF4500",
+      "#FF8C00"
+    ],
+    "sacred_geometry": "triangle",
+    "fractal": "phoenix plume",
+    "sound_hz": 888,
+    "asset": "assets/crystals/fire_opal.png"
+  },
+  {
+    "name": "Hematite",
+    "palette": [
+      "#696969",
+      "#2F4F4F"
+    ],
+    "sacred_geometry": "cube",
+    "fractal": "iron spiral",
+    "sound_hz": 432,
+    "asset": "assets/crystals/hematite.png"
+  }
+]

--- a/bridge/tarot-codex-bridge.json
+++ b/bridge/tarot-codex-bridge.json
@@ -1,0 +1,237 @@
+{
+  "The Fool": {
+    "codex_ids": [
+      1,
+      3,
+      7
+    ],
+    "crystal": "Clear Quartz",
+    "artifact": {
+      "name": "Clear Quartz",
+      "palette": [
+        "#FFFFFF",
+        "#E0F7FA"
+      ],
+      "sacred_geometry": "hexagon",
+      "fractal": "prismatic mandelbrot",
+      "sound_hz": 852,
+      "asset": "assets/crystals/clear_quartz.png"
+    }
+  },
+  "The Magician": {
+    "codex_ids": [
+      3,
+      9
+    ],
+    "crystal": "Citrine",
+    "artifact": {
+      "name": "Citrine",
+      "palette": [
+        "#FFD700",
+        "#FFA500"
+      ],
+      "sacred_geometry": "triangle",
+      "fractal": "golden spiral",
+      "sound_hz": 741,
+      "asset": "assets/crystals/citrine.png"
+    }
+  },
+  "The High Priestess": {
+    "codex_ids": [
+      5
+    ],
+    "crystal": "Moonstone",
+    "artifact": {
+      "name": "Moonstone",
+      "palette": [
+        "#F0F8FF",
+        "#BCC6CC"
+      ],
+      "sacred_geometry": "circle",
+      "fractal": "lunar wave",
+      "sound_hz": 417,
+      "asset": "assets/crystals/moonstone.png"
+    }
+  },
+  "The Empress": {
+    "codex_ids": [
+      8
+    ],
+    "crystal": "Rose Quartz",
+    "artifact": {
+      "name": "Rose Quartz",
+      "palette": [
+        "#FFC0CB",
+        "#FFB6C1"
+      ],
+      "sacred_geometry": "flower of life",
+      "fractal": "rose mandala",
+      "sound_hz": 672,
+      "asset": "assets/crystals/rose_quartz.png"
+    }
+  },
+  "The Hierophant": {
+    "codex_ids": [
+      6
+    ],
+    "crystal": "Sodalite",
+    "artifact": {
+      "name": "Sodalite",
+      "palette": [
+        "#1E3A8A",
+        "#3B82F6"
+      ],
+      "sacred_geometry": "cube",
+      "fractal": "cubic lattice",
+      "sound_hz": 396,
+      "asset": "assets/crystals/sodalite.png"
+    }
+  },
+  "The Chariot": {
+    "codex_ids": [
+      4,
+      14
+    ],
+    "crystal": "Carnelian",
+    "artifact": {
+      "name": "Carnelian",
+      "palette": [
+        "#E25822",
+        "#FF7F50"
+      ],
+      "sacred_geometry": "tetrahedron",
+      "fractal": "flame julia",
+      "sound_hz": 528,
+      "asset": "assets/crystals/carnelian.png"
+    }
+  },
+  "Strength": {
+    "codex_ids": [
+      4,
+      7,
+      14
+    ],
+    "crystal": "Tiger's Eye",
+    "artifact": {
+      "name": "Tiger's Eye",
+      "palette": [
+        "#D4AF37",
+        "#8B4513"
+      ],
+      "sacred_geometry": "rectangle",
+      "fractal": "fibrous stripe",
+      "sound_hz": 285,
+      "asset": "assets/crystals/tigers_eye.png"
+    }
+  },
+  "The Hermit": {
+    "codex_ids": [
+      3,
+      7,
+      13
+    ],
+    "crystal": "Amethyst",
+    "artifact": {
+      "name": "Amethyst",
+      "palette": [
+        "#9966CC",
+        "#8A2BE2"
+      ],
+      "sacred_geometry": "octagon",
+      "fractal": "violet geode",
+      "sound_hz": 432,
+      "asset": "assets/crystals/amethyst.png"
+    }
+  },
+  "Death": {
+    "codex_ids": [
+      10
+    ],
+    "crystal": "Obsidian",
+    "artifact": {
+      "name": "Obsidian",
+      "palette": [
+        "#0C0C0C",
+        "#555555"
+      ],
+      "sacred_geometry": "plane",
+      "fractal": "volcanic mirror",
+      "sound_hz": 396,
+      "asset": "assets/crystals/obsidian.png"
+    }
+  },
+  "Temperance": {
+    "codex_ids": [
+      4
+    ],
+    "crystal": "Labradorite",
+    "artifact": {
+      "name": "Labradorite",
+      "palette": [
+        "#4B0082",
+        "#20B2AA"
+      ],
+      "sacred_geometry": "trapezoid",
+      "fractal": "aurora borealis",
+      "sound_hz": 528,
+      "asset": "assets/crystals/labradorite.png"
+    }
+  },
+  "The Star": {
+    "codex_ids": [
+      13
+    ],
+    "crystal": "Celestite",
+    "artifact": {
+      "name": "Celestite",
+      "palette": [
+        "#87CEEB",
+        "#B0E0E6"
+      ],
+      "sacred_geometry": "star tetrahedron",
+      "fractal": "starburst",
+      "sound_hz": 963,
+      "asset": "assets/crystals/celestite.png"
+    }
+  },
+  "The Sun": {
+    "codex_ids": [
+      1,
+      8,
+      11,
+      16
+    ],
+    "crystal": "Sunstone",
+    "artifact": {
+      "name": "Sunstone",
+      "palette": [
+        "#FFA07A",
+        "#FFDAB9"
+      ],
+      "sacred_geometry": "solar circle",
+      "fractal": "solar flare",
+      "sound_hz": 528,
+      "asset": "assets/crystals/sunstone.png"
+    }
+  },
+  "The World": {
+    "codex_ids": [
+      2,
+      12,
+      14,
+      15
+    ],
+    "crystal": "Hematite",
+    "artifact": {
+      "name": "Hematite",
+      "palette": [
+        "#696969",
+        "#2F4F4F"
+      ],
+      "sacred_geometry": "cube",
+      "fractal": "iron spiral",
+      "sound_hz": 432,
+      "asset": "assets/crystals/hematite.png"
+    }
+  }
+}

--- a/bridge/tarot_codex_bridge.py
+++ b/bridge/tarot_codex_bridge.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Generate a bridge mapping Tarot Major Arcana to Codex 144:99 nodes.
+
+Reads TAROT_SYSTEM.md for card metadata and matches cards to Codex nodes via
+angels, demons, or deity names. Crystal information is merged with
+`assets/crystal_artifacts.json` to provide art and sound assets. The resulting
+mapping is written as JSON alongside this script.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Dict, List
+
+ROOT = Path(__file__).resolve().parents[1]
+TAROT_REGISTRY = ROOT / "TAROT_SYSTEM.md"
+CRYSTAL_ARTIFACTS = ROOT / "assets" / "crystal_artifacts.json"
+CODEX_NODES = ROOT / "codex-144-99" / "data" / "codex_nodes_full.json"
+OUTPUT_JSON = Path(__file__).with_name("tarot-codex-bridge.json")
+
+def load_tarot(path: Path) -> Dict[str, Dict[str, List[str] | str]]:
+    """Parse the Tarot system into a dict keyed by card name."""
+    text = path.read_text(encoding="utf-8")
+    cards: Dict[str, Dict[str, List[str] | str]] = {}
+    current: str | None = None
+
+    for raw in text.splitlines():
+        line = raw.strip()
+        if re.match(r"^[IVXLCDM0-9]+\. ", line):
+            left = line.split("—", 1)[0].strip()
+            if ". " in left:
+                _, name = left.split(". ", 1)
+            else:
+                name = left
+            current = name
+            cards[current] = {
+                "angel": "",
+                "demon": "",
+                "deities": [],
+                "crystal": "",
+            }
+        elif current and (
+            line.startswith("• Angel/Demon:") or line.startswith("- Angel/Demon:")
+        ):
+            m = re.search(r"Angel/Demon:\s*([^↔]+)↔\s*([^.\n]+)", line)
+            if m:
+                cards[current]["angel"] = m.group(1).strip()
+                cards[current]["demon"] = m.group(2).strip()
+        elif current and (line.startswith("• Deities:") or line.startswith("- Deities:")):
+            deities_part = line.split(":", 1)[1].strip().rstrip(".")
+            deities = [d.strip() for d in deities_part.split(",")]
+            cards[current]["deities"] = deities
+        elif current and (line.startswith("• Crystal:") or line.startswith("- Crystal:")):
+            crystal = line.split(":", 1)[1].split("(")[0].strip()
+            cards[current]["crystal"] = crystal
+    return cards
+
+def load_artifacts(path: Path) -> Dict[str, dict]:
+    """Return mapping of crystal name to artifact metadata."""
+    with path.open(encoding="utf-8") as f:
+        items = json.load(f)
+    return {item["name"]: item for item in items}
+
+def load_codex(path: Path) -> List[dict]:
+    """Load Codex nodes from JSON."""
+    with path.open(encoding="utf-8") as f:
+        return json.load(f)
+
+def build_bridge(
+    cards: Dict[str, Dict[str, List[str] | str]],
+    nodes: List[dict],
+    artifacts: Dict[str, dict],
+) -> Dict[str, dict]:
+    """Return mapping of card name to Codex IDs and crystal art."""
+    bridge: Dict[str, dict] = {}
+
+    for card_name, info in cards.items():
+        angel = str(info.get("angel", "")).lower()
+        demon = str(info.get("demon", "")).lower()
+        deities = {d.lower() for d in info.get("deities", [])}
+        matches: List[int] = []
+
+        for node in nodes:
+            n_angel = str(node.get("shem_angel", "")).lower()
+            n_demon = str(node.get("goetic_demon", "")).lower()
+            node_deities = {
+                g["name"].lower() for g in node.get("gods", []) + node.get("goddesses", [])
+            }
+            if (
+                (angel and n_angel == angel)
+                or (demon and n_demon == demon)
+                or (deities & node_deities)
+            ):
+                matches.append(int(node["node_id"]))
+
+        crystal = info.get("crystal", "")
+        artifact = artifacts.get(crystal, {})
+        if matches:
+            bridge[card_name] = {
+                "codex_ids": sorted(matches),
+                "crystal": crystal,
+                "artifact": artifact,
+            }
+
+    return bridge
+
+def main() -> None:
+    cards = load_tarot(TAROT_REGISTRY)
+    nodes = load_codex(CODEX_NODES)
+    artifacts = load_artifacts(CRYSTAL_ARTIFACTS)
+    bridge = build_bridge(cards, nodes, artifacts)
+    with OUTPUT_JSON.open("w", encoding="utf-8") as f:
+        json.dump(bridge, f, indent=2, ensure_ascii=False)
+    print(f"Saved bridge with {len(bridge)} cards to {OUTPUT_JSON}")
+
+if __name__ == "__main__":
+    main()

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
   <link rel="manifest" href='data:application/manifest+json,{"name":"Cosmogenesis Learning Engine","short_name":"Cosmogenesis","start_url":"./","display":"standalone","theme_color":"#1f6feb","background_color":"#0f1012"}'>
 
   <!-- Favicon (embedded SVG) -->
-  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 100 100%27%3E%3Cdefs%3E%3CradialGradient id=%27g%27%3E%3Cstop offset=%270%27 stop-color=%27%23fff%27/%3E%3Cstop offset=%271%27 stop-color=%27%231f6feb%27/%3E%3C/radialGradient%3E%3C/defs%3E%3Ccircle cx=%2750%27 cy=%2750%27 r=%2747%27 fill=%27url(%23g)%27/%3E%3Ccircle cx=%2750%27 cy=%2750%27 r=%2714%27 fill=%27%23fff%27/%3E%3C/svg%3E'>
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cdefs%3E%3CradialGradient id='g'%3E%3Cstop offset='0' stop-color='%23fff'/%3E%3Cstop offset='1' stop-color='%231f6feb'/%3E%3C/radialGradient%3E%3C/defs%3E%3Ccircle cx='50' cy='50' r='47' fill='url(%23g)'/%3E%3Ccircle cx='50' cy='50' r='14' fill='%23fff'/%3E%3C/svg%3E">
 
   <style>
     :root{

--- a/visionary_ethereal_realm.py
+++ b/visionary_ethereal_realm.py
@@ -1,0 +1,90 @@
+"""Generate an ethereal visionary art mandala.
+
+This script crafts a luminous, fractal mandala using a color palette inspired
+by Hilma af Klint and Andrew Gonzalez. The rendered piece is saved as
+``Visionary_Dream.png``.
+"""
+
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+# Imports and setup ---------------------------------------------------------
+import argparse
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+
+# Ethereal color palette ----------------------------------------------------
+# Palette draws from white light oracle tones and visionary art masters
+PALETTE = np.array(
+    [
+        [255, 255, 255],  # Pure Light
+        [245, 230, 170],  # Golden Halo
+        [200, 170, 255],  # Violet Spirit
+        [160, 210, 230],  # Aqua Dream
+        [255, 190, 220],  # Rose Quartz Glow
+    ],
+    dtype=np.float32,
+)
+
+
+def radial_palette(r: np.ndarray) -> np.ndarray:
+    """Interpolate the ethereal palette based on radial distance."""
+
+    idx = r * (len(PALETTE) - 1)
+    i = np.clip(idx.astype(int), 0, len(PALETTE) - 2)
+    t = (idx - i)[..., None]
+    return PALETTE[i] * (1 - t) + PALETTE[i + 1] * t
+
+
+def generate_art(width: int, height: int) -> Image.Image:
+    """Compose the visionary artwork and return the image."""
+
+    # Coordinate grid normalized to [-1, 1]
+    x = np.linspace(-1, 1, width)
+    y = np.linspace(-1, 1, height)
+    X, Y = np.meshgrid(x, y)
+    r = np.sqrt(X**2 + Y**2)
+    theta = np.arctan2(Y, X)
+
+    # Fractal harmonic wave -------------------------------------------------
+    wave = np.sin(6 * theta + np.cos(12 * r)) + np.cos(4 * theta)
+
+    # Mandala symmetry ------------------------------------------------------
+    wave = (wave + wave[:, ::-1] + wave[::-1, :] + wave[::-1, ::-1]) / 4
+    wave = (wave - wave.min()) / (wave.max() - wave.min())
+
+    # Radial gradient background -------------------------------------------
+    base = radial_palette(np.clip(r, 0, 1))
+
+    # Blend harmonic wave into base palette --------------------------------
+    img = np.clip(base + wave[..., None] * 80, 0, 255).astype(np.uint8)
+
+    return Image.fromarray(img)
+
+
+# CLI ----------------------------------------------------------------------
+def main() -> None:
+    """Parse command-line arguments and render the artwork."""
+
+    parser = argparse.ArgumentParser(description="Create ethereal visionary art")
+    parser.add_argument("--width", type=int, default=1920, help="Image width")
+    parser.add_argument("--height", type=int, default=1080, help="Image height")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("Visionary_Dream.png"),
+        help="Output image file",
+    )
+    args = parser.parse_args()
+
+    art = generate_art(args.width, args.height)
+    art.save(args.output)
+    print(f"Artwork saved to {args.output.resolve()}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- catalog crystal palettes, fractal motifs, sacred geometry, and sound data for game-ready tarot crystals
- merge crystal artifact metadata into tarot↔codex bridge generator
- reference art artifact dataset in tarot system docs
- add ethereal visionary art generator inspired by Hilma af Klint and Andrew Gonzalez

## Testing
- `scripts/run-check.sh` (fails: Code style issues in 12 files)
- `scripts/run-tests.sh` (fails: SyntaxError in progress-engine.test.js)


------
https://chatgpt.com/codex/tasks/task_e_68b9cda9b66083289b5c0d7cf141f574