### PR TITLE
refactor: expose numerology constants

### DIFF
--- a/cosmic-helix/README_RENDERER.md
+++ b/cosmic-helix/README_RENDERER.md
@@ -17,6 +17,8 @@ Offline, ND-safe canvas sketch for layered sacred geometry.
 - Muted colors and generous spacing improve readability in dark and light modes.
 - Geometry routines use numerology constants (3,7,9,11,22,33,99,144) to honour
   project canon.
+- Numerology constants are exported as `NUM` from the renderer module so other
+  scripts can share the same symbolic values.
 - Code is modular ES module (`js/helix-renderer.mjs`) with pure functions and
   ASCII quotes only.
 

--- a/cosmic-helix/index.html
+++ b/cosmic-helix/index.html
@@ -26,7 +26,7 @@
   <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
 
   <script type="module">
-    import { renderHelix } from "./js/helix-renderer.mjs";
+    import { renderHelix, NUM } from "./js/helix-renderer.mjs";
 
     const elStatus = document.getElementById("status");
     const canvas = document.getElementById("stage");
@@ -53,9 +53,6 @@
     const palette = await loadJSON("./data/palette.json");
     const active = palette || defaults.palette;
     elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
-
-    // Numerology constants used by geometry routines
-    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
 
     // ND-safe rationale: no motion, high readability, soft colors, layered order
     renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });

--- a/cosmic-helix/js/helix-renderer.mjs
+++ b/cosmic-helix/js/helix-renderer.mjs
@@ -14,21 +14,32 @@
     - numerology constants wire geometry to 3/7/9/11/22/33/99/144
 */
 
+export const NUM = Object.freeze({
+  THREE: 3,
+  SEVEN: 7,
+  NINE: 9,
+  ELEVEN: 11,
+  TWENTYTWO: 22,
+  THIRTYTHREE: 33,
+  NINETYNINE: 99,
+  ONEFORTYFOUR: 144,
+});
+
 export function renderHelix(ctx, opts) {
-  const { width, height, palette, NUM } = opts;
+  const { width, height, palette, NUM: N = NUM } = opts;
   ctx.fillStyle = palette.bg;
   ctx.fillRect(0, 0, width, height);
 
-  drawVesicaField(ctx, width, height, palette.layers[0], NUM);
-  drawTreeOfLife(ctx, width, height, palette.layers[1], palette.layers[2], NUM);
-  drawFibonacci(ctx, width, height, palette.layers[3], NUM);
-  drawHelix(ctx, width, height, palette.layers[4], palette.layers[5], NUM);
+  drawVesicaField(ctx, width, height, palette.layers[0], N);
+  drawTreeOfLife(ctx, width, height, palette.layers[1], palette.layers[2], N);
+  drawFibonacci(ctx, width, height, palette.layers[3], N);
+  drawHelix(ctx, width, height, palette.layers[4], palette.layers[5], N);
 }
 
