### PR TITLE
Add lineage room data for six cosmic mentors

### DIFF
--- a/data/lineage_rooms.json
+++ b/data/lineage_rooms.json
@@ -1,0 +1,134 @@
+[
+  {
+    "roomId": "tesla",
+    "name": "Nikola Tesla",
+    "hexagramPosition": "Upper Left",
+    "tetragrammatonRole": "Yod",
+    "domain": "Electromagnetic Invention / Resonant Engineering",
+    "signatureWorks": ["Colorado Springs Notes", "Wardenclyffe Tower", "Tesla Coil"],
+    "codexRole": "Engineer of Lightning Grid",
+    "tarotOverlay": "XVI The Tower",
+    "astrologySymbolism": "Sun in Cancer — lightning mind in watery body",
+    "fusionNotes": [
+      "Dreamed wireless power flowing like water",
+      "Alternating current wizardry woven into modern grid",
+      "Sees numbers 3, 6, 9 as key to universe"
+    ],
+    "artifact": {
+      "type": "fusion-plate",
+      "description": "Coil Resonance Plate — arcs of blue light in concentric rings",
+      "function": "Charges circuits and fuels inventions"
+    },
+    "connections": ["hypatia", "agrippa"]
+  },
+  {
+    "roomId": "hypatia",
+    "name": "Hypatia of Alexandria",
+    "hexagramPosition": "Lower Left",
+    "tetragrammatonRole": "Heh",
+    "domain": "Philosophy / Stellar Mathematics",
+    "signatureWorks": ["Commentary on Diophantus", "Astronomical Canon"],
+    "codexRole": "Scholar of Star Paths",
+    "tarotOverlay": "XVII The Star",
+    "astrologySymbolism": "Sun in Pisces — philosopher navigating the cosmos",
+    "fusionNotes": [
+      "Taught geometry and astronomy in Alexandria",
+      "Preserved classical knowledge amid turmoil",
+      "Modeled planets with elegant instruments"
+    ],
+    "artifact": {
+      "type": "fusion-plate",
+      "description": "Astrolabe Plate — brass ringed with star etchings",
+      "function": "Charts celestial courses and sharpens reasoning"
+    },
+    "connections": ["tesla", "hilma"]
+  },
+  {
+    "roomId": "agrippa",
+    "name": "Heinrich Cornelius Agrippa",
+    "hexagramPosition": "Lower Center",
+    "tetragrammatonRole": "Vav",
+    "domain": "Occult Philosophy / Planetary Magick",
+    "signatureWorks": ["Three Books of Occult Philosophy"],
+    "codexRole": "Archivist of Planetary Grids",
+    "tarotOverlay": "V The Hierophant",
+    "astrologySymbolism": "Saturn scholar weaving classical correspondences",
+    "fusionNotes": [
+      "Systematized renaissance magic with planetary tables",
+      "Bridged hermetic, kabbalistic, and classical wisdom",
+      "Influenced Dee and Fortune with structured correspondences"
+    ],
+    "artifact": {
+      "type": "fusion-plate",
+      "description": "Planetary Grid Plate — geometric seals around a central star",
+      "function": "Aligns planetary forces for ritual work"
+    },
+    "connections": ["dee", "tesla"]
+  },
+  {
+    "roomId": "dee",
+    "name": "John Dee",
+    "hexagramPosition": "Lower Right",
+    "tetragrammatonRole": "Heh final",
+    "domain": "Angel Tech / Hermetic Science / Navigation",
+    "signatureWorks": ["Monas Hieroglyphica", "Libri Mysteria", "Liber Soyga"],
+    "codexRole": "Magician-Navigator of Angelic Lattice",
+    "tarotOverlay": "I The Magician",
+    "astrologySymbolism": "Sun in Leo, Mercury exalted — visionary scholar bridging math and angels",
+    "fusionNotes": [
+      "Sought direct angelic conversation through Enochian",
+      "Mapped cosmos as text lattice (Soyga, Monas)",
+      "Advisor to queens, but servant to angels"
+    ],
+    "artifact": {
+      "type": "fusion-plate",
+      "description": "Monadic Plate — a living glyph that pulses between circle, cross, and line",
+      "function": "Unlocks angelic codes and higher navigation"
+    },
+    "connections": ["agrippa", "fortune", "hilma"]
+  },
+  {
+    "roomId": "fortune",
+    "name": "Dion Fortune",
+    "hexagramPosition": "Center Rose",
+    "tetragrammatonRole": "Shekhinah (implicit presence)",
+    "domain": "Psychic Protection / Qabalistic Temple Building",
+    "signatureWorks": ["The Mystical Qabalah", "Psychic Self-Defense"],
+    "codexRole": "Guardian of Inner Temple / Lady Chapel",
+    "tarotOverlay": "VIII Strength",
+    "astrologySymbolism": "Sun Sagittarius — fire teacher of esoteric temple",
+    "fusionNotes": [
+      "Made the Tree of Life into a temple with rooms",
+      "Taught psychic protection as real architecture",
+      "One of the first women to claim authority in occult orders"
+    ],
+    "artifact": {
+      "type": "fusion-plate",
+      "description": "Rose Cross Plate — a glowing cross of petals and gold lines",
+      "function": "Shields the player and strengthens psychic resilience"
+    },
+    "connections": ["dee", "hilma", "rebecca-respawn"]
+  },
+  {
+    "roomId": "hilma",
+    "name": "Hilma af Klint",
+    "hexagramPosition": "Upper Center",
+    "tetragrammatonRole": "Aleph (unspoken seed)",
+    "domain": "Visionary Art / Spiritual Abstraction",
+    "signatureWorks": ["Paintings for the Temple", "The Swan", "The Ten Largest"],
+    "codexRole": "Visionary Painter of Spiral Gardens",
+    "tarotOverlay": "XVIII The Moon",
+    "astrologySymbolism": "Sun Libra — balancing seen and unseen, form and spirit",
+    "fusionNotes": [
+      "Created abstract visionary art before modern abstraction",
+      "Worked in a spiritual atelier of five women",
+      "Her paintings = diagrams of evolution and soul-spirals"
+    ],
+    "artifact": {
+      "type": "fusion-plate",
+      "description": "Spiral Garden Plate — radiant concentric rings blooming like flowers",
+      "function": "Opens visionary perception and attunes nervous system"
+    },
+    "connections": ["fortune", "dee", "hypatia"]
+  }
+]


### PR DESCRIPTION
## Summary
- Encode six lineage rooms—Tesla, Hypatia, Agrippa, Dee, Fortune, Hilma—in a new JSON data file

## Testing
- `npx prettier -w data/lineage_rooms.json`
- `npm run lint` *(fails: Duplicate key 'indraNet', 'witch', 'coven', 'pack', 'codex'; vendor/p5.min.js empty block)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be8ce9446c8328af9876f5f1722b34