### PR TITLE
Add base ND-safe stylesheet

### DIFF
--- a/assets/styles/base.css
+++ b/assets/styles/base.css
@@ -1,0 +1,16 @@
+:root{
+  --obsidian:#0F0B1E; --violet:#7A3EB1; --teal:#29C7CE; --gold:#F6C847; /* tokens per covenant */
+}
+*{box-sizing:border-box} html{color-scheme:dark light}
+body{margin:0;font:16px/1.5 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;background:var(--obsidian);color:#eee}
+.wrap{max-width:72rem;margin:auto;padding:2rem}
+.site-hdr{padding:1.25rem 2rem;border-bottom:1px solid #222}
+h1,h2{font-weight:700;margin:0 0 .75rem}
+.sub{opacity:.8}
+button,select{font:inherit;padding:.5rem .75rem;border-radius:.5rem;border:1px solid #333;background:#111;color:#fff}
+button:hover{background:#151515}
+.swatches{display:flex;gap:.5rem;flex-wrap:wrap;margin-top:.5rem}
+.chip{width:2rem;height:2rem;border-radius:.4rem;border:1px solid #444}
+.status{margin:.5rem 0 1rem;opacity:.85}
+canvas{display:block;max-width:100%;height:auto;border:1px solid #2a2a2a;border-radius:.75rem;background:#000}
+@media (prefers-reduced-motion: reduce){ *{animation:none !important; transition:none !important} }


### PR DESCRIPTION
## Summary
- add ND-safe base stylesheet with covenant palette and reduced-motion defaults

## Testing
- `npm test`
- `npm run lint` *(fails: parsing errors and undefined variables)*

------
https://chatgpt.com/codex/tasks/task_e_68c726d2c638832880d80b6e26d010c8