### PR TITLE
feat: add planet-based angel lookup

### DIFF
--- a/scripts/effects/angels.js
+++ b/scripts/effects/angels.js
@@ -1,0 +1,11 @@
+import angels from "../../liber-arcanae/data/consecration-angels.json" assert { type: "json" };
+
+// Retrieves angel metadata for a given planetary name.
+// Returns an object containing the angel's name and attributes or null if not found.
+export function angelForPlanet(planet) {
+  for (const [name, a] of Object.entries(angels)) {
+    if (a.planet === planet) return { name, ...a };
+  }
+  return null;
+}
+


### PR DESCRIPTION
## Summary
- add `angelForPlanet` helper to fetch angel metadata from consecration registry

## Testing
- `./scripts/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c3aa6730b48328a75ee4e2801b7e58