### PR TITLE
Refine Tree of Life layout with canonical paths

### DIFF
--- a/cosmic-helix/README_RENDERER.md
+++ b/cosmic-helix/README_RENDERER.md
@@ -6,7 +6,7 @@ Offline, ND-safe canvas sketch for layered sacred geometry.
 1. Open `index.html` in any modern browser (no server needed).
 2. A 1440×900 canvas will render four static layers:
    - **Vesica field** — intersecting circles forming the womb of forms.
-   - **Tree‑of‑Life scaffold** — ten sephirot with simple straight paths.
+   - **Tree‑of‑Life scaffold** — ten sephirot with twenty‑two straight paths.
    - **Fibonacci curve** — golden spiral polyline anchored to centre.
    - **Double‑helix lattice** — two phase‑shifted sine tracks.
 3. Palette can be customized in `data/palette.json`. If missing, a calm

--- a/cosmic-helix/js/helix-renderer.mjs
+++ b/cosmic-helix/js/helix-renderer.mjs
@@ -39,27 +39,55 @@ function drawVesicaField(ctx, w, h, color, NUM) {
 }
 
 function drawTreeOfLife(ctx, w, h, nodeColor, pathColor, NUM) {
+  // Simplified yet canonical layout: 10 nodes, 22 straight paths.
   ctx.strokeStyle = pathColor;
   ctx.lineWidth = 2;
-  const nodes = [];
-  const centerX = w / 2;
-  const topY = h / NUM.ELEVEN; // proportioned via 11
-  const verticalStep = (h - topY * 2) / NUM.NINE;
-  for (let i = 0; i < 10; i++) {
-    nodes.push({ x: centerX, y: topY + i * verticalStep });
-  }
-  // Draw paths (simple straight connections for ND-safety clarity)
-  nodes.forEach((a, i) => {
-    for (let j = i + 1; j < nodes.length; j++) {
-      if ((j - i) % NUM.THREE === 0 || (j - i) === 1) {
-        ctx.beginPath();
-        ctx.moveTo(a.x, a.y);
-        ctx.lineTo(nodes[j].x, nodes[j].y);
-        ctx.stroke();
-      }
-    }
+
+  const nodes = [
+    { x: w / 2, y: h * 0.05 }, // 0 Kether
+    { x: w * 0.25, y: h * 0.15 }, // 1 Chokmah
+    { x: w * 0.75, y: h * 0.15 }, // 2 Binah
+    { x: w * 0.25, y: h * 0.35 }, // 3 Chesed
+    { x: w * 0.75, y: h * 0.35 }, // 4 Geburah
+    { x: w / 2, y: h * 0.45 }, // 5 Tiphereth
+    { x: w * 0.25, y: h * 0.65 }, // 6 Netzach
+    { x: w * 0.75, y: h * 0.65 }, // 7 Hod
+    { x: w / 2, y: h * 0.75 }, // 8 Yesod
+    { x: w / 2, y: h * 0.9 }, // 9 Malkuth
+  ];
+
+  const paths = [
+    [0, 1],
+    [0, 2],
+    [0, 5],
+    [1, 2],
+    [1, 5],
+    [2, 5],
+    [1, 3],
+    [2, 4],
+    [3, 4],
+    [3, 5],
+    [4, 5],
+    [3, 6],
+    [4, 7],
+    [5, 6],
+    [5, 7],
+    [6, 7],
+    [6, 8],
+    [7, 8],
+    [5, 8],
+    [6, 9],
+    [7, 9],
+    [8, 9],
+  ];
+
+  paths.forEach(([a, b]) => {
+    ctx.beginPath();
+    ctx.moveTo(nodes[a].x, nodes[a].y);
+    ctx.lineTo(nodes[b].x, nodes[b].y);
+    ctx.stroke();
   });
-  // Nodes
+
   ctx.fillStyle = nodeColor;
   nodes.forEach((n) => {
     ctx.beginPath();
@@ -72,7 +100,8 @@ function drawFibonacci(ctx, w, h, color, NUM) {
   ctx.strokeStyle = color;
   ctx.lineWidth = 2;
   const fib = [1, 1];
-  while (fib.length < NUM.NINE) fib.push(fib[fib.length - 1] + fib[fib.length - 2]);
+  while (fib.length < NUM.NINE)
+    fib.push(fib[fib.length - 1] + fib[fib.length - 2]);
   const scale = Math.min(w, h) / NUM.ONEFORTYFOUR; // golden curve size
   let angle = 0;
   let x = w / 2;
@@ -90,15 +119,19 @@ function drawFibonacci(ctx, w, h, color, NUM) {
 
 function drawHelix(ctx, w, h, colorA, colorB, NUM) {
   const midY = h / 2;
-  const amplitude = h / NUM.NINETYNINE * NUM.ELEVEN; // gentle vertical spread
+  const amplitude = (h / NUM.NINETYNINE) * NUM.ELEVEN; // gentle vertical spread
   const stepX = w / NUM.ONEFORTYFOUR;
   ctx.lineWidth = 2;
   for (let phase = 0; phase < 2; phase++) {
     ctx.strokeStyle = phase === 0 ? colorA : colorB;
     ctx.beginPath();
     for (let x = 0; x <= w; x += stepX) {
-      const y = midY + amplitude * Math.sin((x / w) * NUM.THIRTYTHREE * Math.PI + phase * Math.PI);
-      if (x === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+      const y =
+        midY +
+        amplitude *
+          Math.sin((x / w) * NUM.THIRTYTHREE * Math.PI + phase * Math.PI);
+      if (x === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
     }
     ctx.stroke();
   }


### PR DESCRIPTION
## Summary
- Redefine Tree-of-Life scaffold with canonical 10 sephirot and 22 static paths
- Document twenty-two-path scaffold in renderer README

## Testing
- `npm test` *(fails: Identifier 'test' has already been declared)*
- `npx prettier --check cosmic-helix/index.html cosmic-helix/js/helix-renderer.mjs cosmic-helix/README_RENDERER.md cosmic-helix/data/palette.json`

------
https://chatgpt.com/codex/tasks/task_e_68bcdee63860832891b92d5db35f46bc