### PR TITLE
Integrate Tara-21 palette into helix renderer

### DIFF
--- a/cosmic-helix/README_RENDERER.md
+++ b/cosmic-helix/README_RENDERER.md
@@ -1,22 +1,16 @@
-Per Texturas Numerorum, Spira Loquitur.  //
-
 # Cosmic Helix Renderer
 
 Offline, ND-safe canvas sketch for layered sacred geometry.
 
-
 ## Usage
 1. Open `index.html` in any modern browser (no server needed).
 2. A 1440×900 canvas renders four static layers:
-
    - **Vesica field** — intersecting circles forming the womb of forms.
+   - **Tree-of-Life scaffold** — ten sephirot with twenty-two paths.
    - **Fibonacci curve** — golden spiral polyline anchored to centre.
    - **Double-helix lattice** — two phase-shifted sine tracks.
-   - Vesica field — intersecting circles forming the womb of forms.
-   - Tree-of-Life scaffold — ten sephirot with twenty-two paths.
-   - Fibonacci curve — golden spiral polyline anchored to centre.
-   - Double-helix lattice — two phase-shifted sine tracks.
-3. Palette can be customized in `data/palette.json`. Missing data triggers a gentle inline notice with safe defaults.
+
+Palette data lives in `data/palette.json`. Missing data triggers a gentle inline notice with safe defaults.
 
 ## ND-safe notes
 - Static drawing; no animation or autoplay.
@@ -24,37 +18,12 @@ Offline, ND-safe canvas sketch for layered sacred geometry.
 - Layer order clarifies depth without flashing.
 - Geometry parameters lean on numerology constants 3, 7, 9, 11, 22, 33, 99, 144.
 
-
-## Design Notes
-- No animation, autoplay, or flashing; a single render call ensures ND safety.
-- Muted colors and generous spacing improve readability in dark and light modes.
-- Geometry routines use numerology constants (3, 7, 9, 11, 22, 33, 99, 144) to honour project canon.
-- Numerology constants live in `index.html` and are passed to the renderer so the symbolic values remain explicit and easy to tweak.
-- Code is modular ES module (`js/helix-renderer.mjs`) with pure functions and ASCII quotes only.
-
-## Extending
-The renderer is intentionally minimal. Future layers or overlays can be added by extending `renderHelix` with new draw functions while preserving the calm visual hierarchy.
-
-## Related Lore
-For a meditation on the tesseract as symbol of higher consciousness and non-linear learning, see [`docs/tesseract_spiritual.md`](../docs/tesseract_spiritual.md). This companion note situates the helix within a wider cosmological frame.
-
-## Task List
-- [ ] Weave cathedral-scale vesica grids to frame expansive worlds.
-- [ ] Map Tree-of-Life nodes to sanctuaries like Avalon and mountain temples.
-- [ ] Layer Fibonacci paths through oceans, rivers, and volcanic corridors.
-- [ ] Cross-link double-helix lattices with rune, tarot, and reiki lore.
-- [ ] Keep all additions ND-safe: no motion, high contrast, pure functions.
-
-
-## Related Lore
-For a meditation on the tesseract as symbol of higher consciousness and non-linear learning, see [docs/tesseract_spiritual.md](./docs/tesseract_spiritual.md). This companion note situates the helix within a wider cosmological frame.
-
-
 ## Design notes
-- Static HTML and Canvas keep rendering local and deterministic.
-- Geometry routines live in `js/helix-renderer.mjs` with small pure functions and ASCII quotes only.
+- Modular ES module (`js/helix-renderer.mjs`) with small pure functions and ASCII quotes.
+- Color set `Tara-21` encodes twenty-one gentle hues; six tones are mapped to the renderer's layers for balanced contrast.
 
 ## Extending
-The renderer is intentionally minimal. Future layers can extend `renderHelix` while preserving the calm visual hierarchy.
+The renderer is intentionally minimal. Future layers or overlays can extend `renderHelix` while preserving the calm visual hierarchy.
 
-
+## Related lore
+For a meditation on the tesseract as symbol of higher consciousness and non-linear learning, see [`docs/tesseract_spiritual.md`](../docs/tesseract_spiritual.md). This companion note situates the helix within a wider cosmological frame.

