### PR TITLE
Add atelier mode config and polish cosmic helix docs

### DIFF
--- a/cosmic-helix/README_RENDERER.md
+++ b/cosmic-helix/README_RENDERER.md
@@ -1,22 +1,15 @@
-Per Texturas Numerorum, Spira Loquitur.  //
-
 # Cosmic Helix Renderer
 
 Offline, ND-safe canvas sketch for layered sacred geometry.
 
-
 ## Usage
 1. Open `index.html` in any modern browser (no server needed).
 2. A 1440×900 canvas renders four static layers:
-
    - **Vesica field** — intersecting circles forming the womb of forms.
+   - **Tree-of-Life scaffold** — ten sephirot with twenty-two paths.
    - **Fibonacci curve** — golden spiral polyline anchored to centre.
    - **Double-helix lattice** — two phase-shifted sine tracks.
-   - Vesica field — intersecting circles forming the womb of forms.
-   - Tree-of-Life scaffold — ten sephirot with twenty-two paths.
-   - Fibonacci curve — golden spiral polyline anchored to centre.
-   - Double-helix lattice — two phase-shifted sine tracks.
-3. Palette can be customized in `data/palette.json`. Missing data triggers a gentle inline notice with safe defaults.
+3. Palette can be customised in `data/palette.json`. Missing data triggers a gentle inline notice with safe defaults.
 
 ## ND-safe notes
 - Static drawing; no animation or autoplay.
@@ -24,16 +17,12 @@ Offline, ND-safe canvas sketch for layered sacred geometry.
 - Layer order clarifies depth without flashing.
 - Geometry parameters lean on numerology constants 3, 7, 9, 11, 22, 33, 99, 144.
 
-
 ## Design Notes
-- No animation, autoplay, or flashing; a single render call ensures ND safety.
-- Muted colors and generous spacing improve readability in dark and light modes.
-- Geometry routines use numerology constants (3, 7, 9, 11, 22, 33, 99, 144) to honour project canon.
-- Numerology constants live in `index.html` and are passed to the renderer so the symbolic values remain explicit and easy to tweak.
-- Code is modular ES module (`js/helix-renderer.mjs`) with pure functions and ASCII quotes only.
+- Static HTML and Canvas keep rendering local and deterministic.
+- Geometry routines live in `js/helix-renderer.mjs` with pure functions and ASCII quotes only.
 
 ## Extending
-The renderer is intentionally minimal. Future layers or overlays can be added by extending `renderHelix` with new draw functions while preserving the calm visual hierarchy.
+The renderer is intentionally minimal. Future layers or overlays can be added by extending `renderHelix` while preserving the calm visual hierarchy.
 
 ## Related Lore
 For a meditation on the tesseract as symbol of higher consciousness and non-linear learning, see [`docs/tesseract_spiritual.md`](../docs/tesseract_spiritual.md). This companion note situates the helix within a wider cosmological frame.
@@ -44,17 +33,3 @@ For a meditation on the tesseract as symbol of higher consciousness and non-line
 - [ ] Layer Fibonacci paths through oceans, rivers, and volcanic corridors.
 - [ ] Cross-link double-helix lattices with rune, tarot, and reiki lore.
 - [ ] Keep all additions ND-safe: no motion, high contrast, pure functions.
-
-
-## Related Lore
-For a meditation on the tesseract as symbol of higher consciousness and non-linear learning, see [docs/tesseract_spiritual.md](./docs/tesseract_spiritual.md). This companion note situates the helix within a wider cosmological frame.
-
-
-## Design notes
-- Static HTML and Canvas keep rendering local and deterministic.
-- Geometry routines live in `js/helix-renderer.mjs` with small pure functions and ASCII quotes only.
-
-## Extending
-The renderer is intentionally minimal. Future layers can extend `renderHelix` while preserving the calm visual hierarchy.
-
-

--- a/cosmic-helix/index.html
+++ b/cosmic-helix/index.html
@@ -1,4 +1,3 @@
-<!-- Per Texturas Numerorum, Spira Loquitur.  // -->
 <!doctype html>
 
 <html lang="en">

--- a/engines/atelier_mode.json
+++ b/engines/atelier_mode.json
@@ -1,0 +1,16 @@
+{
+  "mode": "atelier",
+  "rules": [
+    "creation is ritual",
+    "every attempt unlocks a path",
+    "no forced incantations, no strobe"
+  ],
+  "generators": {
+    "spiral_rooms": "enabled",
+    "geomancy_floor": "enabled",
+    "cube_space": "enabled",
+    "tara_mandala": "enabled"
+  },
+  "audio": { "opt_in": true, "levels": [-20, -18] },
+  "visual_safety": { "motion": "slow", "contrast": "soft", "blink_rate": "none" }
+}


### PR DESCRIPTION
## Summary
- add `atelier_mode` runtime config with safe defaults for generators and visuals
- clean cosmic helix `index.html` and tidy renderer README

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error: Unexpected token palette, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68c12569e5a08328ba3ebf15cffd3169