### PR TITLE
Add octagram tesseract schema and tidy helix docs

### DIFF
--- a/cosmic-helix/README_RENDERER.md
+++ b/cosmic-helix/README_RENDERER.md
@@ -4,18 +4,13 @@ Per Texturas Numerorum, Spira Loquitur.  //
 
 Offline, ND-safe canvas sketch for layered sacred geometry.
 
-
 ## Usage
 1. Open `index.html` in any modern browser (no server needed).
 2. A 1440×900 canvas renders four static layers:
-
    - **Vesica field** — intersecting circles forming the womb of forms.
+   - **Tree-of-Life scaffold** — ten sephirot with twenty-two paths.
    - **Fibonacci curve** — golden spiral polyline anchored to centre.
    - **Double-helix lattice** — two phase-shifted sine tracks.
-   - Vesica field — intersecting circles forming the womb of forms.
-   - Tree-of-Life scaffold — ten sephirot with twenty-two paths.
-   - Fibonacci curve — golden spiral polyline anchored to centre.
-   - Double-helix lattice — two phase-shifted sine tracks.
 3. Palette can be customized in `data/palette.json`. Missing data triggers a gentle inline notice with safe defaults.
 
 ## ND-safe notes
@@ -23,7 +18,6 @@ Offline, ND-safe canvas sketch for layered sacred geometry.
 - Calm contrast palette reduces sensory strain.
 - Layer order clarifies depth without flashing.
 - Geometry parameters lean on numerology constants 3, 7, 9, 11, 22, 33, 99, 144.
-
 
 ## Design Notes
 - No animation, autoplay, or flashing; a single render call ensures ND safety.
@@ -44,17 +38,3 @@ For a meditation on the tesseract as symbol of higher consciousness and non-line
 - [ ] Layer Fibonacci paths through oceans, rivers, and volcanic corridors.
 - [ ] Cross-link double-helix lattices with rune, tarot, and reiki lore.
 - [ ] Keep all additions ND-safe: no motion, high contrast, pure functions.
-
-
-## Related Lore
-For a meditation on the tesseract as symbol of higher consciousness and non-linear learning, see [docs/tesseract_spiritual.md](./docs/tesseract_spiritual.md). This companion note situates the helix within a wider cosmological frame.
-
-
-## Design notes
-- Static HTML and Canvas keep rendering local and deterministic.
-- Geometry routines live in `js/helix-renderer.mjs` with small pure functions and ASCII quotes only.
-
-## Extending
-The renderer is intentionally minimal. Future layers can extend `renderHelix` while preserving the calm visual hierarchy.
-
-

--- a/schemas/octagram-tesseract-node.schema.json
+++ b/schemas/octagram-tesseract-node.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Octagram Tesseract Node",
+  "type": "object",
+  "required": [
+    "id",
+    "name",
+    "num",
+    "palette",
+    "geometry",
+    "node_type",
+    "narrative",
+    "locked",
+    "lineage",
+    "codex",
+    "render_profile",
+    "safety"
+  ],
+  "properties": {
+    "id": { "type": "string", "pattern": "^OCTA-[A-Z0-9_\\-]+$" },
+    "name": { "type": "string", "minLength": 3 },
+    "num": { "type": "integer", "minimum": 1 },
+    "palette": {
+      "type": "object",
+      "properties": {
+        "primary": { "type": "string", "pattern": "^#([0-9A-Fa-f]{6})$" },
+        "secondary": { "type": "string", "pattern": "^#([0-9A-Fa-f]{6})$" },
+        "accent": { "type": "string", "pattern": "^#([0-9A-Fa-f]{6})$" }
+      },
+      "required": ["primary", "secondary", "accent"]
+    },
+    "geometry": {
+      "type": "object",
+      "properties": {
+        "base": { "enum": ["octagram+tesseract"] },
+        "overlays": { "type": "array", "items": { "type": "string" } }
+      },
+      "required": ["base", "overlays"]
+    },
+    "node_type": { "const": "octagram_tesseract" },
+    "narrative": { "type": "string" },
+    "locked": { "type": "boolean" },
+    "lineage": { "type": "object" },
+    "codex": {
+      "type": "object",
+      "properties": {
+        "anchors": { "type": "array", "items": { "type": "integer" } },
+        "chakra": { "type": "array", "items": { "type": "string" } },
+        "planet": { "type": "array", "items": { "type": "string" } },
+        "element": { "type": "array", "items": { "type": "string" } },
+        "sf": { "type": "array", "items": { "type": "number" } }
+      },
+      "required": ["anchors"]
+    },
+    "render_profile": {
+      "type": "object",
+      "properties": {
+        "disable": { "type": "array", "items": { "type": "string" } },
+        "prefer": { "type": "array", "items": { "type": "string" } },
+        "light": { "type": "string" },
+        "audio": { "type": "string" }
+      }
+    },
+    "safety": {
+      "type": "object",
+      "properties": {
+        "nd_safe": { "type": "boolean" },
+        "intensity_slider": { "type": "boolean" },
+        "no_strobe": { "type": "boolean", "default": true },
+        "no_autoplay": { "type": "boolean", "default": true }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add JSON schema for `octagram_tesseract` nodes with ND-safe palette, geometry, codex, and safety fields
- clean up Cosmic Helix renderer README for clarity and layer listing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0f5157bc48328a850222f3f2708b8