### PR TITLE
Add tests for IndraNet and dataset loader

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,23 @@ circuitum99/
     # ✦ Cathedral of Circuits — Pull Request Checklist ✦
 
 Please confirm all items before merging.  
-This project follows **CONTRIBUTING.md** (Bot Contract).  
+This project follows **CONTRIBUTING.md** (Bot Contract).
 No GitHub Actions. ND-safe only.
+
+
+### 🧪 Offline Testing
+Run the smoke tests locally before opening a PR:
+
+```sh
+node tests/indranet.test.mjs
+node tests/dataset-loader.test.mjs
+```
+
+For Deno users:
+
+```sh
+deno run --allow-read --allow-net tests/dataset-loader.test.mjs
+```
 
 —
 

--- a/tests/dataset-loader.test.mjs
+++ b/tests/dataset-loader.test.mjs
@@ -1,0 +1,34 @@
+import { createServer } from "http";
+import { readFile } from "fs/promises";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+import { loadRegistry } from "../engines/registry-loader.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const palettePath = join(__dirname, "../data/palette.json");
+
+const server = createServer(async (req, res) => {
+  try {
+    const data = await readFile(palettePath);
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(data);
+  } catch (err) {
+    res.writeHead(500);
+    res.end(err.message);
+  }
+});
+server.listen(0);
+await new Promise(r => server.once("listening", r));
+const { port } = server.address();
+const url = `http://localhost:${port}/palette.json`;
+
+const palette = await loadRegistry(url);
+if (!palette.fuchs_palette) throw new Error("Palette load failed");
+
+globalThis.Deno = {};
+const palette2 = await loadRegistry(url);
+if (!palette2.fuchs_palette) throw new Error("Palette load failed under Deno");
+delete globalThis.Deno;
+
+server.close();
+console.log("Dataset loader palette OK");

--- a/tests/indranet.test.mjs
+++ b/tests/indranet.test.mjs
@@ -1,0 +1,45 @@
+import { IndraNet } from "../app/engines/IndraNet.js";
+
+// Minimal DOM stub so IndraNet can mount and render in Node
+function createElementNS(ns, tag) {
+  return {
+    tagName: tag,
+    attrs: {},
+    children: [],
+    style: {},
+    setAttribute(key, value) { this.attrs[key] = value; },
+    appendChild(child) { this.children.push(child); },
+    removeChild(child) {
+      const i = this.children.indexOf(child);
+      if (i >= 0) this.children.splice(i, 1);
+    },
+    get firstChild() { return this.children[0] || null; }
+  };
+}
+
+globalThis.document = { createElementNS };
+
+const container = {
+  children: [],
+  innerHTML: "",
+  appendChild(el) { this.children.push(el); }
+};
+
+const lattice = { rings: 2, nodes_per_ring: 3 };
+const net = new IndraNet({ showLinks: false, palette: { bg: "#123", node: "#fff", link: "#000" }, radius: 60, nodeSize: 5 });
+net.network = { lattice };
+
+net.mount(container).render();
+
+if (container.children.length !== 1) {
+  throw new Error("SVG container not mounted");
+}
+const svg = container.children[0];
+if (svg.style.background !== "#123") {
+  throw new Error("Palette background not applied");
+}
+if (svg.children.length !== lattice.rings * lattice.nodes_per_ring) {
+  throw new Error("Graph node count mismatch");
+}
+
+console.log("IndraNet graph construction OK");


### PR DESCRIPTION
## Summary
- add IndraNet graph construction test
- add dataset loader test with Deno simulation
- document local offline test commands

## Testing
- `node tests/indranet.test.mjs` (fails: SyntaxError in app/engines/IndraNet.js)
- `node tests/dataset-loader.test.mjs`
- `bash scripts/run-check.sh` (fails: Code style issues found in 19 files)


------
https://chatgpt.com/codex/tasks/task_e_68bcdc65a67c8328ad1fdd0f198ac04a