### PR TITLE
docs: add ND-safe style guide and format configs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,15 @@
+{
+  "env": {
+    "browser": true,
+    "node": true,
+    "es2022": true
+  },
+  "extends": ["eslint:recommended"],
+  "parserOptions": {
+    "sourceType": "module"
+  },
+  "rules": {
+    "no-unused-vars": "warn",
+    "no-undef": "error"
+  }
+}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "singleQuote": false,
+  "semi": true,
+  "printWidth": 80,
+  "tabWidth": 2
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,10 @@ This project is museum-grade and ND-safe. To keep contributions flowing smoothly
 
 —
 
+## Formatting
+- Run `npm run fmt` to format code with Prettier.
+- Run `npm run lint` to lint JavaScript.
+
 ## 1. Git Authentication (HTTPS + personal access tokens)
 
 We use **HTTPS with personal access tokens (PATs)** instead of SSH to simplify pushing workflow files.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -1,0 +1,18 @@
+# Style Guide
+
+This project is ND-safe and offline-first. All contributors must honor the following guidelines when writing code, data, or prose.
+
+## ND-Safe Constraints
+
+- **No motion or strobe**: avoid autoplay, flashing, or rapid transitions.
+- **Calm contrast**: use high readability colors and respect user preferences.
+- **Layered geometry**: preserve depth; do not flatten art sources.
+- **ASCII quotes, UTF-8, LF**: ensure files use standard quotes, UTF-8 encoding, and line feeds only.
+
+## Formatting
+
+- JavaScript and JSON are formatted with Prettier (`npm run fmt`).
+- Linting uses ESLint (`npm run lint`) with configs per submodule.
+- Small, pure functions with generous comments explaining design choices and ND-safe rationale.
+
+Follow this guide to keep the Cosmogenesis Learning Engine accessible and trauma-informed.

--- a/cosmic-helix/.eslintrc.json
+++ b/cosmic-helix/.eslintrc.json
@@ -1,0 +1,14 @@
+{
+  "env": {
+    "browser": true,
+    "es2022": true
+  },
+  "extends": ["eslint:recommended"],
+  "parserOptions": {
+    "sourceType": "module"
+  },
+  "rules": {
+    "no-console": "off",
+    "no-unused-vars": "warn"
+  }
+}

--- a/cosmic-helix/.prettierrc.json
+++ b/cosmic-helix/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "printWidth": 80,
+  "tabWidth": 2,
+  "htmlWhitespaceSensitivity": "ignore"
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "preview": "http-server -p 8080 -c-1 .",
     "test": "./scripts/run-tests.sh",
     "fmt": "prettier -w .",
+    "lint": "eslint .",
     "check": "./scripts/run-check.sh",
     "format": "prettier -w src/configLoader.js src/renderPlate.js plugins/soundscape.js test/*.js data/demos.json",
     "generate:flame": "python3 scripts/generate_flame.py --out assets/flame/flame.png",
@@ -30,6 +31,7 @@
   },
   "devDependencies": {
     "http-server": "^14.1.1",
+    "eslint": "^8.57.0",
     "prettier": "^3.4.2"
   },
   "keywords": [


### PR DESCRIPTION
## Summary
- document ND-safe conventions in new STYLE_GUIDE.md
- add ESLint and Prettier configs for root and cosmic-helix renderer
- note formatting commands in CONTRIBUTING

## Testing
- `npx prettier STYLE_GUIDE.md CONTRIBUTING.md package.json cosmic-helix/.eslintrc.json cosmic-helix/.prettierrc.json .eslintrc.json .prettierrc.json --check`
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: SyntaxError Identifier 'test' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_68bcdc6703088328965f5f077d0d4931