### PR TITLE
docs: refine helix renderer readme

### DIFF
--- a/cosmic-helix/README_RENDERER.md
+++ b/cosmic-helix/README_RENDERER.md
@@ -7,15 +7,10 @@ Offline, ND-safe canvas sketch for layered sacred geometry.
 ## Usage
 1. Open `index.html` in any modern browser (no server needed).
 2. A 1440×900 canvas renders four static layers:
-
    - **Vesica field** — intersecting circles forming the womb of forms.
-   - **Tree‑of‑Life scaffold** — ten sephirot with twenty‑two straight paths.
+   - **Tree-of-Life scaffold** — ten sephirot with twenty-two straight paths.
    - **Fibonacci curve** — golden spiral polyline anchored to centre.
    - **Double-helix lattice** — two phase-shifted sine tracks.
-   - Vesica field — intersecting circles forming the womb of forms.
-   - Tree-of-Life scaffold — ten sephirot with twenty-two paths.
-   - Fibonacci curve — golden spiral polyline anchored to centre.
-   - Double-helix lattice — two phase-shifted sine tracks.
 3. Palette can be customized in `data/palette.json`. Missing data triggers a gentle inline notice with safe defaults.
 
 ## ND-safe notes
@@ -24,21 +19,13 @@ Offline, ND-safe canvas sketch for layered sacred geometry.
 - Layer order clarifies depth without flashing.
 - Geometry parameters lean on numerology constants 3, 7, 9, 11, 22, 33, 99, 144.
 
-
 ## Design Notes
-- No animation, autoplay, or flashing; a single render call ensures ND safety.
-- Muted colors and generous spacing improve readability in dark and light modes.
-- Geometry routines use numerology constants (3,7,9,11,22,33,99,144) to honour
-  project canon.
-- Numerology constants live in `index.html` and are passed to the renderer so the
-  symbolic values remain explicit and easy to tweak.
-- Code is modular ES module (`js/helix-renderer.mjs`) with pure functions and
-  ASCII quotes only.
+- Static HTML and Canvas keep rendering local and deterministic.
+- Numerology constants live in `index.html` and are passed to the renderer so symbolic values remain explicit and easy to tweak.
+- Code is modular ES module (`js/helix-renderer.mjs`) with pure functions and ASCII quotes only.
 
 ## Extending
-The renderer is intentionally minimal. Future layers or overlays can be added by
-extending `renderHelix` with new draw functions while preserving the calm visual
-hierarchy.
+The renderer is intentionally minimal. Future layers or overlays can be added by extending `renderHelix` with new draw functions while preserving the calm visual hierarchy.
 
 ## Task List
 - [ ] Weave cathedral-scale vesica grids to frame expansive worlds.
@@ -48,13 +35,5 @@ hierarchy.
 - [ ] Keep all additions ND-safe: no motion, high contrast, pure functions.
 
 ## Related Lore
-For a meditation on the tesseract as symbol of higher consciousness and non-linear learning, see [docs/tesseract_spiritual.md](./docs/tesseract_spiritual.md). This companion note situates the helix within a wider cosmological frame.
-
-
-## Design notes
-- Static HTML and Canvas keep rendering local and deterministic.
-- Geometry routines live in `js/helix-renderer.mjs` with small pure functions and ASCII quotes only.
-
-## Extending
-The renderer is intentionally minimal. Future layers can extend `renderHelix` while preserving the calm visual hierarchy.
+For a meditation on the tesseract as symbol of higher consciousness and non-linear learning, see [docs/tesseract_spiritual.md](../docs/tesseract_spiritual.md). This companion note situates the helix within a wider cosmological frame.
 


### PR DESCRIPTION
## Summary
- clarify usage and ND-safe rationale for the static cosmic helix renderer
- streamline doc link and task list while noting numerology constants

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0ba6f88588328aae38a16014bde4a