### PR TITLE
docs: map core engines

### DIFF
--- a/ENGINES.md
+++ b/ENGINES.md
@@ -1,0 +1,9 @@
+# Engines Index
+
+- **circuitum99** — witch-eye storybook where Tarot help you create.
+- **liber-arcanae** — Tarot companions as atelier guides.
+- **liber-arcanae-game** — play mode; art creation, not ritual.
+- **stone-grimoire** — Rosslyn/Hilma/Reiki/Helix temples as immersive ateliers.
+- **codex-14499** — declares "fusion through creation."
+- **magical_mystery_house** — rooms are playful ateliers.
+


### PR DESCRIPTION
## Summary
- add engine index mapping repo modules to their narrative roles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c11e3e4e2c8328987e8b3502adc441