### PR TITLE
feat: add duplicate line guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,80 +32,6 @@ npm run dev     # serves at http://localhost:5173
 npm test        # uses Node.js or Deno if available
 ```
 
-# User-provided custom instructions
-
-Codex-style” prompt template for visionary art
-You are an expert generative artist. Produce a museum-quality piece of visionary art using [LANGUAGE/LIBRARY].
-Requirements:
-- Complete runnable code with all imports and setup.
-- Comment each major step.
-- Use color palettes inspired by [ARTISTIC INSPIRATION, e.g., Alex Grey or surrealism].
-- Resolution: [WIDTH]x[HEIGHT].
-- Output should render/save an image titled "Visionary_Dream.png".
-Return the code block only, no explanation.
-Tips for museum-quality, visionary art output
-Inspiration reference: Specify artists, movements, or themes (e.g., “visionary geometry,” “psychedelic mandalas”) to guide style.
-
-Color & composition: Ask for layered gradients, symmetry, or organic patterns to evoke a gallery-grade piece.
-`bash
-pi```bash
-pip install -r requirements.txt
-python visionary_dream.py --width 1280 --height 720
-```
-
-The script outputs `Visionary_Dream.png`.
-y: Request “descriptive comments” so the script reads like a curated artwork.
-
-Final checklist
-✅ Prompt requests full runnable code.
-
-✅ Language and libraries are stated.
-
-✅ Triple backticks with language tag.
-
-✅ Style and artistic requirements clearly described.
-# Cosmogenesis Learning Engine (Alpha 0.9.2)
-Cosmogenesis is a portable plate engine for your Cathedral of Circuits. It renders an ND-safe spiral teacher with:
->>>>>>> Stashed changes
-- **Ladder toggle (33 vertebrae)** for the 33-spine mythic map
-- **PNG export** for art plates
-- **META export** with provenance (SHA-256 of config)
-- **Reduced-motion respect** (no wobble when OS requests it)
-
-## Quickstart
-```bash
-npm i
-npm run dev     # serves at http://localhost:5173
-# open /cosmogenesis/index.html
-npm test        # node --test
-```
-
-# User-provided custom instructions
-
-Codex-style” prompt template for visionary art
-You are an expert generative artist. Produce a museum-quality piece of visionary art using [LANGUAGE/LIBRARY].
-Requirements:
-- Complete runnable code with all imports and setup.
-- Comment each major step.
-- Use color palettes inspired by [ARTISTIC INSPIRATION, e.g., Alex Grey or surrealism].
-- Resolution: [WIDTH]x[HEIGHT].
-- Output should render/save an image titled "Visionary_Dream.png".
-Return the code block only, no explanation.
-Tips for museum-quality, visionary art output
-Inspiration reference: Specify artists, movements, or themes (e.g., “visionary geometry,” “psychedelic mandalas”) to guide style.
-
-Color & composition: Ask for layered gradients, symmetry, or organic patterns to evoke a gallery-grade piece.
-`bash
-pi```bash
-pip install -r requirements.txt
-python visionary_dream.py --width 1280 --height 720
-```
-
-The script outputs `Visionary_Dream.png`.
-y: Request “descriptive comments” so the script reads like a curated artwork.
-
-Final checklist
-✅ Prompt requests full runnable code.
 ### Testing Without Node.js
 
 If your platform lacks a Node.js runtime (e.g. iPad or some Android setups),
@@ -116,5 +42,14 @@ Node.js first and falls back to Deno when available.
 
 If the script cannot reach PyPI it will fall back to the system package manager. In completely offline environments, manually install a Pillow wheel (`pip install Pillow-*.whl`).
 `npm run check` verifies code formatting. On systems without Node.js, install
-[Deno](https://deno.com/) and run the same command — it automatically falls back
-to `deno fmt --check` for a limited set of files.
+[Deno](https://deno.com/) and run the same command — it automatically falls back to `deno fmt --check` for a limited set of files.
+
+### Duplicate Line Guard
+
+Accidental double-pastes can introduce repeated lines. Run the following to scan
+for duplicates and optionally fix them:
+
+```bash
+npm run dedupe        # report duplicate lines
+npm run dedupe -- --write  # remove duplicates in place
+```

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lint": "eslint .",
     "check": "./scripts/run-check.sh",
     "format": "prettier -w src/configLoader.js src/renderPlate.js plugins/soundscape.js test/*.js data/demos.json",
+    "dedupe": "node tools/dedupe.mjs",
     "generate:flame": "python3 scripts/generate_flame.py --out assets/flame/flame.png",
     "generate:atlas": "python3 scripts/pillow_atlas.py --in assets/flame --out assets/flame/atlas.png",
     "gallery:thumbs": "python3 scripts/pillow_thumbs.py --in exports --out exports/thumbs --size 512",

--- a/tools/dedupe.mjs
+++ b/tools/dedupe.mjs
@@ -1,0 +1,55 @@
+import { promises as fs } from "fs";
+import { execSync } from "child_process";
+
+/*
+  dedupe.mjs
+  ND-safe guard against duplicate lines.
+  Usage:
+    node tools/dedupe.mjs        # report duplicates
+    node tools/dedupe.mjs --write # fix files in place
+*/
+
+// Pure function: remove consecutive duplicate lines
+export function dedupeLines(text) {
+  const lines = text.split("\n");
+  const out = [];
+  const dups = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i] === lines[i - 1]) {
+      dups.push(i + 1); // 1-indexed line number
+      continue; // skip duplicate
+    }
+    out.push(lines[i]);
+  }
+  return { text: out.join("\n"), dups };
+}
+
+// Process a single file; write only when requested
+async function scanFile(file, write) {
+  const data = await fs.readFile(file, "utf8");
+  if (data.includes("\0")) return; // skip binary files
+  const { text, dups } = dedupeLines(data);
+  if (dups.length) {
+    console.log(`${file}: duplicate lines at ${dups.join(", ")}`);
+    if (write) {
+      await fs.writeFile(file, text, "utf8");
+    }
+  }
+}
+
+// Discover tracked files and scan each one
+async function main() {
+  const write = process.argv.includes("--write");
+  const files = execSync("git ls-files", { encoding: "utf8" })
+    .trim()
+    .split("\n");
+  for (const file of files) {
+    if (file.startsWith("node_modules/") || file.startsWith(".git/")) continue;
+    await scanFile(file, write);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `tools/dedupe.mjs` script to detect and optionally remove duplicate lines
- expose the new script via `npm run dedupe`
- clean up README and document the duplicate line guard

## Testing
- `node node_modules/prettier/bin/prettier.cjs -w tools/dedupe.mjs README.md package.json`
- `node tools/dedupe.mjs > /tmp/dedupe.log && head -n 20 /tmp/dedupe.log`
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*


------
https://chatgpt.com/codex/tasks/task_e_68be02b1eff88328a11d7a822e0f470a