--- a/cosmic-helix/data/palette.json
+++ b/cosmic-helix/data/palette.json
@@ -1,5 +1,27 @@
 {
-  "bg": "#0b0b12",
-  "ink": "#e8e8f0",
-  "layers": ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
+  "set": "Tara-21",
+  "notes": "Balanced, ND-safe. Hue shifts gentle—no strobe.",
+  "colors": [
+    {"name":"Green Tara","hex":"#2EA66F"},
+    {"name":"White Tara","hex":"#EDEBE6"},
+    {"name":"Red Tara","hex":"#C7323B"},
+    {"name":"Yellow Tara","hex":"#F2CB3D"},
+    {"name":"Blue Tara","hex":"#2C6ABF"},
+    {"name":"Black Tara","hex":"#1A1C22"},
+    {"name":"Violet Tara","hex":"#7A4BD9"},
+    {"name":"Orange Tara","hex":"#E77A2E"},
+    {"name":"Pink Tara","hex":"#E987A9"},
+    {"name":"Turquoise Tara","hex":"#3BC6B8"},
+    {"name":"Jade Tara","hex":"#1FA582"},
+    {"name":"Pearl Tara","hex":"#F4F0EA"},
+    {"name":"Saffron Tara","hex":"#F39B1A"},
+    {"name":"Indigo Tara","hex":"#3D2E7A"},
+    {"name":"Teal Tara","hex":"#1F8C86"},
+    {"name":"Crimson Tara","hex":"#8E0E2B"},
+    {"name":"Rose-Gold Tara","hex":"#D8A46C"},
+    {"name":"Sky Tara","hex":"#9CC8F6"},
+    {"name":"Obsidian Tara","hex":"#111418"},
+    {"name":"Silver Tara","hex":"#C9CED6"},
+    {"name":"Octarine Tara","hex":"#9B5CF2"}
+  ]
 }

--- a/cosmic-helix/index.html
+++ b/cosmic-helix/index.html
@@ -10,7 +10,7 @@
   <style>
     /* ND-safe: calm contrast, no motion, generous spacing */
     :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
-    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
     header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
     .status { color:var(--muted); font-size:12px; }
     #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
@@ -39,7 +39,7 @@
         const res = await fetch(path, { cache: "no-store" });
         if (!res.ok) throw new Error(String(res.status));
         return await res.json();
-      } catch (err) {
+      } catch {
         return null;
       }
     }
@@ -52,9 +52,29 @@
       }
     };
 
-    const palette = await loadJSON("./data/palette.json");
-    const active = palette || defaults.palette;
-    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+    const data = await loadJSON("./data/palette.json");
+
+    let active;
+    if (data && Array.isArray(data.colors)) {
+      // Map Tara-21 names to quick lookup
+      const named = Object.fromEntries(data.colors.map(c => [c.name, c.hex]));
+      active = {
+        bg: named["Obsidian Tara"] || defaults.palette.bg,
+        ink: named["Pearl Tara"] || defaults.palette.ink,
+        layers: [
+          named["Green Tara"] || defaults.palette.layers[0],   // Vesica field
+          named["Silver Tara"] || defaults.palette.layers[1],  // Tree paths
+          named["Yellow Tara"] || defaults.palette.layers[2],  // Tree nodes
+          named["Red Tara"] || defaults.palette.layers[3],     // Fibonacci curve
+          named["Blue Tara"] || defaults.palette.layers[4],    // Helix A
+          named["Violet Tara"] || defaults.palette.layers[5]   // Helix B
+        ]
+      };
+      elStatus.textContent = data.set + " palette loaded.";
+    } else {
+      active = defaults.palette;
+      elStatus.textContent = "Palette missing; using safe fallback.";
+    }
 
     // Numerology constants used by geometry routines
     const NUM = {

--- a/cosmic-helix/js/helix-renderer.mjs
+++ b/cosmic-helix/js/helix-renderer.mjs
@@ -13,6 +13,7 @@
     - no motion or flashing; everything rendered once
     - muted palette for calm contrast
     - numerology constants wire geometry to 3/7/9/11/22/33/99/144
+  Colors are provided via Tara-21 palette mapping upstream.
 */
 
 export function renderHelix(ctx, opts) {


### PR DESCRIPTION
## Summary
- Load Tara-21 palette data and map named hues to vesica, tree, Fibonacci, and helix layers with a safe fallback
- Document ND-safe offline renderer and Tara-21 usage
- Note palette mapping in renderer comments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0fb295d8483289afda3ba498e9fce