### PR TITLE
feat: boot helix and collage effects

### DIFF
--- a/index.html
+++ b/index.html
@@ -2235,5 +2235,29 @@
       applyState();
       spiral.draw();
     </script>
+    <script type="module">
+      import { mountHelix, setHelixLayers, setPulse, bindSymbolClick } from "./effects/helix.js";
+      import { mountCollage } from "./effects/collage.js";
+
+      (async () => {
+        try {
+          await mountHelix('#helixMount','data/helix_spec.json','data/symbols.json');
+          await mountCollage('#collageMount','data/symbols.json');
+
+          // sane defaults: angels on, demons off, beads on, calm pulse
+          setHelixLayers('#helixMount',{angels:true, demons:false, beads:true});
+          setPulse('#helixMount', true);
+
+          // click on any slot → show info (no autoplay sound)
+          bindSymbolClick('#helixMount', (detail, meta)=>{
+            const name = meta?.title || detail.key;
+            alert(`${detail.kind.toUpperCase()}: ${name}`);
+            // If you want opt-in tone: playTone(meta?.hz) — implement only by button press to remain ND-safe.
+          });
+        } catch (e) {
+          console.error(e);
+        }
+      })();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- bootstrap helix and collage effects with default layer and pulse settings
- show alert with symbol metadata when clicking helix slots

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c38e1706408328a767b07aa5020bad