### PR TITLE
Expand Tree-of-Life to 22 paths

### DIFF
--- a/helix/js/helix-renderer.mjs
+++ b/helix/js/helix-renderer.mjs
@@ -43,10 +43,18 @@ function drawTree(ctx, w, h, colorNode, colorPath, N) {
   ].map(p => ({ x: p.x * w, y: p.y * h }));
 
   const paths = [
-    [0,1],[0,2],[1,2],[1,3],[1,5],[2,4],[2,5],
-    [3,5],[4,5],[3,6],[4,7],[5,6],[5,7],
-    [6,7],[6,8],[7,8],[8,9]
+    [0,1],[0,2],[0,5],
+    [1,2],[1,3],[1,5],[1,6],
+    [2,3],[2,5],[2,4],
+    [3,4],[3,5],[3,6],
+    [4,5],[4,7],
+    [5,6],[5,7],[5,8],
+    [6,7],[6,8],
+    [7,8],
+    [8,9]
   ];
+  // sanity check: keep symbolic 22 paths
+  if (paths.length !== N.TWENTYTWO) console.warn("Tree path count != 22");
 
   ctx.strokeStyle = colorPath;
   ctx.lineWidth = 2;


### PR DESCRIPTION
## Summary
- Ensure Tree-of-Life scaffold covers all 22 symbolic paths.
- Add numerological path count check for consistency.

## Testing
- `node --check helix/js/helix-renderer.mjs`
- `node -e "import('./helix/js/helix-renderer.mjs').then(m=>console.log('exports',Object.keys(m)))"`


------
https://chatgpt.com/codex/tasks/task_e_68c79a3b4e308328b9e71d548abc2b72