### PR TITLE
Add realm and research links for octagram tesseracts

### DIFF
--- a/registry/octagram-tesseracts.json
+++ b/registry/octagram-tesseracts.json
@@ -1,0 +1,4 @@
+{
+  "realm_links": ["stone-cathedral/realms/avalon/index.md"],
+  "research_links": ["docs/avalon/fortune_index.md"]
+}


### PR DESCRIPTION
## Summary
- add Avalon realm link reference to octagram-tesseracts registry
- add corresponding research link for Avalon fortune index

## Testing
- `npm test`
- `npm run lint` *(fails: Duplicate key 'indraNet', 'witch', 'coven', 'pack', 'codex'; vendor/p5.min.js empty block)*

------
https://chatgpt.com/codex/tasks/task_e_68c103189c4883289e71e5e7afb79dd6