-function drawVesicaField(ctx, w, h, color, NUM) {
+function drawVesicaField(ctx, w, h, color, N) {
   ctx.strokeStyle = color;
-  const radius = Math.min(w, h) / NUM.THREE; // ensures soft overlap
-  const step = radius / NUM.SEVEN; // grid density tuned by 7
+  const radius = Math.min(w, h) / N.THREE; // ensures soft overlap
+  const step = radius / N.SEVEN; // grid density tuned by 7
   for (let y = radius; y <= h - radius; y += step) {
     for (let x = radius; x <= w - radius; x += step) {
       ctx.beginPath();
@@ -38,20 +49,20 @@ function drawVesicaField(ctx, w, h, color, NUM) {
   }
 }
 
-function drawTreeOfLife(ctx, w, h, nodeColor, pathColor, NUM) {
+function drawTreeOfLife(ctx, w, h, nodeColor, pathColor, N) {
   ctx.strokeStyle = pathColor;
   ctx.lineWidth = 2;
   const nodes = [];
   const centerX = w / 2;
-  const topY = h / NUM.ELEVEN; // proportioned via 11
-  const verticalStep = (h - topY * 2) / NUM.NINE;
+  const topY = h / N.ELEVEN; // proportioned via 11
+  const verticalStep = (h - topY * 2) / N.NINE;
   for (let i = 0; i < 10; i++) {
     nodes.push({ x: centerX, y: topY + i * verticalStep });
   }
   // Draw paths (simple straight connections for ND-safety clarity)
   nodes.forEach((a, i) => {
     for (let j = i + 1; j < nodes.length; j++) {
-      if ((j - i) % NUM.THREE === 0 || j - i === 1) {
+      if ((j - i) % N.THREE === 0 || j - i === 1) {
         ctx.beginPath();
         ctx.moveTo(a.x, a.y);
         ctx.lineTo(nodes[j].x, nodes[j].y);
@@ -63,18 +74,17 @@ function drawTreeOfLife(ctx, w, h, nodeColor, pathColor, NUM) {
   ctx.fillStyle = nodeColor;
   nodes.forEach((n) => {
     ctx.beginPath();
-    ctx.arc(n.x, n.y, NUM.NINE / 3, 0, Math.PI * 2);
+    ctx.arc(n.x, n.y, N.NINE / 3, 0, Math.PI * 2);
     ctx.fill();
   });
 }
 
-function drawFibonacci(ctx, w, h, color, NUM) {
+function drawFibonacci(ctx, w, h, color, N) {
   ctx.strokeStyle = color;
   ctx.lineWidth = 2;
   const fib = [1, 1];
-  while (fib.length < NUM.NINE)
-    fib.push(fib[fib.length - 1] + fib[fib.length - 2]);
-  const scale = Math.min(w, h) / NUM.ONEFORTYFOUR; // golden curve size
+  while (fib.length < N.NINE) fib.push(fib[fib.length - 1] + fib[fib.length - 2]);
+  const scale = Math.min(w, h) / N.ONEFORTYFOUR; // golden curve size
   let angle = 0;
   let x = w / 2;
   let y = h / 2;
@@ -89,10 +99,10 @@ function drawFibonacci(ctx, w, h, color, NUM) {
   ctx.stroke();
 }
 
-function drawHelix(ctx, w, h, colorA, colorB, NUM) {
+function drawHelix(ctx, w, h, colorA, colorB, N) {
   const midY = h / 2;
-  const amplitude = (h / NUM.NINETYNINE) * NUM.ELEVEN; // gentle vertical spread
-  const stepX = w / NUM.ONEFORTYFOUR;
+  const amplitude = (h / N.NINETYNINE) * N.ELEVEN; // gentle vertical spread
+  const stepX = w / N.ONEFORTYFOUR;
   ctx.lineWidth = 2;
   for (let phase = 0; phase < 2; phase++) {
     ctx.strokeStyle = phase === 0 ? colorA : colorB;
@@ -101,7 +111,7 @@ function drawHelix(ctx, w, h, colorA, colorB, NUM) {
       const y =
         midY +
         amplitude *
-          Math.sin((x / w) * NUM.THIRTYTHREE * Math.PI + phase * Math.PI);
+          Math.sin((x / w) * N.THIRTYTHREE * Math.PI + phase * Math.PI);
       if (x === 0) ctx.moveTo(x, y);
       else ctx.lineTo(x, y);
     }

--- a/docs/helix/README_RENDERER.md
+++ b/docs/helix/README_RENDERER.md
@@ -13,6 +13,8 @@ Static HTML + Canvas renderer for layered sacred geometry.
 - Palette is read from `data/palette.json`; if missing, index.html falls back to a soft default.
 - Color choices favor calm contrast. Geometry uses numerology constants 3,7,9,11,22,33,99,144.
 
+Numerology constants are exported as `NUM` from the renderer module for reuse in other scripts.
+
 ## References
 - [@lawlor1982]
 

--- a/docs/helix/index.html
+++ b/docs/helix/index.html
@@ -26,7 +26,7 @@
   <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
 
   <script type="module">
-    import { renderHelix } from "./js/helix-renderer.mjs";
+    import { renderHelix, NUM } from "./js/helix-renderer.mjs";
 
     const elStatus = document.getElementById("status");
     const canvas = document.getElementById("stage");
@@ -53,9 +53,6 @@
     const palette = await loadJSON("./data/palette.json");
     const active = palette || defaults.palette;
     elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
-
-    // Numerology constants used by geometry routines
-    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
 
     // ND-safe rationale: no motion, high readability, soft colors, layered order
     renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });

--- a/docs/helix/js/helix-renderer.mjs
+++ b/docs/helix/js/helix-renderer.mjs
@@ -14,8 +14,19 @@
   numerology values to echo the codex alignment.
 */
 
+export const NUM = Object.freeze({
+  THREE: 3,
+  SEVEN: 7,
+  NINE: 9,
+  ELEVEN: 11,
+  TWENTYTWO: 22,
+  THIRTYTHREE: 33,
+  NINETYNINE: 99,
+  ONEFORTYFOUR: 144,
+});
+
 export function renderHelix(ctx, opts) {
-  const { width, height, palette, NUM } = opts;
+  const { width, height, palette, NUM: N = NUM } = opts;
   ctx.save();
   ctx.clearRect(0, 0, width, height);
   ctx.fillStyle = palette.bg;
@@ -24,8 +35,8 @@ export function renderHelix(ctx, opts) {
   drawVesica(ctx, width, height, palette.layers[0]);
   const tree = layoutTree(width, height);
   drawTree(ctx, tree, palette.layers[1], palette.layers[2]);
-  drawFibonacci(ctx, width / 2, height / 2, Math.min(width, height) / NUM.TWENTYTWO, palette.layers[3], NUM.NINETYNINE);
-  drawHelix(ctx, width, height, palette.layers[4], palette.layers[5], NUM.THIRTYTHREE, NUM.SEVEN);
+  drawFibonacci(ctx, width / 2, height / 2, Math.min(width, height) / N.TWENTYTWO, palette.layers[3], N.NINETYNINE);
+  drawHelix(ctx, width, height, palette.layers[4], palette.layers[5], N.THIRTYTHREE, N.SEVEN);
   ctx.restore();
 }
 

--- a/helix/README_RENDERER.md
+++ b/helix/README_RENDERER.md
@@ -17,6 +17,9 @@ Offline-only canvas demo. Encodes a four-layer cosmology without motion.
 Geometry parameters lean on symbolic numbers:
 3, 7, 9, 11, 22, 33, 99, and 144.
 
+Numerology constants are exported as `NUM` from `js/helix-renderer.mjs` so
+other scripts may reuse them.
+
 ## Develop
 No tooling required. Files:
 - `index.html`

--- a/helix/index.html
+++ b/helix/index.html
@@ -26,7 +26,7 @@
   <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
 
   <script type="module">
-    import { renderHelix } from "./js/helix-renderer.mjs";
+    import { renderHelix, NUM } from "./js/helix-renderer.mjs";
 
     const elStatus = document.getElementById("status");
     const canvas = document.getElementById("stage");
@@ -53,9 +53,6 @@
     const palette = await loadJSON("./data/palette.json");
     const active = palette || defaults.palette;
     elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
-
-    // Numerology constants used by geometry routines
-    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
 
     // ND-safe rationale: no motion, high readability, soft colors, layered order
     renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });

--- a/helix/js/helix-renderer.mjs
+++ b/helix/js/helix-renderer.mjs
@@ -5,9 +5,20 @@
   Geometry scales parameterized by numerology constants 3,7,9,11,22,33,99,144.
 */
 
+export const NUM = Object.freeze({
+  THREE: 3,
+  SEVEN: 7,
+  NINE: 9,
+  ELEVEN: 11,
+  TWENTYTWO: 22,
+  THIRTYTHREE: 33,
+  NINETYNINE: 99,
+  ONEFORTYFOUR: 144,
+});
+
 // Draw vesica field (intersecting circles forming gentle grid)
-function drawVesica(ctx, w, h, color, NUM) {
-  const r = Math.min(w, h) / NUM.THREE; // radius tuned by numerology 3
+function drawVesica(ctx, w, h, color, N) {
+  const r = Math.min(w, h) / N.THREE; // radius tuned by numerology 3
   const cx = w / 2;
   const cy = h / 2;
   ctx.strokeStyle = color;
@@ -27,7 +38,7 @@ function drawVesica(ctx, w, h, color, NUM) {
 }
 
 // Draw Tree-of-Life nodes and connecting paths
-function drawTree(ctx, w, h, colorNode, colorPath, NUM) {
+function drawTree(ctx, w, h, colorNode, colorPath, N) {
   const nodes = [
     { x: 0.5, y: 0.06 }, // Kether
     { x: 0.35, y: 0.18 },
@@ -71,18 +82,18 @@ function drawTree(ctx, w, h, colorNode, colorPath, NUM) {
   ctx.fillStyle = colorNode;
   for (const n of nodes) {
     ctx.beginPath();
-    ctx.arc(n.x, n.y, NUM.SEVEN / 2, 0, Math.PI * 2); // node size tuned by 7
+    ctx.arc(n.x, n.y, N.SEVEN / 2, 0, Math.PI * 2); // node size tuned by 7
     ctx.fill();
   }
 }
 
 // Draw static Fibonacci spiral as polyline
-function drawFibonacci(ctx, w, h, color, NUM) {
+function drawFibonacci(ctx, w, h, color, N) {
   const phi = (1 + Math.sqrt(5)) / 2; // golden ratio
-  const c = Math.min(w, h) / NUM.ONEFORTYFOUR; // base radius tied to 144
+  const c = Math.min(w, h) / N.ONEFORTYFOUR; // base radius tied to 144
   const center = { x: w * 0.8, y: h * 0.2 };
   const pts = [];
-  for (let t = 0; t <= NUM.THIRTYTHREE; t += 0.1) {
+  for (let t = 0; t <= N.THIRTYTHREE; t += 0.1) {
     // 0..33 radians
     const r = c * Math.pow(phi, t / (Math.PI / 2));
     const x = center.x + r * Math.cos(t);
@@ -99,9 +110,9 @@ function drawFibonacci(ctx, w, h, color, NUM) {
 }
 
 // Draw static double helix lattice
-function drawHelix(ctx, w, h, colors, NUM) {
-  const amp = w / NUM.ELEVEN; // amplitude using 11
-  const freq = (2 * Math.PI) / (h / NUM.TWENTYTWO); // wave frequency with 22
+function drawHelix(ctx, w, h, colors, N) {
+  const amp = w / N.ELEVEN; // amplitude using 11
+  const freq = (2 * Math.PI) / (h / N.TWENTYTWO); // wave frequency with 22
   ctx.lineWidth = 1.5;
   for (let i = 0; i < 2; i++) {
     const phase = i * Math.PI;
@@ -115,7 +126,7 @@ function drawHelix(ctx, w, h, colors, NUM) {
   }
   // lattice rungs every 18 (9*2) pixels
   ctx.strokeStyle = colors[2] || colors[0];
-  for (let y = 0; y <= h; y += NUM.NINE * 2) {
+  for (let y = 0; y <= h; y += N.NINE * 2) {
     const x1 = w / 2 + amp * Math.sin(freq * y);
     const x2 = w / 2 + amp * Math.sin(freq * y + Math.PI);
     ctx.beginPath();
@@ -126,12 +137,12 @@ function drawHelix(ctx, w, h, colors, NUM) {
 }
 
 export function renderHelix(ctx, opts) {
-  const { width: w, height: h, palette, NUM } = opts;
+  const { width: w, height: h, palette, NUM: N = NUM } = opts;
   ctx.fillStyle = palette.bg;
   ctx.fillRect(0, 0, w, h);
   // Layer order ensures depth without motion
-  drawVesica(ctx, w, h, palette.layers[0], NUM); // L1
-  drawTree(ctx, w, h, palette.layers[1], palette.layers[2], NUM); // L2
-  drawFibonacci(ctx, w, h, palette.layers[3], NUM); // L3
-  drawHelix(ctx, w, h, palette.layers.slice(4), NUM); // L4
+  drawVesica(ctx, w, h, palette.layers[0], N); // L1
+  drawTree(ctx, w, h, palette.layers[1], palette.layers[2], N); // L2
+  drawFibonacci(ctx, w, h, palette.layers[3], N); // L3
+  drawHelix(ctx, w, h, palette.layers.slice(4), N); // L4
 }


### PR DESCRIPTION
## Summary
- export shared numerology constants for helix renderer
- import NUM in static renderer HTML and update docs

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bde7b099008328b3051a1ec34c6e0b