### PR TITLE
docs(renderer): clarify ND-safe layer rationale

### DIFF
--- a/helix/js/helix-renderer.mjs
+++ b/helix/js/helix-renderer.mjs
@@ -6,6 +6,7 @@
 */
 
 // Draw vesica field (intersecting circles forming gentle grid)
+// ND-safe: thin strokes and no fills keep the field calm and non-flickering.
 function drawVesica(ctx, w, h, color, NUM) {
   const r = Math.min(w, h) / NUM.THREE; // radius tuned by numerology 3
   const cx = w / 2;
@@ -27,6 +28,7 @@ function drawVesica(ctx, w, h, color, NUM) {
 }
 
 // Draw Tree-of-Life nodes and connecting paths
+// ND-safe: static scaffold with modest node size for clarity without overwhelm.
 function drawTree(ctx, w, h, colorNode, colorPath, NUM) {
   const nodes = [
     { x:0.5, y:0.06 }, // Kether
@@ -61,6 +63,7 @@ function drawTree(ctx, w, h, colorNode, colorPath, NUM) {
 }
 
 // Draw static Fibonacci spiral as polyline
+// ND-safe: fixed sample step yields smooth curve with zero runtime motion.
 function drawFibonacci(ctx, w, h, color, NUM) {
   const phi = (1 + Math.sqrt(5)) / 2; // golden ratio
   const c = Math.min(w, h) / NUM.ONEFORTYFOUR; // base radius tied to 144
@@ -80,6 +83,7 @@ function drawFibonacci(ctx, w, h, color, NUM) {
 }
 
 // Draw static double helix lattice
+// ND-safe: sine waves are computed once; rungs add depth without kinetic energy.
 function drawHelix(ctx, w, h, colors, NUM) {
   const amp = w / NUM.ELEVEN; // amplitude using 11
   const freq = (2 * Math.PI) / (h / NUM.TWENTYTWO); // wave frequency with 22
@@ -94,7 +98,7 @@ function drawHelix(ctx, w, h, colors, NUM) {
     }
     ctx.stroke();
   }
-  // lattice rungs every 18 (9*2) pixels
+  // lattice rungs every 18 (9*2) pixels to maintain calm rhythm
   ctx.strokeStyle = colors[2] || colors[0];
   for (let y = 0; y <= h; y += NUM.NINE * 2) {
     const x1 = w / 2 + amp * Math.sin(freq * y);


### PR DESCRIPTION
## Summary
- document ND-safe choices for vesica, tree, Fibonacci, and helix layers in `helix-renderer.mjs`

## Testing
- `npm test` *(fails: Identifier 'test' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_68bce0564a788328a824e747fd2f2640