### PR TITLE
Add Liber Arcanae deck manifest

### DIFF
--- a/liber-arcanae/codex_of_abyssiae.json
+++ b/liber-arcanae/codex_of_abyssiae.json
@@ -1,0 +1,132 @@
+{
+  "codex_id": "liber-arcanae/codex_of_abyssiae",
+  "deck_name": "Liber Arcanae — Codex of Abyssiae",
+  "version": "1.1.0",
+  "source_of_truth": "canonical",
+  "notes": "Shared single source for Circuitum99 and Liber-Arcanae. Contains canonical IDs, titles, paths/nodes, and legacy-ID compatibility.",
+  "ids": {
+    "format": {
+      "major": "MA00..MA21",
+      "minor": "W01..W10,WPG,WKN,WQU,WKG / C01.. / S01.. / P01.."
+    },
+    "aliases": {
+      "maj_prefix": ["MA","major"],
+      "wands_prefix": ["W","w","wand","wands"],
+      "cups_prefix": ["C","c","cup","cups"],
+      "swords_prefix": ["S","s","sword","swords"],
+      "pentacles_prefix": ["P","p","pent","pentacles","coins"]
+    }
+  },
+  "canonical": {
+    "major": [
+      ["MA00","The Fool","Rebecca Respawn","Aleph","initiate_zero"],
+      ["MA01","The Magician","Virelai Ezra Lux","Beth","octarine_witch"],
+      ["MA02","The High Priestess","Gemini Rivers","Gimel","twin_rivers"],
+      ["MA03","The Empress","Ann Abyss","Daleth","grief_queen"],
+      ["MA04","The Emperor","Zidaryen","Heh","forest_keeper"],
+      ["MA05","The Hierophant","Winne Reweave","Vav","oracle_weaver"],
+      ["MA06","The Lovers","Bea Betwixted","Zayin","threshold_weaver"],
+      ["MA07","The Chariot","IGNI (Raku Dragon)","Cheth","fire_chariot"],
+      ["MA08","Strength","Morticia Moonbeamer","Teth","rainbow_dark"],
+      ["MA09","The Hermit","Amiyara Skye","Yod","lantern_witch"],
+      ["MA10","Wheel of Fortune","Cael Umbra","Kaph","fate_wheel"],
+      ["MA11","Justice","Elyria Nox","Lamed","black_balance"],
+      ["MA12","The Hanged Man","Mirror Witch","Mem","reflection_trial"],
+      ["MA13","Death","Ann Abyss (Shadow)","Nun","void_gate"],
+      ["MA14","Temperance","Lyra Vox","Samekh","harmonic_oracle"],
+      ["MA15","The Devil","Scarlet Lady","Ayin","scarlet_bind"],
+      ["MA16","The Tower","Fenrix Thorne","Pe","iron_tower"],
+      ["MA17","The Star","Sophia/Gnosis","Tzaddi","wisdom_stream"],
+      ["MA18","The Moon","Moonchild 2000","Qoph","dream_gate"],
+      ["MA19","The Sun","Rebecca Respawn (Solar Double)","Resh","resurrection"],
+      ["MA20","Judgement","Sekhara","Shin","descent_rebirth"],
+      ["MA21","The World","LuxCrux Monad","Tav","infinity_cross"]
+    ],
+    "minor": {
+      "W": [
+        ["W01","Ace of Wands","Spark of IGNI"],
+        ["W02","Two of Wands","Twin Flames"],
+        ["W03","Three of Wands","Expansive Vision"],
+        ["W04","Four of Wands","Sanctuary Portal"],
+        ["W05","Five of Wands","Creative Clash"],
+        ["W06","Six of Wands","Victory of Fire"],
+        ["W07","Seven of Wands","Defender of Truth"],
+        ["W08","Eight of Wands","Rapid Sparks"],
+        ["W09","Nine of Wands","Wounded Flame"],
+        ["W10","Ten of Wands","Burden of Passion"],
+        ["WPG","Page of Wands","Ignition Apprentice"],
+        ["WKN","Knight of Wands","Dragon Rider"],
+        ["WQU","Queen of Wands","Flame Sorceress"],
+        ["WKG","King of Wands","Fire Sovereign"]
+      ],
+      "C": [
+        ["C01","Ace of Cups","Fountain of Gemini"],
+        ["C02","Two of Cups","Sacred Union"],
+        ["C03","Three of Cups","Coven Dance"],
+        ["C04","Four of Cups","Moonlit Reflection"],
+        ["C05","Five of Cups","Grief Chalice"],
+        ["C06","Six of Cups","Childhood Memory"],
+        ["C07","Seven of Cups","Dream Labyrinth"],
+        ["C08","Eight of Cups","Leaving the Old"],
+        ["C09","Nine of Cups","Wish Well"],
+        ["C10","Ten of Cups","Rainbow Covenant"],
+        ["CPG","Page of Cups","Siren Initiate"],
+        ["CKN","Knight of Cups","River Rider"],
+        ["CQU","Queen of Cups","Empath Oracle"],
+        ["CKG","King of Cups","Ocean Sovereign"]
+      ],
+      "S": [
+        ["S01","Ace of Swords","Truth Spark"],
+        ["S02","Two of Swords","Crossroads"],
+        ["S03","Three of Swords","Heartbreak Sigil"],
+        ["S04","Four of Swords","Silent Rest"],
+        ["S05","Five of Swords","Discord Cut"],
+        ["S06","Six of Swords","River Passage"],
+        ["S07","Seven of Swords","Shadow Theft"],
+        ["S08","Eight of Swords","Mirror Prison"],
+        ["S09","Nine of Swords","Nightmare Echo"],
+        ["S10","Ten of Swords","Final Collapse"],
+        ["SPG","Page of Swords","Apprentice of Winds"],
+        ["SKN","Knight of Swords","Storm Rider"],
+        ["SQU","Queen of Swords","Shadow Queen"],
+        ["SKG","King of Swords","Air Sovereign"]
+      ],
+      "P": [
+        ["P01","Ace of Pentacles","Stone Seed"],
+        ["P02","Two of Pentacles","Balance in Motion"],
+        ["P03","Three of Pentacles","Craft Guild"],
+        ["P04","Four of Pentacles","Holding Power"],
+        ["P05","Five of Pentacles","Exile Gate"],
+        ["P06","Six of Pentacles","Reciprocity"],
+        ["P07","Seven of Pentacles","Harvest Waiting"],
+        ["P08","Eight of Pentacles","Artisan's Spiral"],
+        ["P09","Nine of Pentacles","Garden Sovereign"],
+        ["P10","Ten of Pentacles","Ancestral House"],
+        ["PPG","Page of Pentacles","Apprentice of Earth"],
+        ["PKN","Knight of Pentacles","Stone Rider"],
+        ["PQU","Queen of Pentacles","Gaian Matron"],
+        ["PKG","King of Pentacles","Earth Sovereign"]
+      ]
+    }
+  },
+  "compat": {
+    "legacy_to_canonical": {
+      "0": "MA00", "1": "MA01", "2": "MA02", "3": "MA03", "4": "MA04", "5": "MA05", "6": "MA06", "7": "MA07", "8": "MA08", "9": "MA09",
+      "10": "MA10", "11": "MA11", "12": "MA12", "13": "MA13", "14": "MA14", "15": "MA15", "16": "MA16", "17": "MA17", "18": "MA18", "19": "MA19", "20": "MA20", "21": "MA21",
+      "w1": "W01", "w2": "W02", "w3": "W03", "w4": "W04", "w5": "W05", "w6": "W06", "w7": "W07", "w8": "W08", "w9": "W09", "w10": "W10",
+      "wpg": "WPG", "wk": "WKN", "wq": "WQU", "wc": "WKG",
+      "c1": "C01", "c2": "C02", "c3": "C03", "c4": "C04", "c5": "C05", "c6": "C06", "c7": "C07", "c8": "C08", "c9": "C09", "c10": "C10",
+      "cpg": "CPG", "ck": "CKN", "cq": "CQU", "cc": "CKG",
+      "s1": "S01", "s2": "S02", "s3": "S03", "s4": "S04", "s5": "S05", "s6": "S06", "s7": "S07", "s8": "S08", "s9": "S09", "s10": "S10",
+      "spg": "SPG", "sk": "SKN", "sq": "SQU", "sc": "SKG",
+      "p1": "P01", "p2": "P02", "p3": "P03", "p4": "P04", "p5": "P05", "p6": "P06", "p7": "P07", "p8": "P08", "p9": "P09", "p10": "P10",
+      "ppg": "PPG", "pk": "PKN", "pq": "PQU", "pc": "PKG"
+    }
+  },
+  "provenance": {
+    "title": "Deck Manifest — Liber Arcanae: Codex of Abyssiae",
+    "creator": "Rebecca Respawn",
+    "license": "CC0-1.0",
+    "source": "Circuitum99 & Liber-Arcanae shared registry"
+  }
+}


### PR DESCRIPTION
## Summary
- add canonical Liber Arcanae deck manifest with major/minor arcana and legacy ID mapping

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c036ee494c8328bb469cd4b4aa5d02