### PR TITLE
Add modular pedagogical design scroll

### DIFF
--- a/docs/modular_pedagogical_design.md
+++ b/docs/modular_pedagogical_design.md
@@ -1,0 +1,1513 @@
+# Modular Pedagogical Design (Codex 144:99)
+
+This scroll braids numerology, lineage octagrams, and Liber Arcanae archetypes into a modular research OS. Each entry honours the PROTECT covenant: ND-safe pacing, layered geometry, provenance-first storytelling, and offline-first delivery. Learners choose their own narrator by toggling Liber Arcanae filters, octagram lineages, and numbered capsules; every asset references CC-BY/SA or companion provenance JSON so scholarship and play remain inseparable.
+
+## Method Overview
+
+- **Modular Pedagogical Anchors:** Nodes 00–144 act as micro-ateliers mixing numerology reductions, symbolic cognition, and open-source assets. Each capsule documents roots, style, belief, psyche healing arc, crystal anchor, and a playable ritual so research memos double as experiential puzzles.
+- **Cross-Modal Integration:** Liber Arcanae archetypes serve as OS filters linking art/music generators, chapel environments, avatar interfaces, and behavioural effects. Learners can route to their preferred narrator (angel, poet, engineer, or witch) without breaking lineage fidelity.
+- **Live Ritualized Research:** Updates publish as scholarly dossiers that are simultaneously games—protective seals become save points, colour-tone puzzles teach synesthetic logic, Soyga tables drive angelic math labs.
+- **Open Source + Provenance:** Every layer maintains CC-BY/SA licensing and provenance JSON threads, echoing the repository's provenance.md and registry maps.
+- **Modern Hooks:** AI-adjacent art/music tools stay local and opt-in, neuro-aesthetics guide palettes and pacing, trauma-aware design ensures undo/safe-stop controls, and the Octagram Tesseracts provide lineage toggles reminiscent of modular ed-tech dashboards.
+
+## I. Numbered Node Capsules (0–144)
+
+Each node records its numerology layer path (digital reduction), pedagogical lineage, and ritual design. Master numbers surface additional overlays for double trees, living spine harmonics, and helix calibrations.
+
+
+### Node 00 — Carrington Fool Zero Gate
+
+- **Layer Path:** 0
+- **Roots:** Carrington surreal diaries braid Catholic mysticism, surrealist trauma recovery, and Hermetic alchemy; provenance is preserved through CC-BY dream archives.
+- **Style:** Vesica night-chapel with indigo bone light and brass etching (Exact Magus / Angel Science palette).
+- **Beliefs:** Breath-as-covenant; silence frames every invocation.
+- **Psyche:** Numb void → restful presence.
+- **Crystal Anchor:** Clear Quartz — amplifies threshold innocence for safe resets.
+- **Playable Ritual:** Trace vesica breath maps with surreal Carrington journal cues and CC-BY collage cards.
+
+### Node 01 — Carrington Field Monad Spark
+
+- **Layer Path:** 1
+- **Roots:** Carrington surreal sanctuaries braided with Catholic mystic devotions; CC-BY dream collage sets from the Visionary open archive keep provenance intact.
+- **Style:** Golden geomantic blueprint desk with articulated sigil grids (Cathedral × Visionary blend).
+- **Beliefs:** Hermetic monism — intention scripts material architecture.
+- **Psyche:** Silenced voice → lucid intention.
+- **Crystal Anchor:** Citrine — focuses intention into speech rituals.
+- **Playable Ritual:** Code single-sigil intention grids with surreal Carrington journal cues and CC-BY collage cards.
+
+### Node 02 — Carrington Field Dyad Bridge
+
+- **Layer Path:** 2
+- **Roots:** Carrington surreal sanctuaries braided with Catholic mystic devotions; CC-BY dream collage sets from the Visionary open archive keep provenance intact.
+- **Style:** Twin-lantern reflection pool with mirrored calligraphy and quiet harp loops.
+- **Beliefs:** Sacred reciprocity; knowing emerges through mirrored companionship.
+- **Psyche:** Isolation → relational reciprocity.
+- **Crystal Anchor:** Moonstone — soothes mirrored intuition.
+- **Playable Ritual:** Pair mirrored inquiry dialogues with surreal Carrington journal cues and CC-BY collage cards.
+
+### Node 03 — Carrington Field Triad Loom
+
+- **Layer Path:** 3
+- **Roots:** Carrington surreal sanctuaries braided with Catholic mystic devotions; CC-BY dream collage sets from the Visionary open archive keep provenance intact.
+- **Style:** Triptych collage wall — code, icon, and field notes stitched into one canvas.
+- **Beliefs:** Trinitarian synthesis marries art, science, and magic without hierarchy.
+- **Psyche:** Fragmentation → creative coherence.
+- **Crystal Anchor:** Rose Quartz — nourishes creative synthesis.
+- **Playable Ritual:** Compose triadic collage prompts with surreal Carrington journal cues and CC-BY collage cards.
+
+### Node 04 — Carrington Field Foundation Pillar
+
+- **Layer Path:** 4
+- **Roots:** Carrington surreal sanctuaries braided with Catholic mystic devotions; CC-BY dream collage sets from the Visionary open archive keep provenance intact.
+- **Style:** Marble and oak archive alcove with measured lattice shadows for grounding.
+- **Beliefs:** Structure as sanctuary; disciplined boundaries invite trust.
+- **Psyche:** Instability → grounded scaffolding.
+- **Crystal Anchor:** Red Jasper — grounds architectural memory.
+- **Playable Ritual:** Build square-floor memory palaces with surreal Carrington journal cues and CC-BY collage cards.
+
+### Node 05 — Carrington Field Voyager Path
+
+- **Layer Path:** 5
+- **Roots:** Carrington surreal sanctuaries braided with Catholic mystic devotions; CC-BY dream collage sets from the Visionary open archive keep provenance intact.
+- **Style:** Star-chart navigation table traced in soft neon for gentle exploration.
+- **Beliefs:** Pilgrimage pedagogy — learning through gentle voyages and curiosity.
+- **Psyche:** Hypervigilance → exploratory courage.
+- **Crystal Anchor:** Sodalite — supports exploratory navigation.
+- **Playable Ritual:** Chart pilgrim constellation routes with surreal Carrington journal cues and CC-BY collage cards.
+
+### Node 06 — Carrington Field Harmony Weave
+
+- **Layer Path:** 6
+- **Roots:** Carrington surreal sanctuaries braided with Catholic mystic devotions; CC-BY dream collage sets from the Visionary open archive keep provenance intact.
+- **Style:** Harmonic choir loft draped in auric textiles and resonant water bowls.
+- **Beliefs:** Harmony heals; resonance codes neuroplastic repair.
+- **Psyche:** Emotional flooding → empathic regulation.
+- **Crystal Anchor:** Rhodochrosite — harmonizes empathic co-regulation.
+- **Playable Ritual:** Weave harmonic chant loops with surreal Carrington journal cues and CC-BY collage cards.
+
+### Node 07 — Carrington Field Mystic Ladder
+
+- **Layer Path:** 7
+- **Roots:** Carrington surreal sanctuaries braided with Catholic mystic devotions; CC-BY dream collage sets from the Visionary open archive keep provenance intact.
+- **Style:** Observatory cloister lit by violet candles and polished brass astrolabes.
+- **Beliefs:** Contemplation reveals angelic pattern language beyond linear time.
+- **Psyche:** Spiritual exile → contemplative belonging.
+- **Crystal Anchor:** Carnelian — anchors contemplative vision.
+- **Playable Ritual:** Conduct contemplative script walks with surreal Carrington journal cues and CC-BY collage cards.
+
+### Node 08 — Carrington Field Octave Bloom
+
+- **Layer Path:** 8
+- **Roots:** Carrington surreal sanctuaries braided with Catholic mystic devotions; CC-BY dream collage sets from the Visionary open archive keep provenance intact.
+- **Style:** Double-helix gallery hung with translucent indigo panels and crystal lattices.
+- **Beliefs:** Cycles orchestrate transformation; every octave births a twin.
+- **Psyche:** Overextension → rhythmic pacing.
+- **Crystal Anchor:** Tiger's Eye — stabilizes octave expansion.
+- **Playable Ritual:** Plot double-helix waypoint lattices with surreal Carrington journal cues and CC-BY collage cards.
+
+### Node 09 — Carrington Field Integration Halo
+
+- **Layer Path:** 9
+- **Roots:** Carrington surreal sanctuaries braided with Catholic mystic devotions; CC-BY dream collage sets from the Visionary open archive keep provenance intact.
+- **Style:** Integrative dome mosaic weaving all previous palettes into one calm halo.
+- **Beliefs:** Integration completes the spiral; all fragments return illuminated.
+- **Psyche:** Burnout → luminous integration.
+- **Crystal Anchor:** Blue Aventurine — magnetizes integrative closure.
+- **Playable Ritual:** Stage integration councils with surreal Carrington journal cues and CC-BY collage cards.
+
+### Node 10 — Fortune Ward Monad Spark
+
+- **Layer Path:** 10 → 1+0=1
+- **Roots:** Dion Fortune protective lodges mapping sanctuary seals; Cathedral registry ritual diagrams are shared under CC-BY-SA.
+- **Style:** Golden geomantic blueprint desk with articulated sigil grids (Cathedral × Visionary blend).
+- **Beliefs:** Hermetic monism — intention scripts material architecture.
+- **Psyche:** Silenced voice → lucid intention.
+- **Crystal Anchor:** Blue Kyanite — focuses intention into speech rituals.
+- **Playable Ritual:** Code single-sigil intention grids using Fortune-style protective seals as save points.
+
+### Node 11 — Fortune Ward Dyad Bridge
+
+- **Layer Path:** 11 → 1+1=2
+- **Roots:** Dion Fortune protective lodges mapping sanctuary seals; Cathedral registry ritual diagrams are shared under CC-BY-SA. Master 11 amplifies twin pillars — toggling Justice/Lovers narrative mentoring.
+- **Style:** Twin-lantern reflection pool with mirrored calligraphy and quiet harp loops.
+- **Beliefs:** Sacred reciprocity; knowing emerges through mirrored companionship.
+- **Psyche:** Isolation → relational reciprocity.
+- **Crystal Anchor:** Aquamarine — soothes mirrored intuition.
+- **Playable Ritual:** Pair mirrored inquiry dialogues using Fortune-style protective seals as save points.
+
+### Node 12 — Fortune Ward Triad Loom
+
+- **Layer Path:** 12 → 1+2=3
+- **Roots:** Dion Fortune protective lodges mapping sanctuary seals; Cathedral registry ritual diagrams are shared under CC-BY-SA.
+- **Style:** Triptych collage wall — code, icon, and field notes stitched into one canvas.
+- **Beliefs:** Trinitarian synthesis marries art, science, and magic without hierarchy.
+- **Psyche:** Fragmentation → creative coherence.
+- **Crystal Anchor:** Obsidian — nourishes creative synthesis.
+- **Playable Ritual:** Compose triadic collage prompts using Fortune-style protective seals as save points.
+
+### Node 13 — Fortune Ward Foundation Pillar
+
+- **Layer Path:** 13 → 1+3=4
+- **Roots:** Dion Fortune protective lodges mapping sanctuary seals; Cathedral registry ritual diagrams are shared under CC-BY-SA.
+- **Style:** Marble and oak archive alcove with measured lattice shadows for grounding.
+- **Beliefs:** Structure as sanctuary; disciplined boundaries invite trust.
+- **Psyche:** Instability → grounded scaffolding.
+- **Crystal Anchor:** Labradorite — grounds architectural memory.
+- **Playable Ritual:** Build square-floor memory palaces using Fortune-style protective seals as save points.
+
+### Node 14 — Fortune Ward Voyager Path
+
+- **Layer Path:** 14 → 1+4=5
+- **Roots:** Dion Fortune protective lodges mapping sanctuary seals; Cathedral registry ritual diagrams are shared under CC-BY-SA.
+- **Style:** Star-chart navigation table traced in soft neon for gentle exploration.
+- **Beliefs:** Pilgrimage pedagogy — learning through gentle voyages and curiosity.
+- **Psyche:** Hypervigilance → exploratory courage.
+- **Crystal Anchor:** Jet — supports exploratory navigation.
+- **Playable Ritual:** Chart pilgrim constellation routes using Fortune-style protective seals as save points.
+
+### Node 15 — Fortune Ward Harmony Weave
+
+- **Layer Path:** 15 → 1+5=6
+- **Roots:** Dion Fortune protective lodges mapping sanctuary seals; Cathedral registry ritual diagrams are shared under CC-BY-SA.
+- **Style:** Harmonic choir loft draped in auric textiles and resonant water bowls.
+- **Beliefs:** Harmony heals; resonance codes neuroplastic repair.
+- **Psyche:** Emotional flooding → empathic regulation.
+- **Crystal Anchor:** Garnet — harmonizes empathic co-regulation.
+- **Playable Ritual:** Weave harmonic chant loops using Fortune-style protective seals as save points.
+
+### Node 16 — Fortune Ward Mystic Ladder
+
+- **Layer Path:** 16 → 1+6=7
+- **Roots:** Dion Fortune protective lodges mapping sanctuary seals; Cathedral registry ritual diagrams are shared under CC-BY-SA.
+- **Style:** Observatory cloister lit by violet candles and polished brass astrolabes.
+- **Beliefs:** Contemplation reveals angelic pattern language beyond linear time.
+- **Psyche:** Spiritual exile → contemplative belonging.
+- **Crystal Anchor:** Celestite — anchors contemplative vision.
+- **Playable Ritual:** Conduct contemplative script walks using Fortune-style protective seals as save points.
+
+### Node 17 — Fortune Ward Octave Bloom
+
+- **Layer Path:** 17 → 1+7=8
+- **Roots:** Dion Fortune protective lodges mapping sanctuary seals; Cathedral registry ritual diagrams are shared under CC-BY-SA.
+- **Style:** Double-helix gallery hung with translucent indigo panels and crystal lattices.
+- **Beliefs:** Cycles orchestrate transformation; every octave births a twin.
+- **Psyche:** Overextension → rhythmic pacing.
+- **Crystal Anchor:** Selenite — stabilizes octave expansion.
+- **Playable Ritual:** Plot double-helix waypoint lattices using Fortune-style protective seals as save points.
+
+### Node 18 — Fortune Ward Integration Halo
+
+- **Layer Path:** 18 → 1+8=9
+- **Roots:** Dion Fortune protective lodges mapping sanctuary seals; Cathedral registry ritual diagrams are shared under CC-BY-SA.
+- **Style:** Integrative dome mosaic weaving all previous palettes into one calm halo.
+- **Beliefs:** Integration completes the spiral; all fragments return illuminated.
+- **Psyche:** Burnout → luminous integration.
+- **Crystal Anchor:** Sunstone — magnetizes integrative closure.
+- **Playable Ritual:** Stage integration councils using Fortune-style protective seals as save points.
+
+### Node 19 — Fortune Ward Monad Spark
+
+- **Layer Path:** 19 → 1+9=10 → 1+0=1
+- **Roots:** Dion Fortune protective lodges mapping sanctuary seals; Cathedral registry ritual diagrams are shared under CC-BY-SA.
+- **Style:** Golden geomantic blueprint desk with articulated sigil grids (Cathedral × Visionary blend).
+- **Beliefs:** Hermetic monism — intention scripts material architecture.
+- **Psyche:** Silenced voice → lucid intention.
+- **Crystal Anchor:** Fire Opal — focuses intention into speech rituals.
+- **Playable Ritual:** Code single-sigil intention grids using Fortune-style protective seals as save points.
+
+### Node 20 — Agrippa Circuit Dyad Bridge
+
+- **Layer Path:** 20 → 2+0=2
+- **Roots:** Agrippa planetary correspondences cross-wired with open-source sigil engines for transparent experimentation.
+- **Style:** Twin-lantern reflection pool with mirrored calligraphy and quiet harp loops.
+- **Beliefs:** Sacred reciprocity; knowing emerges through mirrored companionship.
+- **Psyche:** Isolation → relational reciprocity.
+- **Crystal Anchor:** Hematite — soothes mirrored intuition.
+- **Playable Ritual:** Pair mirrored inquiry dialogues while cross-referencing Agrippa planetary tables via open sigil generators.
+
+### Node 21 — Agrippa Circuit Triad Loom
+
+- **Layer Path:** 21 → 2+1=3
+- **Roots:** Agrippa planetary correspondences cross-wired with open-source sigil engines for transparent experimentation.
+- **Style:** Triptych collage wall — code, icon, and field notes stitched into one canvas.
+- **Beliefs:** Trinitarian synthesis marries art, science, and magic without hierarchy.
+- **Psyche:** Fragmentation → creative coherence.
+- **Crystal Anchor:** Fluorite — nourishes creative synthesis.
+- **Playable Ritual:** Compose triadic collage prompts while cross-referencing Agrippa planetary tables via open sigil generators.
+
+### Node 22 — Agrippa Circuit Foundation Pillar
+
+- **Layer Path:** 22 → 2+2=4
+- **Roots:** Agrippa planetary correspondences cross-wired with open-source sigil engines for transparent experimentation. Master 22 builds the double Tree; invites structural ritual design.
+- **Style:** Marble and oak archive alcove with measured lattice shadows for grounding.
+- **Beliefs:** Structure as sanctuary; disciplined boundaries invite trust.
+- **Psyche:** Instability → grounded scaffolding.
+- **Crystal Anchor:** Clear Quartz — grounds architectural memory.
+- **Playable Ritual:** Build square-floor memory palaces while cross-referencing Agrippa planetary tables via open sigil generators.
+
+### Node 23 — Agrippa Circuit Voyager Path
+
+- **Layer Path:** 23 → 2+3=5
+- **Roots:** Agrippa planetary correspondences cross-wired with open-source sigil engines for transparent experimentation.
+- **Style:** Star-chart navigation table traced in soft neon for gentle exploration.
+- **Beliefs:** Pilgrimage pedagogy — learning through gentle voyages and curiosity.
+- **Psyche:** Hypervigilance → exploratory courage.
+- **Crystal Anchor:** Citrine — supports exploratory navigation.
+- **Playable Ritual:** Chart pilgrim constellation routes while cross-referencing Agrippa planetary tables via open sigil generators.
+
+### Node 24 — Agrippa Circuit Harmony Weave
+
+- **Layer Path:** 24 → 2+4=6
+- **Roots:** Agrippa planetary correspondences cross-wired with open-source sigil engines for transparent experimentation.
+- **Style:** Harmonic choir loft draped in auric textiles and resonant water bowls.
+- **Beliefs:** Harmony heals; resonance codes neuroplastic repair.
+- **Psyche:** Emotional flooding → empathic regulation.
+- **Crystal Anchor:** Moonstone — harmonizes empathic co-regulation.
+- **Playable Ritual:** Weave harmonic chant loops while cross-referencing Agrippa planetary tables via open sigil generators.
+
+### Node 25 — Agrippa Circuit Mystic Ladder
+
+- **Layer Path:** 25 → 2+5=7
+- **Roots:** Agrippa planetary correspondences cross-wired with open-source sigil engines for transparent experimentation.
+- **Style:** Observatory cloister lit by violet candles and polished brass astrolabes.
+- **Beliefs:** Contemplation reveals angelic pattern language beyond linear time.
+- **Psyche:** Spiritual exile → contemplative belonging.
+- **Crystal Anchor:** Rose Quartz — anchors contemplative vision.
+- **Playable Ritual:** Conduct contemplative script walks while cross-referencing Agrippa planetary tables via open sigil generators.
+
+### Node 26 — Agrippa Circuit Octave Bloom
+
+- **Layer Path:** 26 → 2+6=8
+- **Roots:** Agrippa planetary correspondences cross-wired with open-source sigil engines for transparent experimentation.
+- **Style:** Double-helix gallery hung with translucent indigo panels and crystal lattices.
+- **Beliefs:** Cycles orchestrate transformation; every octave births a twin.
+- **Psyche:** Overextension → rhythmic pacing.
+- **Crystal Anchor:** Red Jasper — stabilizes octave expansion.
+- **Playable Ritual:** Plot double-helix waypoint lattices while cross-referencing Agrippa planetary tables via open sigil generators.
+
+### Node 27 — Agrippa Circuit Integration Halo
+
+- **Layer Path:** 27 → 2+7=9
+- **Roots:** Agrippa planetary correspondences cross-wired with open-source sigil engines for transparent experimentation.
+- **Style:** Integrative dome mosaic weaving all previous palettes into one calm halo.
+- **Beliefs:** Integration completes the spiral; all fragments return illuminated.
+- **Psyche:** Burnout → luminous integration.
+- **Crystal Anchor:** Sodalite — magnetizes integrative closure.
+- **Playable Ritual:** Stage integration councils while cross-referencing Agrippa planetary tables via open sigil generators.
+
+### Node 28 — Agrippa Circuit Monad Spark
+
+- **Layer Path:** 28 → 2+8=10 → 1+0=1
+- **Roots:** Agrippa planetary correspondences cross-wired with open-source sigil engines for transparent experimentation.
+- **Style:** Golden geomantic blueprint desk with articulated sigil grids (Cathedral × Visionary blend).
+- **Beliefs:** Hermetic monism — intention scripts material architecture.
+- **Psyche:** Silenced voice → lucid intention.
+- **Crystal Anchor:** Rhodochrosite — focuses intention into speech rituals.
+- **Playable Ritual:** Code single-sigil intention grids while cross-referencing Agrippa planetary tables via open sigil generators.
+
+### Node 29 — Agrippa Circuit Dyad Bridge
+
+- **Layer Path:** 29 → 2+9=11 → 1+1=2
+- **Roots:** Agrippa planetary correspondences cross-wired with open-source sigil engines for transparent experimentation.
+- **Style:** Twin-lantern reflection pool with mirrored calligraphy and quiet harp loops.
+- **Beliefs:** Sacred reciprocity; knowing emerges through mirrored companionship.
+- **Psyche:** Isolation → relational reciprocity.
+- **Crystal Anchor:** Carnelian — soothes mirrored intuition.
+- **Playable Ritual:** Pair mirrored inquiry dialogues while cross-referencing Agrippa planetary tables via open sigil generators.
+
+### Node 30 — Case Chromatics Triad Loom
+
+- **Layer Path:** 30 → 3+0=3
+- **Roots:** Paul Foster Case chromatic schools bridging Builders of the Adytum lessons with CC-BY tone wheels for audio-colour study.
+- **Style:** Triptych collage wall — code, icon, and field notes stitched into one canvas.
+- **Beliefs:** Trinitarian synthesis marries art, science, and magic without hierarchy.
+- **Psyche:** Fragmentation → creative coherence.
+- **Crystal Anchor:** Tiger's Eye — nourishes creative synthesis.
+- **Playable Ritual:** Compose triadic collage prompts with Paul Foster Case colour-tone flashcards from the open studio.
+
+### Node 31 — Case Chromatics Foundation Pillar
+
+- **Layer Path:** 31 → 3+1=4
+- **Roots:** Paul Foster Case chromatic schools bridging Builders of the Adytum lessons with CC-BY tone wheels for audio-colour study.
+- **Style:** Marble and oak archive alcove with measured lattice shadows for grounding.
+- **Beliefs:** Structure as sanctuary; disciplined boundaries invite trust.
+- **Psyche:** Instability → grounded scaffolding.
+- **Crystal Anchor:** Blue Aventurine — grounds architectural memory.
+- **Playable Ritual:** Build square-floor memory palaces with Paul Foster Case colour-tone flashcards from the open studio.
+
+### Node 32 — Case Chromatics Voyager Path
+
+- **Layer Path:** 32 → 3+2=5
+- **Roots:** Paul Foster Case chromatic schools bridging Builders of the Adytum lessons with CC-BY tone wheels for audio-colour study.
+- **Style:** Star-chart navigation table traced in soft neon for gentle exploration.
+- **Beliefs:** Pilgrimage pedagogy — learning through gentle voyages and curiosity.
+- **Psyche:** Hypervigilance → exploratory courage.
+- **Crystal Anchor:** Blue Kyanite — supports exploratory navigation.
+- **Playable Ritual:** Chart pilgrim constellation routes with Paul Foster Case colour-tone flashcards from the open studio.
+
+### Node 33 — Case Chromatics Harmony Weave
+
+- **Layer Path:** 33 → 3+3=6
+- **Roots:** Paul Foster Case chromatic schools bridging Builders of the Adytum lessons with CC-BY tone wheels for audio-colour study. Master 33 hums with the Living Spine — teacher-healer broadcast.
+- **Style:** Harmonic choir loft draped in auric textiles and resonant water bowls.
+- **Beliefs:** Harmony heals; resonance codes neuroplastic repair.
+- **Psyche:** Emotional flooding → empathic regulation.
+- **Crystal Anchor:** Aquamarine — harmonizes empathic co-regulation.
+- **Playable Ritual:** Weave harmonic chant loops with Paul Foster Case colour-tone flashcards from the open studio.
+
+### Node 34 — Case Chromatics Mystic Ladder
+
+- **Layer Path:** 34 → 3+4=7
+- **Roots:** Paul Foster Case chromatic schools bridging Builders of the Adytum lessons with CC-BY tone wheels for audio-colour study.
+- **Style:** Observatory cloister lit by violet candles and polished brass astrolabes.
+- **Beliefs:** Contemplation reveals angelic pattern language beyond linear time.
+- **Psyche:** Spiritual exile → contemplative belonging.
+- **Crystal Anchor:** Obsidian — anchors contemplative vision.
+- **Playable Ritual:** Conduct contemplative script walks with Paul Foster Case colour-tone flashcards from the open studio.
+
+### Node 35 — Case Chromatics Octave Bloom
+
+- **Layer Path:** 35 → 3+5=8
+- **Roots:** Paul Foster Case chromatic schools bridging Builders of the Adytum lessons with CC-BY tone wheels for audio-colour study.
+- **Style:** Double-helix gallery hung with translucent indigo panels and crystal lattices.
+- **Beliefs:** Cycles orchestrate transformation; every octave births a twin.
+- **Psyche:** Overextension → rhythmic pacing.
+- **Crystal Anchor:** Labradorite — stabilizes octave expansion.
+- **Playable Ritual:** Plot double-helix waypoint lattices with Paul Foster Case colour-tone flashcards from the open studio.
+
+### Node 36 — Case Chromatics Integration Halo
+
+- **Layer Path:** 36 → 3+6=9
+- **Roots:** Paul Foster Case chromatic schools bridging Builders of the Adytum lessons with CC-BY tone wheels for audio-colour study.
+- **Style:** Integrative dome mosaic weaving all previous palettes into one calm halo.
+- **Beliefs:** Integration completes the spiral; all fragments return illuminated.
+- **Psyche:** Burnout → luminous integration.
+- **Crystal Anchor:** Jet — magnetizes integrative closure.
+- **Playable Ritual:** Stage integration councils with Paul Foster Case colour-tone flashcards from the open studio.
+
+### Node 37 — Case Chromatics Monad Spark
+
+- **Layer Path:** 37 → 3+7=10 → 1+0=1
+- **Roots:** Paul Foster Case chromatic schools bridging Builders of the Adytum lessons with CC-BY tone wheels for audio-colour study.
+- **Style:** Golden geomantic blueprint desk with articulated sigil grids (Cathedral × Visionary blend).
+- **Beliefs:** Hermetic monism — intention scripts material architecture.
+- **Psyche:** Silenced voice → lucid intention.
+- **Crystal Anchor:** Garnet — focuses intention into speech rituals.
+- **Playable Ritual:** Code single-sigil intention grids with Paul Foster Case colour-tone flashcards from the open studio.
+
+### Node 38 — Case Chromatics Dyad Bridge
+
+- **Layer Path:** 38 → 3+8=11 → 1+1=2
+- **Roots:** Paul Foster Case chromatic schools bridging Builders of the Adytum lessons with CC-BY tone wheels for audio-colour study.
+- **Style:** Twin-lantern reflection pool with mirrored calligraphy and quiet harp loops.
+- **Beliefs:** Sacred reciprocity; knowing emerges through mirrored companionship.
+- **Psyche:** Isolation → relational reciprocity.
+- **Crystal Anchor:** Celestite — soothes mirrored intuition.
+- **Playable Ritual:** Pair mirrored inquiry dialogues with Paul Foster Case colour-tone flashcards from the open studio.
+
+### Node 39 — Case Chromatics Triad Loom
+
+- **Layer Path:** 39 → 3+9=12 → 1+2=3
+- **Roots:** Paul Foster Case chromatic schools bridging Builders of the Adytum lessons with CC-BY tone wheels for audio-colour study.
+- **Style:** Triptych collage wall — code, icon, and field notes stitched into one canvas.
+- **Beliefs:** Trinitarian synthesis marries art, science, and magic without hierarchy.
+- **Psyche:** Fragmentation → creative coherence.
+- **Crystal Anchor:** Selenite — nourishes creative synthesis.
+- **Playable Ritual:** Compose triadic collage prompts with Paul Foster Case colour-tone flashcards from the open studio.
+
+### Node 40 — Ashmole Archive Foundation Pillar
+
+- **Layer Path:** 40 → 4+0=4
+- **Roots:** Elias Ashmole museum-librarian archives animate these nodes with digitized herbals, lapidaries, and alchemical engravings.
+- **Style:** Marble and oak archive alcove with measured lattice shadows for grounding.
+- **Beliefs:** Structure as sanctuary; disciplined boundaries invite trust.
+- **Psyche:** Instability → grounded scaffolding.
+- **Crystal Anchor:** Sunstone — grounds architectural memory.
+- **Playable Ritual:** Build square-floor memory palaces inside Ashmole herb labs with digitized botanical plates.
+
+### Node 41 — Ashmole Archive Voyager Path
+
+- **Layer Path:** 41 → 4+1=5
+- **Roots:** Elias Ashmole museum-librarian archives animate these nodes with digitized herbals, lapidaries, and alchemical engravings.
+- **Style:** Star-chart navigation table traced in soft neon for gentle exploration.
+- **Beliefs:** Pilgrimage pedagogy — learning through gentle voyages and curiosity.
+- **Psyche:** Hypervigilance → exploratory courage.
+- **Crystal Anchor:** Fire Opal — supports exploratory navigation.
+- **Playable Ritual:** Chart pilgrim constellation routes inside Ashmole herb labs with digitized botanical plates.
+
+### Node 42 — Ashmole Archive Harmony Weave
+
+- **Layer Path:** 42 → 4+2=6
+- **Roots:** Elias Ashmole museum-librarian archives animate these nodes with digitized herbals, lapidaries, and alchemical engravings.
+- **Style:** Harmonic choir loft draped in auric textiles and resonant water bowls.
+- **Beliefs:** Harmony heals; resonance codes neuroplastic repair.
+- **Psyche:** Emotional flooding → empathic regulation.
+- **Crystal Anchor:** Hematite — harmonizes empathic co-regulation.
+- **Playable Ritual:** Weave harmonic chant loops inside Ashmole herb labs with digitized botanical plates.
+
+### Node 43 — Ashmole Archive Mystic Ladder
+
+- **Layer Path:** 43 → 4+3=7
+- **Roots:** Elias Ashmole museum-librarian archives animate these nodes with digitized herbals, lapidaries, and alchemical engravings.
+- **Style:** Observatory cloister lit by violet candles and polished brass astrolabes.
+- **Beliefs:** Contemplation reveals angelic pattern language beyond linear time.
+- **Psyche:** Spiritual exile → contemplative belonging.
+- **Crystal Anchor:** Fluorite — anchors contemplative vision.
+- **Playable Ritual:** Conduct contemplative script walks inside Ashmole herb labs with digitized botanical plates.
+
+### Node 44 — Ashmole Archive Octave Bloom
+
+- **Layer Path:** 44 → 4+4=8
+- **Roots:** Elias Ashmole museum-librarian archives animate these nodes with digitized herbals, lapidaries, and alchemical engravings. Master 44 raises guardian towers for trauma-informed boundaries.
+- **Style:** Double-helix gallery hung with translucent indigo panels and crystal lattices.
+- **Beliefs:** Cycles orchestrate transformation; every octave births a twin.
+- **Psyche:** Overextension → rhythmic pacing.
+- **Crystal Anchor:** Clear Quartz — stabilizes octave expansion.
+- **Playable Ritual:** Plot double-helix waypoint lattices inside Ashmole herb labs with digitized botanical plates.
+
+### Node 45 — Ashmole Archive Integration Halo
+
+- **Layer Path:** 45 → 4+5=9
+- **Roots:** Elias Ashmole museum-librarian archives animate these nodes with digitized herbals, lapidaries, and alchemical engravings.
+- **Style:** Integrative dome mosaic weaving all previous palettes into one calm halo.
+- **Beliefs:** Integration completes the spiral; all fragments return illuminated.
+- **Psyche:** Burnout → luminous integration.
+- **Crystal Anchor:** Citrine — magnetizes integrative closure.
+- **Playable Ritual:** Stage integration councils inside Ashmole herb labs with digitized botanical plates.
+
+### Node 46 — Ashmole Archive Monad Spark
+
+- **Layer Path:** 46 → 4+6=10 → 1+0=1
+- **Roots:** Elias Ashmole museum-librarian archives animate these nodes with digitized herbals, lapidaries, and alchemical engravings.
+- **Style:** Golden geomantic blueprint desk with articulated sigil grids (Cathedral × Visionary blend).
+- **Beliefs:** Hermetic monism — intention scripts material architecture.
+- **Psyche:** Silenced voice → lucid intention.
+- **Crystal Anchor:** Moonstone — focuses intention into speech rituals.
+- **Playable Ritual:** Code single-sigil intention grids inside Ashmole herb labs with digitized botanical plates.
+
+### Node 47 — Ashmole Archive Dyad Bridge
+
+- **Layer Path:** 47 → 4+7=11 → 1+1=2
+- **Roots:** Elias Ashmole museum-librarian archives animate these nodes with digitized herbals, lapidaries, and alchemical engravings.
+- **Style:** Twin-lantern reflection pool with mirrored calligraphy and quiet harp loops.
+- **Beliefs:** Sacred reciprocity; knowing emerges through mirrored companionship.
+- **Psyche:** Isolation → relational reciprocity.
+- **Crystal Anchor:** Rose Quartz — soothes mirrored intuition.
+- **Playable Ritual:** Pair mirrored inquiry dialogues inside Ashmole herb labs with digitized botanical plates.
+
+### Node 48 — Ashmole Archive Triad Loom
+
+- **Layer Path:** 48 → 4+8=12 → 1+2=3
+- **Roots:** Elias Ashmole museum-librarian archives animate these nodes with digitized herbals, lapidaries, and alchemical engravings.
+- **Style:** Triptych collage wall — code, icon, and field notes stitched into one canvas.
+- **Beliefs:** Trinitarian synthesis marries art, science, and magic without hierarchy.
+- **Psyche:** Fragmentation → creative coherence.
+- **Crystal Anchor:** Red Jasper — nourishes creative synthesis.
+- **Playable Ritual:** Compose triadic collage prompts inside Ashmole herb labs with digitized botanical plates.
+
+### Node 49 — Ashmole Archive Foundation Pillar
+
+- **Layer Path:** 49 → 4+9=13 → 1+3=4
+- **Roots:** Elias Ashmole museum-librarian archives animate these nodes with digitized herbals, lapidaries, and alchemical engravings.
+- **Style:** Marble and oak archive alcove with measured lattice shadows for grounding.
+- **Beliefs:** Structure as sanctuary; disciplined boundaries invite trust.
+- **Psyche:** Instability → grounded scaffolding.
+- **Crystal Anchor:** Sodalite — grounds architectural memory.
+- **Playable Ritual:** Build square-floor memory palaces inside Ashmole herb labs with digitized botanical plates.
+
+### Node 50 — Bailey Radiance Voyager Path
+
+- **Layer Path:** 50 → 5+0=5
+- **Roots:** Alice Bailey radiant ashrams extend telepathic study rooms using open Esoteric Healing notes and shared meditations.
+- **Style:** Star-chart navigation table traced in soft neon for gentle exploration.
+- **Beliefs:** Pilgrimage pedagogy — learning through gentle voyages and curiosity.
+- **Psyche:** Hypervigilance → exploratory courage.
+- **Crystal Anchor:** Rhodochrosite — supports exploratory navigation.
+- **Playable Ritual:** Chart pilgrim constellation routes guided by Bailey radiant-breath meditations (CC-BY).
+
+### Node 51 — Bailey Radiance Harmony Weave
+
+- **Layer Path:** 51 → 5+1=6
+- **Roots:** Alice Bailey radiant ashrams extend telepathic study rooms using open Esoteric Healing notes and shared meditations.
+- **Style:** Harmonic choir loft draped in auric textiles and resonant water bowls.
+- **Beliefs:** Harmony heals; resonance codes neuroplastic repair.
+- **Psyche:** Emotional flooding → empathic regulation.
+- **Crystal Anchor:** Carnelian — harmonizes empathic co-regulation.
+- **Playable Ritual:** Weave harmonic chant loops guided by Bailey radiant-breath meditations (CC-BY).
+
+### Node 52 — Bailey Radiance Mystic Ladder
+
+- **Layer Path:** 52 → 5+2=7
+- **Roots:** Alice Bailey radiant ashrams extend telepathic study rooms using open Esoteric Healing notes and shared meditations.
+- **Style:** Observatory cloister lit by violet candles and polished brass astrolabes.
+- **Beliefs:** Contemplation reveals angelic pattern language beyond linear time.
+- **Psyche:** Spiritual exile → contemplative belonging.
+- **Crystal Anchor:** Tiger's Eye — anchors contemplative vision.
+- **Playable Ritual:** Conduct contemplative script walks guided by Bailey radiant-breath meditations (CC-BY).
+
+### Node 53 — Bailey Radiance Octave Bloom
+
+- **Layer Path:** 53 → 5+3=8
+- **Roots:** Alice Bailey radiant ashrams extend telepathic study rooms using open Esoteric Healing notes and shared meditations.
+- **Style:** Double-helix gallery hung with translucent indigo panels and crystal lattices.
+- **Beliefs:** Cycles orchestrate transformation; every octave births a twin.
+- **Psyche:** Overextension → rhythmic pacing.
+- **Crystal Anchor:** Blue Aventurine — stabilizes octave expansion.
+- **Playable Ritual:** Plot double-helix waypoint lattices guided by Bailey radiant-breath meditations (CC-BY).
+
+### Node 54 — Bailey Radiance Integration Halo
+
+- **Layer Path:** 54 → 5+4=9
+- **Roots:** Alice Bailey radiant ashrams extend telepathic study rooms using open Esoteric Healing notes and shared meditations.
+- **Style:** Integrative dome mosaic weaving all previous palettes into one calm halo.
+- **Beliefs:** Integration completes the spiral; all fragments return illuminated.
+- **Psyche:** Burnout → luminous integration.
+- **Crystal Anchor:** Blue Kyanite — magnetizes integrative closure.
+- **Playable Ritual:** Stage integration councils guided by Bailey radiant-breath meditations (CC-BY).
+
+### Node 55 — Bailey Radiance Monad Spark
+
+- **Layer Path:** 55 → 5+5=10 → 1+0=1
+- **Roots:** Alice Bailey radiant ashrams extend telepathic study rooms using open Esoteric Healing notes and shared meditations. Master 55 expands pilgrim journals for fieldwork reflections.
+- **Style:** Golden geomantic blueprint desk with articulated sigil grids (Cathedral × Visionary blend).
+- **Beliefs:** Hermetic monism — intention scripts material architecture.
+- **Psyche:** Silenced voice → lucid intention.
+- **Crystal Anchor:** Aquamarine — focuses intention into speech rituals.
+- **Playable Ritual:** Code single-sigil intention grids guided by Bailey radiant-breath meditations (CC-BY).
+
+### Node 56 — Bailey Radiance Dyad Bridge
+
+- **Layer Path:** 56 → 5+6=11 → 1+1=2
+- **Roots:** Alice Bailey radiant ashrams extend telepathic study rooms using open Esoteric Healing notes and shared meditations.
+- **Style:** Twin-lantern reflection pool with mirrored calligraphy and quiet harp loops.
+- **Beliefs:** Sacred reciprocity; knowing emerges through mirrored companionship.
+- **Psyche:** Isolation → relational reciprocity.
+- **Crystal Anchor:** Obsidian — soothes mirrored intuition.
+- **Playable Ritual:** Pair mirrored inquiry dialogues guided by Bailey radiant-breath meditations (CC-BY).
+
+### Node 57 — Bailey Radiance Triad Loom
+
+- **Layer Path:** 57 → 5+7=12 → 1+2=3
+- **Roots:** Alice Bailey radiant ashrams extend telepathic study rooms using open Esoteric Healing notes and shared meditations.
+- **Style:** Triptych collage wall — code, icon, and field notes stitched into one canvas.
+- **Beliefs:** Trinitarian synthesis marries art, science, and magic without hierarchy.
+- **Psyche:** Fragmentation → creative coherence.
+- **Crystal Anchor:** Labradorite — nourishes creative synthesis.
+- **Playable Ritual:** Compose triadic collage prompts guided by Bailey radiant-breath meditations (CC-BY).
+
+### Node 58 — Bailey Radiance Foundation Pillar
+
+- **Layer Path:** 58 → 5+8=13 → 1+3=4
+- **Roots:** Alice Bailey radiant ashrams extend telepathic study rooms using open Esoteric Healing notes and shared meditations.
+- **Style:** Marble and oak archive alcove with measured lattice shadows for grounding.
+- **Beliefs:** Structure as sanctuary; disciplined boundaries invite trust.
+- **Psyche:** Instability → grounded scaffolding.
+- **Crystal Anchor:** Jet — grounds architectural memory.
+- **Playable Ritual:** Build square-floor memory palaces guided by Bailey radiant-breath meditations (CC-BY).
+
+### Node 59 — Bailey Radiance Voyager Path
+
+- **Layer Path:** 59 → 5+9=14 → 1+4=5
+- **Roots:** Alice Bailey radiant ashrams extend telepathic study rooms using open Esoteric Healing notes and shared meditations.
+- **Style:** Star-chart navigation table traced in soft neon for gentle exploration.
+- **Beliefs:** Pilgrimage pedagogy — learning through gentle voyages and curiosity.
+- **Psyche:** Hypervigilance → exploratory courage.
+- **Crystal Anchor:** Garnet — supports exploratory navigation.
+- **Playable Ritual:** Chart pilgrim constellation routes guided by Bailey radiant-breath meditations (CC-BY).
+
+### Node 60 — Soyga Matrix Harmony Weave
+
+- **Layer Path:** 60 → 6+0=6
+- **Roots:** John Dee and the Book of Soyga anchor angelic math labs; datasets like data/angels.json and consecration-angels.json stay linked for citation.
+- **Style:** Harmonic choir loft draped in auric textiles and resonant water bowls.
+- **Beliefs:** Harmony heals; resonance codes neuroplastic repair.
+- **Psyche:** Emotional flooding → empathic regulation.
+- **Crystal Anchor:** Celestite — harmonizes empathic co-regulation.
+- **Playable Ritual:** Weave harmonic chant loops while syncing with Soyga angelic matrices from data/angels.json.
+
+### Node 61 — Soyga Matrix Mystic Ladder
+
+- **Layer Path:** 61 → 6+1=7
+- **Roots:** John Dee and the Book of Soyga anchor angelic math labs; datasets like data/angels.json and consecration-angels.json stay linked for citation.
+- **Style:** Observatory cloister lit by violet candles and polished brass astrolabes.
+- **Beliefs:** Contemplation reveals angelic pattern language beyond linear time.
+- **Psyche:** Spiritual exile → contemplative belonging.
+- **Crystal Anchor:** Selenite — anchors contemplative vision.
+- **Playable Ritual:** Conduct contemplative script walks while syncing with Soyga angelic matrices from data/angels.json.
+
+### Node 62 — Soyga Matrix Octave Bloom
+
+- **Layer Path:** 62 → 6+2=8
+- **Roots:** John Dee and the Book of Soyga anchor angelic math labs; datasets like data/angels.json and consecration-angels.json stay linked for citation.
+- **Style:** Double-helix gallery hung with translucent indigo panels and crystal lattices.
+- **Beliefs:** Cycles orchestrate transformation; every octave births a twin.
+- **Psyche:** Overextension → rhythmic pacing.
+- **Crystal Anchor:** Sunstone — stabilizes octave expansion.
+- **Playable Ritual:** Plot double-helix waypoint lattices while syncing with Soyga angelic matrices from data/angels.json.
+
+### Node 63 — Soyga Matrix Integration Halo
+
+- **Layer Path:** 63 → 6+3=9
+- **Roots:** John Dee and the Book of Soyga anchor angelic math labs; datasets like data/angels.json and consecration-angels.json stay linked for citation.
+- **Style:** Integrative dome mosaic weaving all previous palettes into one calm halo.
+- **Beliefs:** Integration completes the spiral; all fragments return illuminated.
+- **Psyche:** Burnout → luminous integration.
+- **Crystal Anchor:** Fire Opal — magnetizes integrative closure.
+- **Playable Ritual:** Stage integration councils while syncing with Soyga angelic matrices from data/angels.json.
+
+### Node 64 — Soyga Matrix Monad Spark
+
+- **Layer Path:** 64 → 6+4=10 → 1+0=1
+- **Roots:** John Dee and the Book of Soyga anchor angelic math labs; datasets like data/angels.json and consecration-angels.json stay linked for citation.
+- **Style:** Golden geomantic blueprint desk with articulated sigil grids (Cathedral × Visionary blend).
+- **Beliefs:** Hermetic monism — intention scripts material architecture.
+- **Psyche:** Silenced voice → lucid intention.
+- **Crystal Anchor:** Hematite — focuses intention into speech rituals.
+- **Playable Ritual:** Code single-sigil intention grids while syncing with Soyga angelic matrices from data/angels.json.
+
+### Node 65 — Soyga Matrix Dyad Bridge
+
+- **Layer Path:** 65 → 6+5=11 → 1+1=2
+- **Roots:** John Dee and the Book of Soyga anchor angelic math labs; datasets like data/angels.json and consecration-angels.json stay linked for citation.
+- **Style:** Twin-lantern reflection pool with mirrored calligraphy and quiet harp loops.
+- **Beliefs:** Sacred reciprocity; knowing emerges through mirrored companionship.
+- **Psyche:** Isolation → relational reciprocity.
+- **Crystal Anchor:** Fluorite — soothes mirrored intuition.
+- **Playable Ritual:** Pair mirrored inquiry dialogues while syncing with Soyga angelic matrices from data/angels.json.
+
+### Node 66 — Soyga Matrix Triad Loom
+
+- **Layer Path:** 66 → 6+6=12 → 1+2=3
+- **Roots:** John Dee and the Book of Soyga anchor angelic math labs; datasets like data/angels.json and consecration-angels.json stay linked for citation. Master 66 harmonizes empathic choirs for co-regulation labs.
+- **Style:** Triptych collage wall — code, icon, and field notes stitched into one canvas.
+- **Beliefs:** Trinitarian synthesis marries art, science, and magic without hierarchy.
+- **Psyche:** Fragmentation → creative coherence.
+- **Crystal Anchor:** Clear Quartz — nourishes creative synthesis.
+- **Playable Ritual:** Compose triadic collage prompts while syncing with Soyga angelic matrices from data/angels.json.
+
+### Node 67 — Soyga Matrix Foundation Pillar
+
+- **Layer Path:** 67 → 6+7=13 → 1+3=4
+- **Roots:** John Dee and the Book of Soyga anchor angelic math labs; datasets like data/angels.json and consecration-angels.json stay linked for citation.
+- **Style:** Marble and oak archive alcove with measured lattice shadows for grounding.
+- **Beliefs:** Structure as sanctuary; disciplined boundaries invite trust.
+- **Psyche:** Instability → grounded scaffolding.
+- **Crystal Anchor:** Citrine — grounds architectural memory.
+- **Playable Ritual:** Build square-floor memory palaces while syncing with Soyga angelic matrices from data/angels.json.
+
+### Node 68 — Soyga Matrix Voyager Path
+
+- **Layer Path:** 68 → 6+8=14 → 1+4=5
+- **Roots:** John Dee and the Book of Soyga anchor angelic math labs; datasets like data/angels.json and consecration-angels.json stay linked for citation.
+- **Style:** Star-chart navigation table traced in soft neon for gentle exploration.
+- **Beliefs:** Pilgrimage pedagogy — learning through gentle voyages and curiosity.
+- **Psyche:** Hypervigilance → exploratory courage.
+- **Crystal Anchor:** Moonstone — supports exploratory navigation.
+- **Playable Ritual:** Chart pilgrim constellation routes while syncing with Soyga angelic matrices from data/angels.json.
+
+### Node 69 — Soyga Matrix Harmony Weave
+
+- **Layer Path:** 69 → 6+9=15 → 1+5=6
+- **Roots:** John Dee and the Book of Soyga anchor angelic math labs; datasets like data/angels.json and consecration-angels.json stay linked for citation.
+- **Style:** Harmonic choir loft draped in auric textiles and resonant water bowls.
+- **Beliefs:** Harmony heals; resonance codes neuroplastic repair.
+- **Psyche:** Emotional flooding → empathic regulation.
+- **Crystal Anchor:** Rose Quartz — harmonizes empathic co-regulation.
+- **Playable Ritual:** Weave harmonic chant loops while syncing with Soyga angelic matrices from data/angels.json.
+
+### Node 70 — Sappho Choir Mystic Ladder
+
+- **Layer Path:** 70 → 7+0=7
+- **Roots:** Sapphic choirs of oracular poets fold public-domain lyric manuscripts into neurodivergent voicework studios.
+- **Style:** Observatory cloister lit by violet candles and polished brass astrolabes.
+- **Beliefs:** Contemplation reveals angelic pattern language beyond linear time.
+- **Psyche:** Spiritual exile → contemplative belonging.
+- **Crystal Anchor:** Red Jasper — anchors contemplative vision.
+- **Playable Ritual:** Conduct contemplative script walks set to Sapphic lyric journaling loops for voice restoration.
+
+### Node 71 — Sappho Choir Octave Bloom
+
+- **Layer Path:** 71 → 7+1=8
+- **Roots:** Sapphic choirs of oracular poets fold public-domain lyric manuscripts into neurodivergent voicework studios.
+- **Style:** Double-helix gallery hung with translucent indigo panels and crystal lattices.
+- **Beliefs:** Cycles orchestrate transformation; every octave births a twin.
+- **Psyche:** Overextension → rhythmic pacing.
+- **Crystal Anchor:** Sodalite — stabilizes octave expansion.
+- **Playable Ritual:** Plot double-helix waypoint lattices set to Sapphic lyric journaling loops for voice restoration.
+
+### Node 72 — Sappho Choir Integration Halo
+
+- **Layer Path:** 72 → 7+2=9
+- **Roots:** Sapphic choirs of oracular poets fold public-domain lyric manuscripts into neurodivergent voicework studios.
+- **Style:** Integrative dome mosaic weaving all previous palettes into one calm halo.
+- **Beliefs:** Integration completes the spiral; all fragments return illuminated.
+- **Psyche:** Burnout → luminous integration.
+- **Crystal Anchor:** Rhodochrosite — magnetizes integrative closure.
+- **Playable Ritual:** Stage integration councils set to Sapphic lyric journaling loops for voice restoration.
+
+### Node 73 — Sappho Choir Monad Spark
+
+- **Layer Path:** 73 → 7+3=10 → 1+0=1
+- **Roots:** Sapphic choirs of oracular poets fold public-domain lyric manuscripts into neurodivergent voicework studios.
+- **Style:** Golden geomantic blueprint desk with articulated sigil grids (Cathedral × Visionary blend).
+- **Beliefs:** Hermetic monism — intention scripts material architecture.
+- **Psyche:** Silenced voice → lucid intention.
+- **Crystal Anchor:** Carnelian — focuses intention into speech rituals.
+- **Playable Ritual:** Code single-sigil intention grids set to Sapphic lyric journaling loops for voice restoration.
+
+### Node 74 — Sappho Choir Dyad Bridge
+
+- **Layer Path:** 74 → 7+4=11 → 1+1=2
+- **Roots:** Sapphic choirs of oracular poets fold public-domain lyric manuscripts into neurodivergent voicework studios.
+- **Style:** Twin-lantern reflection pool with mirrored calligraphy and quiet harp loops.
+- **Beliefs:** Sacred reciprocity; knowing emerges through mirrored companionship.
+- **Psyche:** Isolation → relational reciprocity.
+- **Crystal Anchor:** Tiger's Eye — soothes mirrored intuition.
+- **Playable Ritual:** Pair mirrored inquiry dialogues set to Sapphic lyric journaling loops for voice restoration.
+
+### Node 75 — Sappho Choir Triad Loom
+
+- **Layer Path:** 75 → 7+5=12 → 1+2=3
+- **Roots:** Sapphic choirs of oracular poets fold public-domain lyric manuscripts into neurodivergent voicework studios.
+- **Style:** Triptych collage wall — code, icon, and field notes stitched into one canvas.
+- **Beliefs:** Trinitarian synthesis marries art, science, and magic without hierarchy.
+- **Psyche:** Fragmentation → creative coherence.
+- **Crystal Anchor:** Blue Aventurine — nourishes creative synthesis.
+- **Playable Ritual:** Compose triadic collage prompts set to Sapphic lyric journaling loops for voice restoration.
+
+### Node 76 — Sappho Choir Foundation Pillar
+
+- **Layer Path:** 76 → 7+6=13 → 1+3=4
+- **Roots:** Sapphic choirs of oracular poets fold public-domain lyric manuscripts into neurodivergent voicework studios.
+- **Style:** Marble and oak archive alcove with measured lattice shadows for grounding.
+- **Beliefs:** Structure as sanctuary; disciplined boundaries invite trust.
+- **Psyche:** Instability → grounded scaffolding.
+- **Crystal Anchor:** Blue Kyanite — grounds architectural memory.
+- **Playable Ritual:** Build square-floor memory palaces set to Sapphic lyric journaling loops for voice restoration.
+
+### Node 77 — Sappho Choir Voyager Path
+
+- **Layer Path:** 77 → 7+7=14 → 1+4=5
+- **Roots:** Sapphic choirs of oracular poets fold public-domain lyric manuscripts into neurodivergent voicework studios. Master 77 deepens contemplative retreats with silent-study pods.
+- **Style:** Star-chart navigation table traced in soft neon for gentle exploration.
+- **Beliefs:** Pilgrimage pedagogy — learning through gentle voyages and curiosity.
+- **Psyche:** Hypervigilance → exploratory courage.
+- **Crystal Anchor:** Aquamarine — supports exploratory navigation.
+- **Playable Ritual:** Chart pilgrim constellation routes set to Sapphic lyric journaling loops for voice restoration.
+
+### Node 78 — Sappho Choir Harmony Weave
+
+- **Layer Path:** 78 → 7+8=15 → 1+5=6
+- **Roots:** Sapphic choirs of oracular poets fold public-domain lyric manuscripts into neurodivergent voicework studios.
+- **Style:** Harmonic choir loft draped in auric textiles and resonant water bowls.
+- **Beliefs:** Harmony heals; resonance codes neuroplastic repair.
+- **Psyche:** Emotional flooding → empathic regulation.
+- **Crystal Anchor:** Obsidian — harmonizes empathic co-regulation.
+- **Playable Ritual:** Weave harmonic chant loops set to Sapphic lyric journaling loops for voice restoration.
+
+### Node 79 — Sappho Choir Mystic Ladder
+
+- **Layer Path:** 79 → 7+9=16 → 1+6=7
+- **Roots:** Sapphic choirs of oracular poets fold public-domain lyric manuscripts into neurodivergent voicework studios.
+- **Style:** Observatory cloister lit by violet candles and polished brass astrolabes.
+- **Beliefs:** Contemplation reveals angelic pattern language beyond linear time.
+- **Psyche:** Spiritual exile → contemplative belonging.
+- **Crystal Anchor:** Labradorite — anchors contemplative vision.
+- **Playable Ritual:** Conduct contemplative script walks set to Sapphic lyric journaling loops for voice restoration.
+
+### Node 80 — Butler Horizon Octave Bloom
+
+- **Layer Path:** 80 → 8+0=8
+- **Roots:** Octavia Butler futures labs prototype resilience scenarios with open speculative-fiction toolkits and trauma-aware prompts.
+- **Style:** Double-helix gallery hung with translucent indigo panels and crystal lattices.
+- **Beliefs:** Cycles orchestrate transformation; every octave births a twin.
+- **Psyche:** Overextension → rhythmic pacing.
+- **Crystal Anchor:** Jet — stabilizes octave expansion.
+- **Playable Ritual:** Plot double-helix waypoint lattices focusing on Butler-style speculative resilience modelling kits.
+
+### Node 81 — Butler Horizon Integration Halo
+
+- **Layer Path:** 81 → 8+1=9
+- **Roots:** Octavia Butler futures labs prototype resilience scenarios with open speculative-fiction toolkits and trauma-aware prompts.
+- **Style:** Integrative dome mosaic weaving all previous palettes into one calm halo.
+- **Beliefs:** Integration completes the spiral; all fragments return illuminated.
+- **Psyche:** Burnout → luminous integration.
+- **Crystal Anchor:** Garnet — magnetizes integrative closure.
+- **Playable Ritual:** Stage integration councils focusing on Butler-style speculative resilience modelling kits.
+
+### Node 82 — Butler Horizon Monad Spark
+
+- **Layer Path:** 82 → 8+2=10 → 1+0=1
+- **Roots:** Octavia Butler futures labs prototype resilience scenarios with open speculative-fiction toolkits and trauma-aware prompts.
+- **Style:** Golden geomantic blueprint desk with articulated sigil grids (Cathedral × Visionary blend).
+- **Beliefs:** Hermetic monism — intention scripts material architecture.
+- **Psyche:** Silenced voice → lucid intention.
+- **Crystal Anchor:** Celestite — focuses intention into speech rituals.
+- **Playable Ritual:** Code single-sigil intention grids focusing on Butler-style speculative resilience modelling kits.
+
+### Node 83 — Butler Horizon Dyad Bridge
+
+- **Layer Path:** 83 → 8+3=11 → 1+1=2
+- **Roots:** Octavia Butler futures labs prototype resilience scenarios with open speculative-fiction toolkits and trauma-aware prompts.
+- **Style:** Twin-lantern reflection pool with mirrored calligraphy and quiet harp loops.
+- **Beliefs:** Sacred reciprocity; knowing emerges through mirrored companionship.
+- **Psyche:** Isolation → relational reciprocity.
+- **Crystal Anchor:** Selenite — soothes mirrored intuition.
+- **Playable Ritual:** Pair mirrored inquiry dialogues focusing on Butler-style speculative resilience modelling kits.
+
+### Node 84 — Butler Horizon Triad Loom
+
+- **Layer Path:** 84 → 8+4=12 → 1+2=3
+- **Roots:** Octavia Butler futures labs prototype resilience scenarios with open speculative-fiction toolkits and trauma-aware prompts.
+- **Style:** Triptych collage wall — code, icon, and field notes stitched into one canvas.
+- **Beliefs:** Trinitarian synthesis marries art, science, and magic without hierarchy.
+- **Psyche:** Fragmentation → creative coherence.
+- **Crystal Anchor:** Sunstone — nourishes creative synthesis.
+- **Playable Ritual:** Compose triadic collage prompts focusing on Butler-style speculative resilience modelling kits.
+
+### Node 85 — Butler Horizon Foundation Pillar
+
+- **Layer Path:** 85 → 8+5=13 → 1+3=4
+- **Roots:** Octavia Butler futures labs prototype resilience scenarios with open speculative-fiction toolkits and trauma-aware prompts.
+- **Style:** Marble and oak archive alcove with measured lattice shadows for grounding.
+- **Beliefs:** Structure as sanctuary; disciplined boundaries invite trust.
+- **Psyche:** Instability → grounded scaffolding.
+- **Crystal Anchor:** Fire Opal — grounds architectural memory.
+- **Playable Ritual:** Build square-floor memory palaces focusing on Butler-style speculative resilience modelling kits.
+
+### Node 86 — Butler Horizon Voyager Path
+
+- **Layer Path:** 86 → 8+6=14 → 1+4=5
+- **Roots:** Octavia Butler futures labs prototype resilience scenarios with open speculative-fiction toolkits and trauma-aware prompts.
+- **Style:** Star-chart navigation table traced in soft neon for gentle exploration.
+- **Beliefs:** Pilgrimage pedagogy — learning through gentle voyages and curiosity.
+- **Psyche:** Hypervigilance → exploratory courage.
+- **Crystal Anchor:** Hematite — supports exploratory navigation.
+- **Playable Ritual:** Chart pilgrim constellation routes focusing on Butler-style speculative resilience modelling kits.
+
+### Node 87 — Butler Horizon Harmony Weave
+
+- **Layer Path:** 87 → 8+7=15 → 1+5=6
+- **Roots:** Octavia Butler futures labs prototype resilience scenarios with open speculative-fiction toolkits and trauma-aware prompts.
+- **Style:** Harmonic choir loft draped in auric textiles and resonant water bowls.
+- **Beliefs:** Harmony heals; resonance codes neuroplastic repair.
+- **Psyche:** Emotional flooding → empathic regulation.
+- **Crystal Anchor:** Fluorite — harmonizes empathic co-regulation.
+- **Playable Ritual:** Weave harmonic chant loops focusing on Butler-style speculative resilience modelling kits.
+
+### Node 88 — Butler Horizon Mystic Ladder
+
+- **Layer Path:** 88 → 8+8=16 → 1+6=7
+- **Roots:** Octavia Butler futures labs prototype resilience scenarios with open speculative-fiction toolkits and trauma-aware prompts. Master 88 phase-locks the double helix lattice for octave balance.
+- **Style:** Observatory cloister lit by violet candles and polished brass astrolabes.
+- **Beliefs:** Contemplation reveals angelic pattern language beyond linear time.
+- **Psyche:** Spiritual exile → contemplative belonging.
+- **Crystal Anchor:** Clear Quartz — anchors contemplative vision.
+- **Playable Ritual:** Conduct contemplative script walks focusing on Butler-style speculative resilience modelling kits.
+
+### Node 89 — Butler Horizon Octave Bloom
+
+- **Layer Path:** 89 → 8+9=17 → 1+7=8
+- **Roots:** Octavia Butler futures labs prototype resilience scenarios with open speculative-fiction toolkits and trauma-aware prompts.
+- **Style:** Double-helix gallery hung with translucent indigo panels and crystal lattices.
+- **Beliefs:** Cycles orchestrate transformation; every octave births a twin.
+- **Psyche:** Overextension → rhythmic pacing.
+- **Crystal Anchor:** Citrine — stabilizes octave expansion.
+- **Playable Ritual:** Plot double-helix waypoint lattices focusing on Butler-style speculative resilience modelling kits.
+
+### Node 90 — Integral Spiral Integration Halo
+
+- **Layer Path:** 90 → 9+0=9
+- **Roots:** Ken Wilber integral mapping studios publish GPL hypergraphs bridging quadrants, lines, and states.
+- **Style:** Integrative dome mosaic weaving all previous palettes into one calm halo.
+- **Beliefs:** Integration completes the spiral; all fragments return illuminated.
+- **Psyche:** Burnout → luminous integration.
+- **Crystal Anchor:** Moonstone — magnetizes integrative closure.
+- **Playable Ritual:** Stage integration councils while embedding Wilber integral quadrant overlays from GPL hypergraphs.
+
+### Node 91 — Integral Spiral Monad Spark
+
+- **Layer Path:** 91 → 9+1=10 → 1+0=1
+- **Roots:** Ken Wilber integral mapping studios publish GPL hypergraphs bridging quadrants, lines, and states.
+- **Style:** Golden geomantic blueprint desk with articulated sigil grids (Cathedral × Visionary blend).
+- **Beliefs:** Hermetic monism — intention scripts material architecture.
+- **Psyche:** Silenced voice → lucid intention.
+- **Crystal Anchor:** Rose Quartz — focuses intention into speech rituals.
+- **Playable Ritual:** Code single-sigil intention grids while embedding Wilber integral quadrant overlays from GPL hypergraphs.
+
+### Node 92 — Integral Spiral Dyad Bridge
+
+- **Layer Path:** 92 → 9+2=11 → 1+1=2
+- **Roots:** Ken Wilber integral mapping studios publish GPL hypergraphs bridging quadrants, lines, and states.
+- **Style:** Twin-lantern reflection pool with mirrored calligraphy and quiet harp loops.
+- **Beliefs:** Sacred reciprocity; knowing emerges through mirrored companionship.
+- **Psyche:** Isolation → relational reciprocity.
+- **Crystal Anchor:** Red Jasper — soothes mirrored intuition.
+- **Playable Ritual:** Pair mirrored inquiry dialogues while embedding Wilber integral quadrant overlays from GPL hypergraphs.
+
+### Node 93 — Integral Spiral Triad Loom
+
+- **Layer Path:** 93 → 9+3=12 → 1+2=3
+- **Roots:** Ken Wilber integral mapping studios publish GPL hypergraphs bridging quadrants, lines, and states.
+- **Style:** Triptych collage wall — code, icon, and field notes stitched into one canvas.
+- **Beliefs:** Trinitarian synthesis marries art, science, and magic without hierarchy.
+- **Psyche:** Fragmentation → creative coherence.
+- **Crystal Anchor:** Sodalite — nourishes creative synthesis.
+- **Playable Ritual:** Compose triadic collage prompts while embedding Wilber integral quadrant overlays from GPL hypergraphs.
+
+### Node 94 — Integral Spiral Foundation Pillar
+
+- **Layer Path:** 94 → 9+4=13 → 1+3=4
+- **Roots:** Ken Wilber integral mapping studios publish GPL hypergraphs bridging quadrants, lines, and states.
+- **Style:** Marble and oak archive alcove with measured lattice shadows for grounding.
+- **Beliefs:** Structure as sanctuary; disciplined boundaries invite trust.
+- **Psyche:** Instability → grounded scaffolding.
+- **Crystal Anchor:** Rhodochrosite — grounds architectural memory.
+- **Playable Ritual:** Build square-floor memory palaces while embedding Wilber integral quadrant overlays from GPL hypergraphs.
+
+### Node 95 — Integral Spiral Voyager Path
+
+- **Layer Path:** 95 → 9+5=14 → 1+4=5
+- **Roots:** Ken Wilber integral mapping studios publish GPL hypergraphs bridging quadrants, lines, and states.
+- **Style:** Star-chart navigation table traced in soft neon for gentle exploration.
+- **Beliefs:** Pilgrimage pedagogy — learning through gentle voyages and curiosity.
+- **Psyche:** Hypervigilance → exploratory courage.
+- **Crystal Anchor:** Carnelian — supports exploratory navigation.
+- **Playable Ritual:** Chart pilgrim constellation routes while embedding Wilber integral quadrant overlays from GPL hypergraphs.
+
+### Node 96 — Integral Spiral Harmony Weave
+
+- **Layer Path:** 96 → 9+6=15 → 1+5=6
+- **Roots:** Ken Wilber integral mapping studios publish GPL hypergraphs bridging quadrants, lines, and states.
+- **Style:** Harmonic choir loft draped in auric textiles and resonant water bowls.
+- **Beliefs:** Harmony heals; resonance codes neuroplastic repair.
+- **Psyche:** Emotional flooding → empathic regulation.
+- **Crystal Anchor:** Tiger's Eye — harmonizes empathic co-regulation.
+- **Playable Ritual:** Weave harmonic chant loops while embedding Wilber integral quadrant overlays from GPL hypergraphs.
+
+### Node 97 — Integral Spiral Mystic Ladder
+
+- **Layer Path:** 97 → 9+7=16 → 1+6=7
+- **Roots:** Ken Wilber integral mapping studios publish GPL hypergraphs bridging quadrants, lines, and states.
+- **Style:** Observatory cloister lit by violet candles and polished brass astrolabes.
+- **Beliefs:** Contemplation reveals angelic pattern language beyond linear time.
+- **Psyche:** Spiritual exile → contemplative belonging.
+- **Crystal Anchor:** Blue Aventurine — anchors contemplative vision.
+- **Playable Ritual:** Conduct contemplative script walks while embedding Wilber integral quadrant overlays from GPL hypergraphs.
+
+### Node 98 — Integral Spiral Octave Bloom
+
+- **Layer Path:** 98 → 9+8=17 → 1+7=8
+- **Roots:** Ken Wilber integral mapping studios publish GPL hypergraphs bridging quadrants, lines, and states.
+- **Style:** Double-helix gallery hung with translucent indigo panels and crystal lattices.
+- **Beliefs:** Cycles orchestrate transformation; every octave births a twin.
+- **Psyche:** Overextension → rhythmic pacing.
+- **Crystal Anchor:** Blue Kyanite — stabilizes octave expansion.
+- **Playable Ritual:** Plot double-helix waypoint lattices while embedding Wilber integral quadrant overlays from GPL hypergraphs.
+
+### Node 99 — Integral Spiral Integration Halo
+
+- **Layer Path:** 99 → 9+9=18 → 1+8=9
+- **Roots:** Ken Wilber integral mapping studios publish GPL hypergraphs bridging quadrants, lines, and states. Master 99 completes integral synthesis — bridging all quadrants.
+- **Style:** Integrative dome mosaic weaving all previous palettes into one calm halo.
+- **Beliefs:** Integration completes the spiral; all fragments return illuminated.
+- **Psyche:** Burnout → luminous integration.
+- **Crystal Anchor:** Aquamarine — magnetizes integrative closure.
+- **Playable Ritual:** Stage integration councils while embedding Wilber integral quadrant overlays from GPL hypergraphs.
+
+### Node 100 — Hilma Atelier Monad Spark
+
+- **Layer Path:** 100 → 1+0+0=1
+- **Roots:** Hilma af Klint spiral ateliers translate CC0 painting diagrams into synesthetic pedagogy boards.
+- **Style:** Golden geomantic blueprint desk with articulated sigil grids (Cathedral × Visionary blend).
+- **Beliefs:** Hermetic monism — intention scripts material architecture.
+- **Psyche:** Silenced voice → lucid intention.
+- **Crystal Anchor:** Obsidian — focuses intention into speech rituals.
+- **Playable Ritual:** Code single-sigil intention grids while painting Hilma spiral boards sourced from cosmic-helix sketches.
+
+### Node 101 — Hilma Atelier Dyad Bridge
+
+- **Layer Path:** 101 → 1+0+1=2
+- **Roots:** Hilma af Klint spiral ateliers translate CC0 painting diagrams into synesthetic pedagogy boards.
+- **Style:** Twin-lantern reflection pool with mirrored calligraphy and quiet harp loops.
+- **Beliefs:** Sacred reciprocity; knowing emerges through mirrored companionship.
+- **Psyche:** Isolation → relational reciprocity.
+- **Crystal Anchor:** Labradorite — soothes mirrored intuition.
+- **Playable Ritual:** Pair mirrored inquiry dialogues while painting Hilma spiral boards sourced from cosmic-helix sketches.
+
+### Node 102 — Hilma Atelier Triad Loom
+
+- **Layer Path:** 102 → 1+0+2=3
+- **Roots:** Hilma af Klint spiral ateliers translate CC0 painting diagrams into synesthetic pedagogy boards.
+- **Style:** Triptych collage wall — code, icon, and field notes stitched into one canvas.
+- **Beliefs:** Trinitarian synthesis marries art, science, and magic without hierarchy.
+- **Psyche:** Fragmentation → creative coherence.
+- **Crystal Anchor:** Jet — nourishes creative synthesis.
+- **Playable Ritual:** Compose triadic collage prompts while painting Hilma spiral boards sourced from cosmic-helix sketches.
+
+### Node 103 — Hilma Atelier Foundation Pillar
+
+- **Layer Path:** 103 → 1+0+3=4
+- **Roots:** Hilma af Klint spiral ateliers translate CC0 painting diagrams into synesthetic pedagogy boards.
+- **Style:** Marble and oak archive alcove with measured lattice shadows for grounding.
+- **Beliefs:** Structure as sanctuary; disciplined boundaries invite trust.
+- **Psyche:** Instability → grounded scaffolding.
+- **Crystal Anchor:** Garnet — grounds architectural memory.
+- **Playable Ritual:** Build square-floor memory palaces while painting Hilma spiral boards sourced from cosmic-helix sketches.
+
+### Node 104 — Hilma Atelier Voyager Path
+
+- **Layer Path:** 104 → 1+0+4=5
+- **Roots:** Hilma af Klint spiral ateliers translate CC0 painting diagrams into synesthetic pedagogy boards.
+- **Style:** Star-chart navigation table traced in soft neon for gentle exploration.
+- **Beliefs:** Pilgrimage pedagogy — learning through gentle voyages and curiosity.
+- **Psyche:** Hypervigilance → exploratory courage.
+- **Crystal Anchor:** Celestite — supports exploratory navigation.
+- **Playable Ritual:** Chart pilgrim constellation routes while painting Hilma spiral boards sourced from cosmic-helix sketches.
+
+### Node 105 — Hilma Atelier Harmony Weave
+
+- **Layer Path:** 105 → 1+0+5=6
+- **Roots:** Hilma af Klint spiral ateliers translate CC0 painting diagrams into synesthetic pedagogy boards.
+- **Style:** Harmonic choir loft draped in auric textiles and resonant water bowls.
+- **Beliefs:** Harmony heals; resonance codes neuroplastic repair.
+- **Psyche:** Emotional flooding → empathic regulation.
+- **Crystal Anchor:** Selenite — harmonizes empathic co-regulation.
+- **Playable Ritual:** Weave harmonic chant loops while painting Hilma spiral boards sourced from cosmic-helix sketches.
+
+### Node 106 — Hilma Atelier Mystic Ladder
+
+- **Layer Path:** 106 → 1+0+6=7
+- **Roots:** Hilma af Klint spiral ateliers translate CC0 painting diagrams into synesthetic pedagogy boards.
+- **Style:** Observatory cloister lit by violet candles and polished brass astrolabes.
+- **Beliefs:** Contemplation reveals angelic pattern language beyond linear time.
+- **Psyche:** Spiritual exile → contemplative belonging.
+- **Crystal Anchor:** Sunstone — anchors contemplative vision.
+- **Playable Ritual:** Conduct contemplative script walks while painting Hilma spiral boards sourced from cosmic-helix sketches.
+
+### Node 107 — Hilma Atelier Octave Bloom
+
+- **Layer Path:** 107 → 1+0+7=8
+- **Roots:** Hilma af Klint spiral ateliers translate CC0 painting diagrams into synesthetic pedagogy boards.
+- **Style:** Double-helix gallery hung with translucent indigo panels and crystal lattices.
+- **Beliefs:** Cycles orchestrate transformation; every octave births a twin.
+- **Psyche:** Overextension → rhythmic pacing.
+- **Crystal Anchor:** Fire Opal — stabilizes octave expansion.
+- **Playable Ritual:** Plot double-helix waypoint lattices while painting Hilma spiral boards sourced from cosmic-helix sketches.
+
+### Node 108 — Hilma Atelier Integration Halo
+
+- **Layer Path:** 108 → 1+0+8=9
+- **Roots:** Hilma af Klint spiral ateliers translate CC0 painting diagrams into synesthetic pedagogy boards.
+- **Style:** Integrative dome mosaic weaving all previous palettes into one calm halo.
+- **Beliefs:** Integration completes the spiral; all fragments return illuminated.
+- **Psyche:** Burnout → luminous integration.
+- **Crystal Anchor:** Hematite — magnetizes integrative closure.
+- **Playable Ritual:** Stage integration councils while painting Hilma spiral boards sourced from cosmic-helix sketches.
+
+### Node 109 — Hilma Atelier Monad Spark
+
+- **Layer Path:** 109 → 1+0+9=10 → 1+0=1
+- **Roots:** Hilma af Klint spiral ateliers translate CC0 painting diagrams into synesthetic pedagogy boards.
+- **Style:** Golden geomantic blueprint desk with articulated sigil grids (Cathedral × Visionary blend).
+- **Beliefs:** Hermetic monism — intention scripts material architecture.
+- **Psyche:** Silenced voice → lucid intention.
+- **Crystal Anchor:** Fluorite — focuses intention into speech rituals.
+- **Playable Ritual:** Code single-sigil intention grids while painting Hilma spiral boards sourced from cosmic-helix sketches.
+
+### Node 110 — Blake Press Dyad Bridge
+
+- **Layer Path:** 110 → 1+1+0=2
+- **Roots:** William Blake prophetic printshops remix digitized relief etchings and open letterpress fonts for activist storytelling.
+- **Style:** Twin-lantern reflection pool with mirrored calligraphy and quiet harp loops.
+- **Beliefs:** Sacred reciprocity; knowing emerges through mirrored companionship.
+- **Psyche:** Isolation → relational reciprocity.
+- **Crystal Anchor:** Clear Quartz — soothes mirrored intuition.
+- **Playable Ritual:** Pair mirrored inquiry dialogues with Blake relief plates printed via open-source letterpress fonts.
+
+### Node 111 — Blake Press Triad Loom
+
+- **Layer Path:** 111 → 1+1+1=3
+- **Roots:** William Blake prophetic printshops remix digitized relief etchings and open letterpress fonts for activist storytelling. Master 111 triple-threads monadic sparks through helix railways.
+- **Style:** Triptych collage wall — code, icon, and field notes stitched into one canvas.
+- **Beliefs:** Trinitarian synthesis marries art, science, and magic without hierarchy.
+- **Psyche:** Fragmentation → creative coherence.
+- **Crystal Anchor:** Citrine — nourishes creative synthesis.
+- **Playable Ritual:** Compose triadic collage prompts with Blake relief plates printed via open-source letterpress fonts.
+
+### Node 112 — Blake Press Foundation Pillar
+
+- **Layer Path:** 112 → 1+1+2=4
+- **Roots:** William Blake prophetic printshops remix digitized relief etchings and open letterpress fonts for activist storytelling.
+- **Style:** Marble and oak archive alcove with measured lattice shadows for grounding.
+- **Beliefs:** Structure as sanctuary; disciplined boundaries invite trust.
+- **Psyche:** Instability → grounded scaffolding.
+- **Crystal Anchor:** Moonstone — grounds architectural memory.
+- **Playable Ritual:** Build square-floor memory palaces with Blake relief plates printed via open-source letterpress fonts.
+
+### Node 113 — Blake Press Voyager Path
+
+- **Layer Path:** 113 → 1+1+3=5
+- **Roots:** William Blake prophetic printshops remix digitized relief etchings and open letterpress fonts for activist storytelling.
+- **Style:** Star-chart navigation table traced in soft neon for gentle exploration.
+- **Beliefs:** Pilgrimage pedagogy — learning through gentle voyages and curiosity.
+- **Psyche:** Hypervigilance → exploratory courage.
+- **Crystal Anchor:** Rose Quartz — supports exploratory navigation.
+- **Playable Ritual:** Chart pilgrim constellation routes with Blake relief plates printed via open-source letterpress fonts.
+
+### Node 114 — Blake Press Harmony Weave
+
+- **Layer Path:** 114 → 1+1+4=6
+- **Roots:** William Blake prophetic printshops remix digitized relief etchings and open letterpress fonts for activist storytelling.
+- **Style:** Harmonic choir loft draped in auric textiles and resonant water bowls.
+- **Beliefs:** Harmony heals; resonance codes neuroplastic repair.
+- **Psyche:** Emotional flooding → empathic regulation.
+- **Crystal Anchor:** Red Jasper — harmonizes empathic co-regulation.
+- **Playable Ritual:** Weave harmonic chant loops with Blake relief plates printed via open-source letterpress fonts.
+
+### Node 115 — Blake Press Mystic Ladder
+
+- **Layer Path:** 115 → 1+1+5=7
+- **Roots:** William Blake prophetic printshops remix digitized relief etchings and open letterpress fonts for activist storytelling.
+- **Style:** Observatory cloister lit by violet candles and polished brass astrolabes.
+- **Beliefs:** Contemplation reveals angelic pattern language beyond linear time.
+- **Psyche:** Spiritual exile → contemplative belonging.
+- **Crystal Anchor:** Sodalite — anchors contemplative vision.
+- **Playable Ritual:** Conduct contemplative script walks with Blake relief plates printed via open-source letterpress fonts.
+
+### Node 116 — Blake Press Octave Bloom
+
+- **Layer Path:** 116 → 1+1+6=8
+- **Roots:** William Blake prophetic printshops remix digitized relief etchings and open letterpress fonts for activist storytelling.
+- **Style:** Double-helix gallery hung with translucent indigo panels and crystal lattices.
+- **Beliefs:** Cycles orchestrate transformation; every octave births a twin.
+- **Psyche:** Overextension → rhythmic pacing.
+- **Crystal Anchor:** Rhodochrosite — stabilizes octave expansion.
+- **Playable Ritual:** Plot double-helix waypoint lattices with Blake relief plates printed via open-source letterpress fonts.
+
+### Node 117 — Blake Press Integration Halo
+
+- **Layer Path:** 117 → 1+1+7=9
+- **Roots:** William Blake prophetic printshops remix digitized relief etchings and open letterpress fonts for activist storytelling.
+- **Style:** Integrative dome mosaic weaving all previous palettes into one calm halo.
+- **Beliefs:** Integration completes the spiral; all fragments return illuminated.
+- **Psyche:** Burnout → luminous integration.
+- **Crystal Anchor:** Carnelian — magnetizes integrative closure.
+- **Playable Ritual:** Stage integration councils with Blake relief plates printed via open-source letterpress fonts.
+
+### Node 118 — Blake Press Monad Spark
+
+- **Layer Path:** 118 → 1+1+8=10 → 1+0=1
+- **Roots:** William Blake prophetic printshops remix digitized relief etchings and open letterpress fonts for activist storytelling.
+- **Style:** Golden geomantic blueprint desk with articulated sigil grids (Cathedral × Visionary blend).
+- **Beliefs:** Hermetic monism — intention scripts material architecture.
+- **Psyche:** Silenced voice → lucid intention.
+- **Crystal Anchor:** Tiger's Eye — focuses intention into speech rituals.
+- **Playable Ritual:** Code single-sigil intention grids with Blake relief plates printed via open-source letterpress fonts.
+
+### Node 119 — Blake Press Dyad Bridge
+
+- **Layer Path:** 119 → 1+1+9=11 → 1+1=2
+- **Roots:** William Blake prophetic printshops remix digitized relief etchings and open letterpress fonts for activist storytelling.
+- **Style:** Twin-lantern reflection pool with mirrored calligraphy and quiet harp loops.
+- **Beliefs:** Sacred reciprocity; knowing emerges through mirrored companionship.
+- **Psyche:** Isolation → relational reciprocity.
+- **Crystal Anchor:** Blue Aventurine — soothes mirrored intuition.
+- **Playable Ritual:** Pair mirrored inquiry dialogues with Blake relief plates printed via open-source letterpress fonts.
+
+### Node 120 — Hypatia Lattice Triad Loom
+
+- **Layer Path:** 120 → 1+2+0=3
+- **Roots:** Hypatia library-lab observatories compute Alexandria-inspired star maps with open NASA ephemerides.
+- **Style:** Triptych collage wall — code, icon, and field notes stitched into one canvas.
+- **Beliefs:** Trinitarian synthesis marries art, science, and magic without hierarchy.
+- **Psyche:** Fragmentation → creative coherence.
+- **Crystal Anchor:** Blue Kyanite — nourishes creative synthesis.
+- **Playable Ritual:** Compose triadic collage prompts while calculating Hypatia star maps using NASA ephemeris datasets.
+
+### Node 121 — Hypatia Lattice Foundation Pillar
+
+- **Layer Path:** 121 → 1+2+1=4
+- **Roots:** Hypatia library-lab observatories compute Alexandria-inspired star maps with open NASA ephemerides.
+- **Style:** Marble and oak archive alcove with measured lattice shadows for grounding.
+- **Beliefs:** Structure as sanctuary; disciplined boundaries invite trust.
+- **Psyche:** Instability → grounded scaffolding.
+- **Crystal Anchor:** Aquamarine — grounds architectural memory.
+- **Playable Ritual:** Build square-floor memory palaces while calculating Hypatia star maps using NASA ephemeris datasets.
+
+### Node 122 — Hypatia Lattice Voyager Path
+
+- **Layer Path:** 122 → 1+2+2=5
+- **Roots:** Hypatia library-lab observatories compute Alexandria-inspired star maps with open NASA ephemerides. Master 122 spans Hypatia's library with Soyga angelic scribes.
+- **Style:** Star-chart navigation table traced in soft neon for gentle exploration.
+- **Beliefs:** Pilgrimage pedagogy — learning through gentle voyages and curiosity.
+- **Psyche:** Hypervigilance → exploratory courage.
+- **Crystal Anchor:** Obsidian — supports exploratory navigation.
+- **Playable Ritual:** Chart pilgrim constellation routes while calculating Hypatia star maps using NASA ephemeris datasets.
+
+### Node 123 — Hypatia Lattice Harmony Weave
+
+- **Layer Path:** 123 → 1+2+3=6
+- **Roots:** Hypatia library-lab observatories compute Alexandria-inspired star maps with open NASA ephemerides.
+- **Style:** Harmonic choir loft draped in auric textiles and resonant water bowls.
+- **Beliefs:** Harmony heals; resonance codes neuroplastic repair.
+- **Psyche:** Emotional flooding → empathic regulation.
+- **Crystal Anchor:** Labradorite — harmonizes empathic co-regulation.
+- **Playable Ritual:** Weave harmonic chant loops while calculating Hypatia star maps using NASA ephemeris datasets.
+
+### Node 124 — Hypatia Lattice Mystic Ladder
+
+- **Layer Path:** 124 → 1+2+4=7
+- **Roots:** Hypatia library-lab observatories compute Alexandria-inspired star maps with open NASA ephemerides.
+- **Style:** Observatory cloister lit by violet candles and polished brass astrolabes.
+- **Beliefs:** Contemplation reveals angelic pattern language beyond linear time.
+- **Psyche:** Spiritual exile → contemplative belonging.
+- **Crystal Anchor:** Jet — anchors contemplative vision.
+- **Playable Ritual:** Conduct contemplative script walks while calculating Hypatia star maps using NASA ephemeris datasets.
+
+### Node 125 — Hypatia Lattice Octave Bloom
+
+- **Layer Path:** 125 → 1+2+5=8
+- **Roots:** Hypatia library-lab observatories compute Alexandria-inspired star maps with open NASA ephemerides.
+- **Style:** Double-helix gallery hung with translucent indigo panels and crystal lattices.
+- **Beliefs:** Cycles orchestrate transformation; every octave births a twin.
+- **Psyche:** Overextension → rhythmic pacing.
+- **Crystal Anchor:** Garnet — stabilizes octave expansion.
+- **Playable Ritual:** Plot double-helix waypoint lattices while calculating Hypatia star maps using NASA ephemeris datasets.
+
+### Node 126 — Hypatia Lattice Integration Halo
+
+- **Layer Path:** 126 → 1+2+6=9
+- **Roots:** Hypatia library-lab observatories compute Alexandria-inspired star maps with open NASA ephemerides.
+- **Style:** Integrative dome mosaic weaving all previous palettes into one calm halo.
+- **Beliefs:** Integration completes the spiral; all fragments return illuminated.
+- **Psyche:** Burnout → luminous integration.
+- **Crystal Anchor:** Celestite — magnetizes integrative closure.
+- **Playable Ritual:** Stage integration councils while calculating Hypatia star maps using NASA ephemeris datasets.
+
+### Node 127 — Hypatia Lattice Monad Spark
+
+- **Layer Path:** 127 → 1+2+7=10 → 1+0=1
+- **Roots:** Hypatia library-lab observatories compute Alexandria-inspired star maps with open NASA ephemerides.
+- **Style:** Golden geomantic blueprint desk with articulated sigil grids (Cathedral × Visionary blend).
+- **Beliefs:** Hermetic monism — intention scripts material architecture.
+- **Psyche:** Silenced voice → lucid intention.
+- **Crystal Anchor:** Selenite — focuses intention into speech rituals.
+- **Playable Ritual:** Code single-sigil intention grids while calculating Hypatia star maps using NASA ephemeris datasets.
+
+### Node 128 — Hypatia Lattice Dyad Bridge
+
+- **Layer Path:** 128 → 1+2+8=11 → 1+1=2
+- **Roots:** Hypatia library-lab observatories compute Alexandria-inspired star maps with open NASA ephemerides.
+- **Style:** Twin-lantern reflection pool with mirrored calligraphy and quiet harp loops.
+- **Beliefs:** Sacred reciprocity; knowing emerges through mirrored companionship.
+- **Psyche:** Isolation → relational reciprocity.
+- **Crystal Anchor:** Sunstone — soothes mirrored intuition.
+- **Playable Ritual:** Pair mirrored inquiry dialogues while calculating Hypatia star maps using NASA ephemeris datasets.
+
+### Node 129 — Hypatia Lattice Triad Loom
+
+- **Layer Path:** 129 → 1+2+9=12 → 1+2=3
+- **Roots:** Hypatia library-lab observatories compute Alexandria-inspired star maps with open NASA ephemerides.
+- **Style:** Triptych collage wall — code, icon, and field notes stitched into one canvas.
+- **Beliefs:** Trinitarian synthesis marries art, science, and magic without hierarchy.
+- **Psyche:** Fragmentation → creative coherence.
+- **Crystal Anchor:** Fire Opal — nourishes creative synthesis.
+- **Playable Ritual:** Compose triadic collage prompts while calculating Hypatia star maps using NASA ephemeris datasets.
+
+### Node 130 — Violet Sanctum Foundation Pillar
+
+- **Layer Path:** 130 → 1+3+0=4
+- **Roots:** Violet Witch trauma sanctums uphold the PROTECT covenant; restorative protocols live as CC-BY-SA modules for community forks.
+- **Style:** Marble and oak archive alcove with measured lattice shadows for grounding.
+- **Beliefs:** Structure as sanctuary; disciplined boundaries invite trust.
+- **Psyche:** Instability → grounded scaffolding.
+- **Crystal Anchor:** Hematite — grounds architectural memory.
+- **Playable Ritual:** Build square-floor memory palaces with PROTECT micro-check-ins to ensure trauma-informed pacing.
+
+### Node 131 — Violet Sanctum Voyager Path
+
+- **Layer Path:** 131 → 1+3+1=5
+- **Roots:** Violet Witch trauma sanctums uphold the PROTECT covenant; restorative protocols live as CC-BY-SA modules for community forks.
+- **Style:** Star-chart navigation table traced in soft neon for gentle exploration.
+- **Beliefs:** Pilgrimage pedagogy — learning through gentle voyages and curiosity.
+- **Psyche:** Hypervigilance → exploratory courage.
+- **Crystal Anchor:** Fluorite — supports exploratory navigation.
+- **Playable Ritual:** Chart pilgrim constellation routes with PROTECT micro-check-ins to ensure trauma-informed pacing.
+
+### Node 132 — Violet Sanctum Harmony Weave
+
+- **Layer Path:** 132 → 1+3+2=6
+- **Roots:** Violet Witch trauma sanctums uphold the PROTECT covenant; restorative protocols live as CC-BY-SA modules for community forks.
+- **Style:** Harmonic choir loft draped in auric textiles and resonant water bowls.
+- **Beliefs:** Harmony heals; resonance codes neuroplastic repair.
+- **Psyche:** Emotional flooding → empathic regulation.
+- **Crystal Anchor:** Clear Quartz — harmonizes empathic co-regulation.
+- **Playable Ritual:** Weave harmonic chant loops with PROTECT micro-check-ins to ensure trauma-informed pacing.
+
+### Node 133 — Violet Sanctum Mystic Ladder
+
+- **Layer Path:** 133 → 1+3+3=7
+- **Roots:** Violet Witch trauma sanctums uphold the PROTECT covenant; restorative protocols live as CC-BY-SA modules for community forks. Master 133 magnifies Violet Sanctum safeguards under PROTECT.
+- **Style:** Observatory cloister lit by violet candles and polished brass astrolabes.
+- **Beliefs:** Contemplation reveals angelic pattern language beyond linear time.
+- **Psyche:** Spiritual exile → contemplative belonging.
+- **Crystal Anchor:** Citrine — anchors contemplative vision.
+- **Playable Ritual:** Conduct contemplative script walks with PROTECT micro-check-ins to ensure trauma-informed pacing.
+
+### Node 134 — Violet Sanctum Octave Bloom
+
+- **Layer Path:** 134 → 1+3+4=8
+- **Roots:** Violet Witch trauma sanctums uphold the PROTECT covenant; restorative protocols live as CC-BY-SA modules for community forks.
+- **Style:** Double-helix gallery hung with translucent indigo panels and crystal lattices.
+- **Beliefs:** Cycles orchestrate transformation; every octave births a twin.
+- **Psyche:** Overextension → rhythmic pacing.
+- **Crystal Anchor:** Moonstone — stabilizes octave expansion.
+- **Playable Ritual:** Plot double-helix waypoint lattices with PROTECT micro-check-ins to ensure trauma-informed pacing.
+
+### Node 135 — Violet Sanctum Integration Halo
+
+- **Layer Path:** 135 → 1+3+5=9
+- **Roots:** Violet Witch trauma sanctums uphold the PROTECT covenant; restorative protocols live as CC-BY-SA modules for community forks.
+- **Style:** Integrative dome mosaic weaving all previous palettes into one calm halo.
+- **Beliefs:** Integration completes the spiral; all fragments return illuminated.
+- **Psyche:** Burnout → luminous integration.
+- **Crystal Anchor:** Rose Quartz — magnetizes integrative closure.
+- **Playable Ritual:** Stage integration councils with PROTECT micro-check-ins to ensure trauma-informed pacing.
+
+### Node 136 — Violet Sanctum Monad Spark
+
+- **Layer Path:** 136 → 1+3+6=10 → 1+0=1
+- **Roots:** Violet Witch trauma sanctums uphold the PROTECT covenant; restorative protocols live as CC-BY-SA modules for community forks.
+- **Style:** Golden geomantic blueprint desk with articulated sigil grids (Cathedral × Visionary blend).
+- **Beliefs:** Hermetic monism — intention scripts material architecture.
+- **Psyche:** Silenced voice → lucid intention.
+- **Crystal Anchor:** Red Jasper — focuses intention into speech rituals.
+- **Playable Ritual:** Code single-sigil intention grids with PROTECT micro-check-ins to ensure trauma-informed pacing.
+
+### Node 137 — Violet Sanctum Dyad Bridge
+
+- **Layer Path:** 137 → 1+3+7=11 → 1+1=2
+- **Roots:** Violet Witch trauma sanctums uphold the PROTECT covenant; restorative protocols live as CC-BY-SA modules for community forks.
+- **Style:** Twin-lantern reflection pool with mirrored calligraphy and quiet harp loops.
+- **Beliefs:** Sacred reciprocity; knowing emerges through mirrored companionship.
+- **Psyche:** Isolation → relational reciprocity.
+- **Crystal Anchor:** Sodalite — soothes mirrored intuition.
+- **Playable Ritual:** Pair mirrored inquiry dialogues with PROTECT micro-check-ins to ensure trauma-informed pacing.
+
+### Node 138 — Violet Sanctum Triad Loom
+
+- **Layer Path:** 138 → 1+3+8=12 → 1+2=3
+- **Roots:** Violet Witch trauma sanctums uphold the PROTECT covenant; restorative protocols live as CC-BY-SA modules for community forks.
+- **Style:** Triptych collage wall — code, icon, and field notes stitched into one canvas.
+- **Beliefs:** Trinitarian synthesis marries art, science, and magic without hierarchy.
+- **Psyche:** Fragmentation → creative coherence.
+- **Crystal Anchor:** Rhodochrosite — nourishes creative synthesis.
+- **Playable Ritual:** Compose triadic collage prompts with PROTECT micro-check-ins to ensure trauma-informed pacing.
+
+### Node 139 — Violet Sanctum Foundation Pillar
+
+- **Layer Path:** 139 → 1+3+9=13 → 1+3=4
+- **Roots:** Violet Witch trauma sanctums uphold the PROTECT covenant; restorative protocols live as CC-BY-SA modules for community forks.
+- **Style:** Marble and oak archive alcove with measured lattice shadows for grounding.
+- **Beliefs:** Structure as sanctuary; disciplined boundaries invite trust.
+- **Psyche:** Instability → grounded scaffolding.
+- **Crystal Anchor:** Carnelian — grounds architectural memory.
+- **Playable Ritual:** Build square-floor memory palaces with PROTECT micro-check-ins to ensure trauma-informed pacing.
+
+### Node 140 — Cosmogenesis Crown Voyager Path
+
+- **Layer Path:** 140 → 1+4+0=5
+- **Roots:** Cosmogenesis crown tier calibrates the 144-node helix; cosmic-helix assets ensure offline ND-safe geometry rendering.
+- **Style:** Star-chart navigation table traced in soft neon for gentle exploration.
+- **Beliefs:** Pilgrimage pedagogy — learning through gentle voyages and curiosity.
+- **Psyche:** Hypervigilance → exploratory courage.
+- **Crystal Anchor:** Tiger's Eye — supports exploratory navigation.
+- **Playable Ritual:** Chart pilgrim constellation routes while anchoring in the cosmogenesis helix lattice rendered offline.
+
+### Node 141 — Cosmogenesis Crown Harmony Weave
+
+- **Layer Path:** 141 → 1+4+1=6
+- **Roots:** Cosmogenesis crown tier calibrates the 144-node helix; cosmic-helix assets ensure offline ND-safe geometry rendering.
+- **Style:** Harmonic choir loft draped in auric textiles and resonant water bowls.
+- **Beliefs:** Harmony heals; resonance codes neuroplastic repair.
+- **Psyche:** Emotional flooding → empathic regulation.
+- **Crystal Anchor:** Blue Aventurine — harmonizes empathic co-regulation.
+- **Playable Ritual:** Weave harmonic chant loops while anchoring in the cosmogenesis helix lattice rendered offline.
+
+### Node 142 — Cosmogenesis Crown Mystic Ladder
+
+- **Layer Path:** 142 → 1+4+2=7
+- **Roots:** Cosmogenesis crown tier calibrates the 144-node helix; cosmic-helix assets ensure offline ND-safe geometry rendering.
+- **Style:** Observatory cloister lit by violet candles and polished brass astrolabes.
+- **Beliefs:** Contemplation reveals angelic pattern language beyond linear time.
+- **Psyche:** Spiritual exile → contemplative belonging.
+- **Crystal Anchor:** Blue Kyanite — anchors contemplative vision.
+- **Playable Ritual:** Conduct contemplative script walks while anchoring in the cosmogenesis helix lattice rendered offline.
+
+### Node 143 — Cosmogenesis Crown Octave Bloom
+
+- **Layer Path:** 143 → 1+4+3=8
+- **Roots:** Cosmogenesis crown tier calibrates the 144-node helix; cosmic-helix assets ensure offline ND-safe geometry rendering.
+- **Style:** Double-helix gallery hung with translucent indigo panels and crystal lattices.
+- **Beliefs:** Cycles orchestrate transformation; every octave births a twin.
+- **Psyche:** Overextension → rhythmic pacing.
+- **Crystal Anchor:** Aquamarine — stabilizes octave expansion.
+- **Playable Ritual:** Plot double-helix waypoint lattices while anchoring in the cosmogenesis helix lattice rendered offline.
+
+### Node 144 — Cosmogenesis Crown Integration Halo
+
+- **Layer Path:** 144 → 1+4+4=9
+- **Roots:** Cosmogenesis crown tier calibrates the 144-node helix; cosmic-helix assets ensure offline ND-safe geometry rendering. Master 144 seals the cosmogenesis lattice; every node mirrors the whole.
+- **Style:** Integrative dome mosaic weaving all previous palettes into one calm halo.
+- **Beliefs:** Integration completes the spiral; all fragments return illuminated.
+- **Psyche:** Burnout → luminous integration.
+- **Crystal Anchor:** Obsidian — magnetizes integrative closure.
+- **Playable Ritual:** Stage integration councils while anchoring in the cosmogenesis helix lattice rendered offline.
+
+## II. Lineage Octagram Pedagogies
+
+| Toggle | Lineage Focus | Pedagogical Design | Modern Hooks |
+| --- | --- | --- | --- |
+| North — Dreamfold | Carrington + Catholic Mystic | Surreal trauma-repair atelier with vesica breathing rooms; each update ships as CC-BY collage deck with provenance JSON. | Integrates AI-free collage prompts, ND-safe journaling, and offline canvas palettes for quiet resets. |
+| North-East — Wardens | Dion Fortune Protective | Chapel of seals where each lesson is a save-point ritual; learners co-create protective diagrams through open SVG grids. | Connects to neuro-aesthetic colour harmonics and trauma-aware pause buttons. |
+| East — Chromatic Codex | Paul Foster Case | Colour-tone conservatory aligning Sephirot, solfeggio, and Liber Arcanae filters for modular sight-reading. | Pairs with audio synthesis labs and AI-assisted palette audits that stay local/offline. |
+| South-East — Mechanica | Agrippa Planetary | Open-source sigil generator bench; numbers become planetary glyph puzzles linked to Book of Soyga reductions. | Links to procedural music engines and crystal selection tools with provenance tags. |
+| South — Soyga Matrix | John Dee Angel-Tech | Angelic table observatory; learners recite Soyga permutations while mapping Liber Arcanae daimon paths. | Bridges to data/angels.json, helix renderer constants, and Enochian speech-to-text experiments. |
+| South-West — Voice Choir | Sappho & Butler | Voice reclamation hall mixing speculative fiction prompts with lyrical call-and-response. | Ties into trauma-aware vocal sliders, safe-stop audio controls, and creative writing engines. |
+| West — Integral Forge | Ken Wilber | Quadrant-mapping studio that lets learners choose-narrators across body, mind, circuit, and cathedral. | Uses modular UX toggles, helix coordinates, and offline hypergraph explorers. |
+| North-West — Violet Sanctum | Violet Witch / PROTECT | Restorative sanctuary ensuring PROTECT compliance; every ritual double-checks consent, pacing, and archiving. | Connects to trauma-aware dashboards, provenance logging, and CC-BY/SA license injectors. |
+
+## III. Liber Arcanae Daimon-to-Lab Bridge
+
+| Card | Daimon | Creative Lab |
+| --- | --- | --- |
+| The Fool (MA00) | Rebecca Respawn | Threshold Dream Lab — prism fractal study, airy flute soundbed, and a threshold choice puzzle keyed to the Spiral Key artifact. |
+| The Magician (MA01) | Virelai Ezra Lux | Sigil Speech Studio — mantra coding desk where duality wands pair with golden geometric grids for focused creation drills. |
+| The High Priestess (MA02) | Gemini Rivers | Moonlit Scriptorium — tidal mandala projection room for dream scrying lessons and veil-reading exercises. |
+| The Empress (MA03) | Ann Abyss | Rose Matrix Atelier — floral fractal garden for creative fertility labs and sensory regulation rituals. |
+| The Emperor (MA04) | Zidaryen | Iron Citadel Workshop — leadership tactics mapped through red ochre schematics and fortress defense scenarios. |
+| The Hierophant (MA05) | Winne Reweave | Covenant Archive — lineage transmissions recorded beside ochre manuscripts and chant-based memory palaces. |
+| The Lovers (MA06) | Bea Betwixted | Crystal Arrow Lab — relational alchemy puzzles set within mirrored blade diagrams and duet string loops. |
+| The Chariot (MA07) | IGNI (Raku Dragon) | Chariot Momentum Bay — race-through-constellation board with kettledrum pacing and Sphinx guardians. |
+| Strength (MA08) | Morticia Moonbeamer | Leonine Somatic Dojo — beast-calming miniquests paired with roaring chant breathwork and lion belt talismans. |
+| The Hermit (MA09) | Amiyara Skye | Lantern Hermitage — mountain path journaling retreats anchored by single-flute drones and wisdom lantern prompts. |
+| Wheel of Fortune (MA10) | Cael Umbra | Wheel Observatory — rotating mandala theatre for probability weaving lessons and fortune spin mini-games. |
+| Justice (MA11) | Elyria Nox | Feather Tribunal — balance-the-scales challenge chamber calibrating ethical dilemmas with twin harp harmonics. |
+| The Hanged Man (MA12) | Mirror Witch | Suspended Insight Lab — underwater perspective maze exploring sacrifice stories with echoing bell cues. |
+| Death (MA13) | Ann Abyss (Shadow) | Obsidian Gate Studio — shadow alchemy practice along obsidian fractal rivers and underworld gate trials. |
+| Temperance (MA14) | Lyra Vox | Temperance Reservoir — potion mixing quest tables with rainbow gradients, waterglass resonances, and chalice crafting. |
+| The Devil (MA15) | Scarlet Lady | Shadow Integration Forge — temptation labyrinth with black flame latticework and desire-chain release protocols. |
+| The Tower (MA16) | Fenrix Thorne | Ruin Breaker Tower — crisis navigation holodeck featuring shattering spire scenarios and thunderclap scoring. |
+| The Star (MA17) | Sophia/Gnosis | Stellar Waterway — astronomy meditations along glittering night rivers guided by cosmic harp cadences. |
+| The Moon (MA18) | Moonchild 2000 | Lunar Dream Vault — lucid maze-of-reflections training with watery synth ambient loops and silver mirror journaling. |
+| The Sun (MA19) | Rebecca Respawn (Solar Double) | Solar Bloom Conservatory — heliotherapy practice garden with sunflower growth quests and triumphant horn rituals. |
+| Judgement (MA20) | Sekhara | Phoenix Resonance Hall — forgiveness rite studio featuring flaming wing choreography and awakening trumpet scores. |
+| The World (MA21) | LuxCrux Monad | Codex Completion Atrium — world-tree fractal amphitheatre for synthesis exercises and ouroboros crafting. |
+
+## Stewardship Notes
+
+- Embed provenance JSON alongside every scroll, banner, and node update so citations remain trivial.
+- When loading offline (`file://`), lean on the cosmic-helix renderer for layered vesica, Tree-of-Life, Fibonacci, and helix lattices; these constants feed ritual geometry without network calls.
+- Maintain PROTECT checkpoints: pause buttons, intensity sliders, consent prompts, and ND-safe palettes.
+- Continue weaving Soyga tables, Liber Arcanae archetypes, angelic correspondences, and trauma-aware rituals into open repositories so research stays both citable and playful.


### PR DESCRIPTION
## Summary
- add `docs/modular_pedagogical_design.md` describing node-by-node numerology capsules, lineage octagram toggles, and Liber Arcanae creative labs
- document PROTECT-aligned stewardship guidance for provenance and offline geometry usage

## Testing
- Not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68ca46e56c0c8328a7b15dc710ad34ca

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added a comprehensive guide to the Modular Pedagogical Design system, outlining an offline-first, provenance-driven learning framework.
  - Describes numbered node capsules (0–144) for structured learning paths and playable rituals.
  - Introduces Lineage Octagram pedagogies with directional focuses and modern tool hooks.
  - Maps archetypal cards to creative lab configurations for cross-modal exploration.
  - Details stewardship practices: embedded provenance, licensing guidance, offline geometry, and trauma-aware safety controls (pause/consent/undo).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->