### PR TITLE
Fix package.json structure for automated scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,14 @@
     "dev": "http-server -p 5173 -c-1 .",
     "start": "npm run dev",
     "preview": "http-server -p 8080 -c-1 .",
-    "test": "node --test",
+    "test": "./scripts/run-tests.sh",
     "fmt": "prettier -w .",
-    "check": "prettier -c ."
+    "check": "./scripts/run-check.sh",
+    "format": "prettier -w src/configLoader.js src/renderPlate.js plugins/soundscape.js test/*.js data/demos.json",
+    "generate:flame": "python3 scripts/generate_flame.py --out assets/flame/flame.png",
+    "generate:atlas": "python3 scripts/pillow_atlas.py --in assets/flame --out assets/flame/atlas.png",
+    "gallery:thumbs": "python3 scripts/pillow_thumbs.py --in exports --out exports/thumbs --size 512",
+    "postinstall": "echo \"Optional: pip install pillow numpy && npm i -D http-server prettier\""
   },
   "dependencies": {
     "ajv": "^8.17.1"
@@ -26,18 +31,6 @@
   "devDependencies": {
     "http-server": "^14.1.1",
     "prettier": "^3.4.2"
-    "build": "echo \"Static app -- no bundling required. Use 'Export SVG/PNG' in-app.\"",
-    "test": "./scripts/run-tests.sh",
-    "fmt": "prettier -w .",
-    "check": "prettier -c .",
-    "test": "node --test",
-    "format": "prettier -w src/configLoader.js src/renderPlate.js plugins/soundscape.js test/*.js data/demos.json",
-    "check": "prettier -c src/configLoader.js src/renderPlate.js plugins/soundscape.js test/*.js data/demos.json",
-    "check": "./scripts/run-check.sh",
-    "generate:flame": "python3 scripts/generate_flame.py --out assets/flame/flame.png",
-    "generate:atlas": "python3 scripts/pillow_atlas.py --in assets/flame --out assets/flame/atlas.png",
-    "gallery:thumbs": "python3 scripts/pillow_thumbs.py --in exports --out exports/thumbs --size 512",
-    "postinstall": "echo \"Optional: pip install pillow numpy && npm i -D http-server prettier\""
   },
   "keywords": [
     "cosmogenesis",
@@ -48,12 +41,5 @@
     "pillow",
     "svg",
     "png"
-  ],
-  "dependencies": {
-    "ajv": "^8.12.0"
-  },
-  "devDependencies": {
-    "http-server": "^14.1.1",
-    "prettier": "^3.3.3"
-  }
+  ]
 }


### PR DESCRIPTION
## Summary
- clean up `package.json` to deduplicate sections and move script definitions to `scripts`

## Testing
- `npm test` *(fails: Identifier 'test' has already been declared)*
- `npm run check` *(fails: Code style issues found in 17 files)*

------
https://chatgpt.com/codex/tasks/task_e_68bcad88e9a08328bc842d8686045f9f