### PR TITLE
Add OCTA-ACHAD tesseract node

### DIFF
--- a/data/tesseract-nodes.json
+++ b/data/tesseract-nodes.json
@@ -1,27 +1,30 @@
 {
   "nodes": [
-    {"id": "agrippa", "label": "Agrippa"},
-    {"id": "hypatia", "label": "Hypatia"},
-    {"id": "einstein", "label": "Einstein"}
-  ],
-  "edges": [
-    {"from": "agrippa", "to": "hypatia"},
-    {"from": "hypatia", "to": "einstein"}
     { "id": "home", "label": "Home" },
     { "id": "agrippa", "label": "Agrippa" },
     { "id": "hypatia", "label": "Hypatia" },
-    { "id": "einstein", "label": "Einstein" }
+    { "id": "einstein", "label": "Einstein" },
+    {
+      "id": "OCTA-ACHAD",
+      "name": "Frater Achad Octagram Tesseract — Maat Gate",
+      "label": "Frater Achad Octagram Tesseract — Maat Gate",
+      "num": 903,
+      "palette": { "primary": "#191970", "secondary": "#00CED1", "accent": "#FF69B4" },
+      "geometry": { "base": "octagram+tesseract", "overlays": ["maat_feather", "daath_gate", "mirror_torus"] },
+      "node_type": "octagram_tesseract",
+      "narrative": "Keys of Paradox and the Hidden Sephira",
+      "locked": true,
+      "lineage": { "school": "Maatian Qabalah", "keys": ["Da’ath Bridge", "Liber 31", "Tree Inversion"], "motto": "Paradox Opens" },
+      "codex": { "anchors": [11,21,31,33,72,144], "chakra": ["Throat", "Third Eye"], "planet": ["Saturn", "Uranus"], "element": ["Air", "Ether"], "sf": [741,963] },
+      "render_profile": { "disable": ["helix_renderer"], "prefer": ["void_bridge", "feather_scale", "mirror_torus"], "light": "teal_neon_line", "audio": "maat_whisper_scale" },
+      "safety": { "nd_safe": true, "intensity_slider": true }
+    }
   ],
   "edges": [
     { "from": "home", "to": "agrippa" },
     { "from": "home", "to": "hypatia" },
-    { "from": "home", "to": "einstein" }
-    {"id": "agrippa", "label": "Agrippa"},
-    {"id": "hypatia", "label": "Hypatia"},
-    {"id": "einstein", "label": "Einstein"}
-  ],
-  "edges": [
-    {"from": "agrippa", "to": "hypatia"},
-    {"from": "hypatia", "to": "einstein"}
+    { "from": "home", "to": "einstein" },
+    { "from": "agrippa", "to": "hypatia" },
+    { "from": "hypatia", "to": "einstein" }
   ]
 }


### PR DESCRIPTION
## Summary
- Add OCTA-ACHAD entry to tesseract node registry with palette, geometry, and safety metadata

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c101efc2a48328bf2f8664a8d78406