### PR TITLE
fix: stabilize cosmic helix renderer

### DIFF
--- a/cosmic-helix/README_RENDERER.md
+++ b/cosmic-helix/README_RENDERER.md
@@ -38,8 +38,8 @@ motion-free.
 - Muted colors and generous spacing improve readability in dark and light modes.
 - Geometry routines use numerology constants (3,7,9,11,22,33,99,144) to honour
   project canon.
-- Numerology constants are exported as `NUM` from the renderer module so other
-  scripts can share the same symbolic values.
+- Numerology constants live in `index.html` and are passed to the renderer so the
+  symbolic values remain explicit and easy to tweak.
 - Code is modular ES module (`js/helix-renderer.mjs`) with pure functions and
   ASCII quotes only.
 

--- a/cosmic-helix/index.html
+++ b/cosmic-helix/index.html
@@ -29,7 +29,7 @@
   <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
 
   <script type="module">
-    import { renderHelix, NUM } from "./js/helix-renderer.mjs";
+    import { renderHelix } from "./js/helix-renderer.mjs";
 
     const elStatus = document.getElementById("status");
     const canvas = document.getElementById("stage");
@@ -47,9 +47,9 @@
 
     const defaults = {
       palette: {
-        bg:"#0b0b12",
-        ink:"#e8e8f0",
-        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
+        bg: "#0b0b12",
+        ink: "#e8e8f0",
+        layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
       }
     };
 
@@ -57,8 +57,20 @@
     const active = palette || defaults.palette;
     elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
 
+    // Numerology constants used by geometry routines
+    const NUM = {
+      THREE: 3,
+      SEVEN: 7,
+      NINE: 9,
+      ELEVEN: 11,
+      TWENTYTWO: 22,
+      THIRTYTHREE: 33,
+      NINETYNINE: 99,
+      ONEFORTYFOUR: 144
+    };
+
     // ND-safe rationale: no motion, high readability, soft colors, layered order
-    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
+    renderHelix(ctx, { width: canvas.width, height: canvas.height, palette: active, NUM });
   </script>
 </body>
 </html>

--- a/cosmic-helix/js/helix-renderer.mjs
+++ b/cosmic-helix/js/helix-renderer.mjs
@@ -1,9 +1,6 @@
 /*
   helix-renderer.mjs
-  Motto: Per Texturas Numerorum, Spira Loquitur.
   ND-safe static renderer for layered sacred geometry.
-
-  Seal Motto: Per Texturas Numerorum, Spira Loquitur.
 
   Layers:
     1) Vesica field (intersecting circles)
@@ -17,19 +14,8 @@
     - numerology constants wire geometry to 3/7/9/11/22/33/99/144
 */
 
-export const NUM = Object.freeze({
-  THREE: 3,
-  SEVEN: 7,
-  NINE: 9,
-  ELEVEN: 11,
-  TWENTYTWO: 22,
-  THIRTYTHREE: 33,
-  NINETYNINE: 99,
-  ONEFORTYFOUR: 144,
-});
-
 export function renderHelix(ctx, opts) {
-  const { width, height, palette, NUM: N = NUM } = opts;
+  const { width, height, palette, NUM: N } = opts;
   ctx.fillStyle = palette.bg;
   ctx.fillRect(0, 0, width, height);
 
@@ -52,10 +38,9 @@ function drawVesicaField(ctx, w, h, color, N) {
   }
 }
 
-
+function drawTreeOfLife(ctx, w, h, pathColor, nodeColor, N) {
   ctx.strokeStyle = pathColor;
   ctx.lineWidth = 2;
-
 
   const nodes = [
     { x: w / 2, y: h * 0.05 }, // 0 Kether
@@ -67,32 +52,14 @@ function drawVesicaField(ctx, w, h, color, N) {
     { x: w * 0.25, y: h * 0.65 }, // 6 Netzach
     { x: w * 0.75, y: h * 0.65 }, // 7 Hod
     { x: w / 2, y: h * 0.75 }, // 8 Yesod
-    { x: w / 2, y: h * 0.9 }, // 9 Malkuth
+    { x: w / 2, y: h * 0.9 } // 9 Malkuth
   ];
 
   const paths = [
-    [0, 1],
-    [0, 2],
-    [0, 5],
-    [1, 2],
-    [1, 5],
-    [2, 5],
-    [1, 3],
-    [2, 4],
-    [3, 4],
-    [3, 5],
-    [4, 5],
-    [3, 6],
-    [4, 7],
-    [5, 6],
-    [5, 7],
-    [6, 7],
-    [6, 8],
-    [7, 8],
-    [5, 8],
-    [6, 9],
-    [7, 9],
-    [8, 9],
+    [0, 1], [0, 2], [0, 5], [1, 2], [1, 5], [2, 5],
+    [1, 3], [2, 4], [3, 4], [3, 5], [4, 5],
+    [3, 6], [4, 7], [5, 6], [5, 7], [6, 7],
+    [6, 8], [7, 8], [5, 8], [6, 9], [7, 9], [8, 9]
   ];
 
   paths.forEach(([a, b]) => {
@@ -100,25 +67,6 @@ function drawVesicaField(ctx, w, h, color, N) {
     ctx.moveTo(nodes[a].x, nodes[a].y);
     ctx.lineTo(nodes[b].x, nodes[b].y);
     ctx.stroke();
-
-  const nodes = [];
-  const centerX = w / 2;
-  const topY = h / N.ELEVEN; // proportioned via 11
-  const verticalStep = (h - topY * 2) / N.NINE;
-  for (let i = 0; i < 10; i++) {
-    nodes.push({ x: centerX, y: topY + i * verticalStep });
-  }
-  // Draw paths (simple straight connections for ND-safety clarity)
-  nodes.forEach((a, i) => {
-    for (let j = i + 1; j < nodes.length; j++) {
-      if ((j - i) % N.THREE === 0 || j - i === 1) {
-        ctx.beginPath();
-        ctx.moveTo(a.x, a.y);
-        ctx.lineTo(nodes[j].x, nodes[j].y);
-        ctx.stroke();
-      }
-    }
-
   });
 
   ctx.fillStyle = nodeColor;
@@ -160,11 +108,11 @@ function drawHelix(ctx, w, h, colorA, colorB, N) {
     for (let x = 0; x <= w; x += stepX) {
       const y =
         midY +
-        amplitude *
-          Math.sin((x / w) * N.THIRTYTHREE * Math.PI + phase * Math.PI);
+        amplitude * Math.sin((x / w) * N.THIRTYTHREE * Math.PI + phase * Math.PI);
       if (x === 0) ctx.moveTo(x, y);
       else ctx.lineTo(x, y);
     }
     ctx.stroke();
   }
 }
+


### PR DESCRIPTION
## Summary
- refactor helix renderer into pure functions drawing vesica, tree-of-life, fibonacci curve, and static double helix
- define numerology constants and palette fallback in index and document design notes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be279e182483288d9c72a395ca588d