### PR TITLE
docs: clarify cosmic helix renderer

### DIFF
--- a/cosmic-helix/README_RENDERER.md
+++ b/cosmic-helix/README_RENDERER.md
@@ -2,59 +2,25 @@ Per Texturas Numerorum, Spira Loquitur.  //
 
 # Cosmic Helix Renderer
 
-Offline, ND-safe canvas sketch for layered sacred geometry.
-
+Offline ND-safe canvas sketch for layered sacred geometry.
 
 ## Usage
-1. Open `index.html` in any modern browser (no server needed).
+1. Double-click `index.html` in any modern browser.
 2. A 1440×900 canvas renders four static layers:
-
    - **Vesica field** — intersecting circles forming the womb of forms.
+   - **Tree-of-Life scaffold** — ten sephirot with twenty-two paths.
    - **Fibonacci curve** — golden spiral polyline anchored to centre.
    - **Double-helix lattice** — two phase-shifted sine tracks.
-   - Vesica field — intersecting circles forming the womb of forms.
-   - Tree-of-Life scaffold — ten sephirot with twenty-two paths.
-   - Fibonacci curve — golden spiral polyline anchored to centre.
-   - Double-helix lattice — two phase-shifted sine tracks.
-3. Palette can be customized in `data/palette.json`. Missing data triggers a gentle inline notice with safe defaults.
+3. Palette can be customised in `data/palette.json`. Missing data triggers a gentle inline notice with safe defaults.
 
-## ND-safe notes
-- Static drawing; no animation or autoplay.
+## ND-safe choices
+- Single render pass; no animation or autoplay.
 - Calm contrast palette reduces sensory strain.
 - Layer order clarifies depth without flashing.
-- Geometry parameters lean on numerology constants 3, 7, 9, 11, 22, 33, 99, 144.
-
-
-## Design Notes
-- No animation, autoplay, or flashing; a single render call ensures ND safety.
-- Muted colors and generous spacing improve readability in dark and light modes.
-- Geometry routines use numerology constants (3, 7, 9, 11, 22, 33, 99, 144) to honour project canon.
-- Numerology constants live in `index.html` and are passed to the renderer so the symbolic values remain explicit and easy to tweak.
-- Code is modular ES module (`js/helix-renderer.mjs`) with pure functions and ASCII quotes only.
-
-## Extending
-The renderer is intentionally minimal. Future layers or overlays can be added by extending `renderHelix` with new draw functions while preserving the calm visual hierarchy.
-
-## Related Lore
-For a meditation on the tesseract as symbol of higher consciousness and non-linear learning, see [`docs/tesseract_spiritual.md`](../docs/tesseract_spiritual.md). This companion note situates the helix within a wider cosmological frame.
-
-## Task List
-- [ ] Weave cathedral-scale vesica grids to frame expansive worlds.
-- [ ] Map Tree-of-Life nodes to sanctuaries like Avalon and mountain temples.
-- [ ] Layer Fibonacci paths through oceans, rivers, and volcanic corridors.
-- [ ] Cross-link double-helix lattices with rune, tarot, and reiki lore.
-- [ ] Keep all additions ND-safe: no motion, high contrast, pure functions.
-
-
-## Related Lore
-For a meditation on the tesseract as symbol of higher consciousness and non-linear learning, see [docs/tesseract_spiritual.md](./docs/tesseract_spiritual.md). This companion note situates the helix within a wider cosmological frame.
-
 
 ## Design notes
-- Static HTML and Canvas keep rendering local and deterministic.
-- Geometry routines live in `js/helix-renderer.mjs` with small pure functions and ASCII quotes only.
+- Geometry parameters lean on numerology constants 3, 7, 9, 11, 22, 33, 99, 144.
+- Implementation uses pure functions in `js/helix-renderer.mjs`, ES modules, ASCII quotes, UTF-8, LF.
 
 ## Extending
-The renderer is intentionally minimal. Future layers can extend `renderHelix` while preserving the calm visual hierarchy.
-
-
+Add future layers by extending `renderHelix` with new pure draw functions while preserving the calm visual hierarchy.

--- a/cosmic-helix/index.html
+++ b/cosmic-helix/index.html
@@ -34,12 +34,14 @@
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
 
+    // Local fetch helper; if the file is absent we fall back to defaults.
     async function loadJSON(path) {
       try {
         const res = await fetch(path, { cache: "no-store" });
         if (!res.ok) throw new Error(String(res.status));
         return await res.json();
       } catch (err) {
+        // Offline-first: missing files simply return null.
         return null;
       }
     }
@@ -52,6 +54,7 @@
       }
     };
 
+    // If palette.json is missing we notify and use the embedded safe palette.
     const palette = await loadJSON("./data/palette.json");
     const active = palette || defaults.palette;
     elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";

--- a/cosmic-helix/js/helix-renderer.mjs
+++ b/cosmic-helix/js/helix-renderer.mjs
@@ -20,6 +20,7 @@ export function renderHelix(ctx, opts) {
   ctx.fillStyle = palette.bg;
   ctx.fillRect(0, 0, width, height);
 
+  // Layer order matters: background first, lattice last for depth.
   drawVesicaField(ctx, width, height, palette.layers[0], N);
   drawTreeOfLife(ctx, width, height, palette.layers[1], palette.layers[2], N);
   drawFibonacci(ctx, width, height, palette.layers[3], N);
@@ -27,6 +28,7 @@ export function renderHelix(ctx, opts) {
 }
 
 function drawVesicaField(ctx, w, h, color, N) {
+  // Static circle grid; spacing via N.SEVEN keeps scene open.
   ctx.strokeStyle = color;
   const radius = Math.min(w, h) / N.THREE; // ensures soft overlap
   const step = radius / N.SEVEN; // grid density tuned by 7
@@ -40,6 +42,7 @@ function drawVesicaField(ctx, w, h, color, N) {
 }
 
 function drawTreeOfLife(ctx, w, h, pathColor, nodeColor, N) {
+  // Simplified scaffold for clarity; no overlapping paths.
   ctx.strokeStyle = pathColor;
   ctx.lineWidth = 2;
 
@@ -82,6 +85,7 @@ function drawFibonacci(ctx, w, h, color, N) {
   ctx.strokeStyle = color;
   ctx.lineWidth = 2;
   const fib = [1, 1];
+  // Finite sequence avoids infinite spiral and keeps render deterministic.
   while (fib.length < N.NINE) fib.push(fib[fib.length - 1] + fib[fib.length - 2]);
   const scale = Math.min(w, h) / N.ONEFORTYFOUR; // golden curve size
   let angle = 0;
@@ -99,6 +103,7 @@ function drawFibonacci(ctx, w, h, color, N) {
 }
 
 function drawHelix(ctx, w, h, colorA, colorB, N) {
+  // Two fixed sine tracks form a quiet lattice.
   const midY = h / 2;
   const amplitude = (h / N.NINETYNINE) * N.ELEVEN; // gentle vertical spread
   const stepX = w / N.ONEFORTYFOUR;


### PR DESCRIPTION
## Summary
- document offline Cosmic Helix renderer and ND-safe design
- clarify layer rendering order and palette fallback comments
- trim README for the static renderer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c11e60ea0c8328bc466d2d0f02cedb