### PR TITLE
refactor: stub schema validation and clean chamber engine tests

### DIFF
--- a/docs/WORLD_BUILDING_TASKS.md
+++ b/docs/WORLD_BUILDING_TASKS.md
@@ -1,0 +1,41 @@
+# World Building & Multi-Game Integration
+
+This document tracks the current state of the Cosmogenesis Learning Engine
+and outlines next steps for using it across multiple games and complex
+creative environments.
+
+## Completed Foundations
+- Cosmic Helix renderer: offline, ND-safe canvas sketch providing layered
+  geometry (vesica, Tree-of-Life, Fibonacci, helix).
+- Module loader (`src/remoteExperienceLoader.js`) can pull experiences from
+  external repositories.
+- Bridge configuration (`bridge/c99-bridge.json`) links this engine with the
+  **circuitum99** soul repository.
+- Plugin registry stubs exist under `plugins/` and `tests/` proving the engine
+  can discover optional features.
+
+## Current Repository Links
+- `circuitum99/` and `stone-grimoire/` directories mirror the soul and body
+  projects, allowing shared data and lore.
+- `bridge/` exposes JSON descriptors for cross-repo hand‑off.
+- `docs/repo_integration.md` describes how modules are discovered at runtime.
+
+## Multi‑Game Expansion Ideas
+- Treat each game world as a self‑contained module with its own schema and
+  assets; load modules dynamically via the existing registry system.
+- Use numerology constants (3,7,9,11,22,33,99,144) to keep geometry and lore
+  consistent across realms.
+- Provide a world‑building API so games can request canvas layers, NPC data,
+  or narrative seeds from this engine.
+- Store palettes, node maps, and quest templates in `/data` so other repos can
+  reuse them without network calls.
+
+## Outstanding Tasks
+- [ ] Finish schema files for style packs and provenance to validate incoming
+  modules.
+- [ ] Replace failing tests and convert remaining CommonJS tests to ESM.
+- [ ] Implement base engines (`spiral`, `chamber`, `art`, `sound`) as
+  documented in `TASKS.md`.
+- [ ] Create example world module demonstrating multi‑game hand‑off.
+- [ ] Document a minimal world‑building API in `docs/`.
+

