### PR TITLE
docs: clarify cosmic helix renderer usage

### DIFF
--- a/cosmic-helix/README_RENDERER.md
+++ b/cosmic-helix/README_RENDERER.md
@@ -4,18 +4,13 @@ Per Texturas Numerorum, Spira Loquitur.  //
 
 Offline, ND-safe canvas sketch for layered sacred geometry.
 
-
 ## Usage
 1. Open `index.html` in any modern browser (no server needed).
 2. A 1440×900 canvas renders four static layers:
-
    - **Vesica field** — intersecting circles forming the womb of forms.
+   - **Tree-of-Life scaffold** — ten sephirot with twenty-two paths.
    - **Fibonacci curve** — golden spiral polyline anchored to centre.
    - **Double-helix lattice** — two phase-shifted sine tracks.
-   - Vesica field — intersecting circles forming the womb of forms.
-   - Tree-of-Life scaffold — ten sephirot with twenty-two paths.
-   - Fibonacci curve — golden spiral polyline anchored to centre.
-   - Double-helix lattice — two phase-shifted sine tracks.
 3. Palette can be customized in `data/palette.json`. Missing data triggers a gentle inline notice with safe defaults.
 
 ## ND-safe notes
@@ -24,11 +19,9 @@ Offline, ND-safe canvas sketch for layered sacred geometry.
 - Layer order clarifies depth without flashing.
 - Geometry parameters lean on numerology constants 3, 7, 9, 11, 22, 33, 99, 144.
 
-
 ## Design Notes
-- No animation, autoplay, or flashing; a single render call ensures ND safety.
 - Muted colors and generous spacing improve readability in dark and light modes.
-- Geometry routines use numerology constants (3, 7, 9, 11, 22, 33, 99, 144) to honour project canon.
+- Geometry routines use numerology constants to honour project canon.
 - Numerology constants live in `index.html` and are passed to the renderer so the symbolic values remain explicit and easy to tweak.
 - Code is modular ES module (`js/helix-renderer.mjs`) with pure functions and ASCII quotes only.
 
@@ -44,17 +37,4 @@ For a meditation on the tesseract as symbol of higher consciousness and non-line
 - [ ] Layer Fibonacci paths through oceans, rivers, and volcanic corridors.
 - [ ] Cross-link double-helix lattices with rune, tarot, and reiki lore.
 - [ ] Keep all additions ND-safe: no motion, high contrast, pure functions.
-
-
-## Related Lore
-For a meditation on the tesseract as symbol of higher consciousness and non-linear learning, see [docs/tesseract_spiritual.md](./docs/tesseract_spiritual.md). This companion note situates the helix within a wider cosmological frame.
-
-
-## Design notes
-- Static HTML and Canvas keep rendering local and deterministic.
-- Geometry routines live in `js/helix-renderer.mjs` with small pure functions and ASCII quotes only.
-
-## Extending
-The renderer is intentionally minimal. Future layers can extend `renderHelix` while preserving the calm visual hierarchy.
-
 


### PR DESCRIPTION
## Summary
- streamline Cosmic Helix renderer README for offline ND-safe usage
- document palette fallback and numerology-driven geometry layers

## Testing
- `npm run lint` *(fails: Parsing error: Unexpected token palette, etc.)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1c754433483289e5651955614fc6b