--- a/engines/interface-guard.js
+++ b/engines/interface-guard.js
@@ -1,15 +1,21 @@
-// Validates incoming JSON against minimal interface schema; soft-fail to protect runtime.
-export async function validateInterface(payload, schemaUrl="/assets/data/interface.schema.json"){
-  try{
-    const [schema, AjvMod] = await Promise.all([
-      fetch(schemaUrl).then(r=>r.json()),
-      import("ajv").catch(async()=>{
-        const txt = await fetch("https://cdn.skypack.dev/ajv@8?min").then(r=>r.text());
-        return import(`data:text/javascript,${encodeURIComponent(txt)}`);
-      })
-    ]);
-    const ajv = new AjvMod.default({allErrors:true, strict:false});
-    const valid = ajv.validate(schema, payload);
-    return {valid, errors: ajv.errors||[]};
-  }catch(e){ return {valid:false, errors:[{message:e.message}]}; }
+// Validates incoming JSON against minimal interface schema.
+// ND-safe: avoids network requests and uses tiny built-in checks.
+export async function validateInterface(
+  payload,
+  schemaUrl = "/assets/data/interface.schema.json",
+) {
+  try {
+    const res = await fetch(schemaUrl);
+    if (!res.ok) throw new Error("schema fetch failed");
+    // Only ensure top-level required keys exist from schema.
+    const { required = [] } = await res.json();
+    for (const key of required) {
+      if (!(key in payload)) {
+        return { valid: false, errors: [{ message: `missing ${key}` }] };
+      }
+    }
+    return { valid: true, errors: [] };
+  } catch (e) {
+    return { valid: false, errors: [{ message: e.message }] };
+  }
 }

--- a/src/engines/chamber-engine.js
+++ b/src/engines/chamber-engine.js
@@ -1,12 +1,14 @@
+// Minimal chamber engine for tracking open rooms and payloads.
+// ND-safe: no animation, pure state container with soft defaults.
 export const chamberEngine = (() => {
   const openChambers = new Set();
   const payloads = new Map();
   let current = null;
 
   function openMultiple(ids = []) {
-    ids.forEach((id) => {
+    ids.forEach(id => {
       openChambers.add(id);
-      current = id;
+      current = id; // last opened becomes current
     });
   }
 
@@ -18,45 +20,6 @@ export const chamberEngine = (() => {
 
   function setPayload(id, data) {
     payloads.set(id, data);
-    ids.forEach(id => { openChambers.add(id); current = id; });
-  }
-  function closeAll() {
-    openChambers.clear(); payloads.clear(); current = null;
-class ChamberEngine extends EventTarget {
-  constructor() {
-    super();
-    this.current = null;
-    this.skin = null;
-    this.guardian = null;
-    this.payloads = new Map();
-    this.openChambers = new Set();
-  }
-
-  open(id) {
-    this.current = id;
-    this.openChambers.add(id);
-    this.dispatchEvent(new CustomEvent('chamber:open', { detail: id }));
-  }
-
-  openMultiple(ids = []) {
-    ids.forEach((id) => {
-      this.openChambers.add(id);
-      this.dispatchEvent(new CustomEvent('chamber:open', { detail: id }));
-    });
-    this.current = ids.at(-1) ?? this.current;
-  }
-
-  close(id) {
-    this.openChambers.delete(id);
-    if (this.current === id) {
-      this.current = null;
-    }
-    this.dispatchEvent(new CustomEvent('chamber:close', { detail: id }));
-  }
-
-  applySkin(skinId) {
-    this.skin = skinId;
-    this.dispatchEvent(new CustomEvent('skin:apply', { detail: skinId }));
   }
 
   function getPayload(id) {
@@ -69,6 +32,10 @@ class ChamberEngine extends EventTarget {
     }
   }
 
+  function currentChamber() {
+    return current;
+  }
+
   return {
     openMultiple,
     closeAll,
@@ -77,39 +44,6 @@ class ChamberEngine extends EventTarget {
     copyPayload,
     openChambers,
     payloads,
-    current: () => current,
+    current: currentChamber,
   };
-  setPayload(payload, id = this.current) {
-    if (id == null) return;
-    this.payloads.set(id, payload);
-    this.dispatchEvent(
-      new CustomEvent('payload:set', { detail: { id, payload } })
-    );
-  }
-
-  getPayload(id = this.current) {
-    return id == null ? undefined : this.payloads.get(id);
-  }
-
-  copyPayload(fromId, toId = this.current) {
-    const payload = this.getPayload(fromId);
-    if (payload !== undefined && toId != null) {
-      this.setPayload(payload, toId);
-    }
-    return payload;
-export const chamberEngine = (() => {
-  const openChambers = new Set();
-  const payloads = new Map();
-  let current = null;
-
-  function openMultiple(ids = []) {
-    ids.forEach(id => { openChambers.add(id); current = id; });
-  }
-  function closeAll() {
-    openChambers.clear(); payloads.clear(); current = null;
-  }
-  function setPayload(id, data) { payloads.set(id, data); }
-  function getPayload(id) { return payloads.get(id) ?? null; }
-
-  return { openMultiple, closeAll, openChambers, payloads, current: () => current, setPayload, getPayload };
 })();

--- a/test/chamber-engine.test.js
+++ b/test/chamber-engine.test.js
@@ -2,17 +2,21 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { chamberEngine } from '../src/engines/chamber-engine.js';
 
-test('chamber opens multiple and tracks current', () => {
+function reset() {
   chamberEngine.closeAll();
+}
+
+test('openMultiple registers chambers and sets current', () => {
+  reset();
   chamberEngine.openMultiple(['crypt', 'nave', 'garden']);
-  chamberEngine.openMultiple(['crypt','nave','garden']);
   assert.equal(chamberEngine.current(), 'garden');
   assert.ok(chamberEngine.openChambers.has('crypt'));
   assert.ok(chamberEngine.openChambers.has('nave'));
   assert.ok(chamberEngine.openChambers.has('garden'));
 });
 
-test('chamber payloads set/get and closeAll clears', () => {
+test('payload set/get and closeAll clears state', () => {
+  reset();
   chamberEngine.setPayload('crypt', { tone: 'C' });
   assert.deepEqual(chamberEngine.getPayload('crypt'), { tone: 'C' });
   chamberEngine.closeAll();
@@ -20,52 +24,10 @@ test('chamber payloads set/get and closeAll clears', () => {
   assert.equal(chamberEngine.getPayload('crypt'), null);
 });
 
-test('copyPayload duplicates payload between chambers', () => {
-  chamberEngine.closeAll();
+test('copyPayload duplicates existing payload', () => {
+  reset();
   chamberEngine.openMultiple(['alpha', 'beta']);
-  chamberEngine.setPayload('alpha', 'source data');
+  chamberEngine.setPayload('alpha', 'source');
   chamberEngine.copyPayload('alpha', 'beta');
-  assert.equal(chamberEngine.getPayload('beta'), 'source data');
-import assert from 'node:assert/strict';
-import { test } from 'node:test';
-import { chamberEngine } from '../src/engines/chamber-engine.js';
-
-const resetEngine = () => {
-  chamberEngine.openChambers.clear();
-  chamberEngine.payloads.clear();
-  chamberEngine.current = null;
-};
-
-test('openMultiple opens all chambers and sets current', () => {
-  resetEngine();
-  chamberEngine.openMultiple(['alpha', 'beta']);
-  assert.deepEqual([...chamberEngine.openChambers], ['alpha', 'beta']);
-  assert.equal(chamberEngine.current, 'beta');
-});
-
-test('copyPayload duplicates payload between chambers', () => {
-  resetEngine();
-  chamberEngine.openMultiple(['alpha', 'beta']);
-  chamberEngine.setPayload('source data', 'alpha');
-  chamberEngine.copyPayload('alpha', 'beta');
-  assert.equal(chamberEngine.getPayload('beta'), 'source data');
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
-import { chamberEngine } from '../src/engines/chamber-engine.js';
-
-test('chamber opens multiple and tracks current', () => {
-  chamberEngine.closeAll();
-  chamberEngine.openMultiple(['crypt','nave','garden']);
-  assert.equal(chamberEngine.current(), 'garden');
-  assert.ok(chamberEngine.openChambers.has('crypt'));
-  assert.ok(chamberEngine.openChambers.has('nave'));
-  assert.ok(chamberEngine.openChambers.has('garden'));
-});
-
-test('chamber payloads set/get and closeAll clears', () => {
-  chamberEngine.setPayload('crypt', { tone: 'C' });
-  assert.deepEqual(chamberEngine.getPayload('crypt'), { tone: 'C' });
-  chamberEngine.closeAll();
-  assert.equal(chamberEngine.current(), null);
-  assert.equal(chamberEngine.getPayload('crypt'), null);
+  assert.equal(chamberEngine.getPayload('beta'), 'source');
 });


### PR DESCRIPTION
## Summary
- replace brittle schema validation with tiny offline checker
- rebuild chamber engine and its tests for predictable state management

## Testing
- `node --test tests/interface.test.js`
- `node --test test/chamber-engine.test.js`
- `npm test` *(fails: 8 tests fail in unrelated suites)*
- `npm run check` *(fails: Prettier reports style issues in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc56d5e908328b926c059140b4eb6