### PR TITLE
Polish cosmic helix renderer and configure Netlify

### DIFF
--- a/cosmic-helix/README_RENDERER.md
+++ b/cosmic-helix/README_RENDERER.md
@@ -1,94 +1,29 @@
 # Cosmic Helix Renderer (Offline, ND-safe)
 
-Static offline renderer that draws the requested four-layer cosmology on a 1440x900 canvas. The module stays inside `cosmic-helix/` so the main project index keeps its lore focus (why: preserves the existing entry point while adding this research tool).
+Static HTML + Canvas renderer that draws the requested four-layer cosmology on a 1440x900 canvas. The module lives inside
+`cosmic-helix/` so the root index keeps its established lore-first entry point (why: preserves the wider narrative while adding
+this focused research plate).
 
-## Files
-- `index.html` – entry point that loads the palette (with fallback) and invokes the renderer.
-- `js/helix-renderer.mjs` – pure drawing routines for the four calm layers.
-- `data/palette.json` – optional colour overrides. Missing data triggers a safe fallback.
+## Files in this capsule
+- `index.html` &mdash; entry point that loads the palette (with fallback), seeds numerology constants, and invokes the renderer.
+- `js/helix-renderer.mjs` &mdash; ES module of small pure drawing functions (one helper per layer plus utilities).
+- `data/palette.json` &mdash; optional colour overrides. Missing data triggers a calm fallback and a gentle notice.
 
-## Usage
-1. Double-click `index.html` in any modern browser. No server or network requests are required.
-2. The status line reports whether the palette file loaded or if the fallback colours were applied.
-3. The canvas renders these static layers in order:
-   - **L1 Vesica field** – intersecting circles arranged with 3/7/9/11 spacing to evoke the vesica womb.
-   - **L2 Tree-of-Life scaffold** – ten sephirot linked by twenty-two paths, sized from 99/144 ratios for readability.
-   - **L3 Fibonacci curve** – a golden spiral polyline sampled across 144 points for smooth calm arcs.
-   - **L4 Double-helix lattice** – two phase-shifted sine strands with thirty-three cross ties.
-
-## ND-safe design notes
-- Single render pass only; there is no animation, autoplay, or flashing.
-- Muted palette with readable contrast and transparent strokes reduces sensory strain.
-- Inline comments explain how numerology constants guide spacing so future stewards understand the symbolism.
-- If the palette file is absent, both the header and the canvas receive a gentle notice instead of failing silently.
-
-## Customising colour
-Edit `data/palette.json` to tune colours. Keep the keys:
-- `bg` – background colour for both page and canvas.
-- `ink` – text colour used for notices.
-- `muted` – optional accent used by the status line.
-- `layers` – array of six hex values applied to the four geometry layers plus helix rungs.
-
-If the JSON is missing or malformed, the renderer loads bundled safe colours and reports the fallback.
-
-## Extending safely
-Add new geometry by composing additional pure helper functions inside `js/helix-renderer.mjs`. Maintain the ND-safe covenant: static rendering, layered depth (never flattened into a single outline), calm palette, ASCII quotes, UTF-8, and detailed comments on why choices were made.
-Static HTML + Canvas renderer that draws four calm geometry layers: Vesica field, Tree-of-Life scaffold, Fibonacci spiral, and a static double-helix lattice. Everything runs by double-clicking `index.html`; no build tools, no motion.
-
-## Why this sits in `cosmic-helix/`
-Keeping the renderer inside this folder protects the root `index.html` lore while fulfilling the layered cosmology brief. Comments in the HTML and module explain that decision for future stewards.
-
-## Files
-- `index.html` – entry point with status line, numerology constants, and palette loading.
-- `js/helix-renderer.mjs` – pure ES module of small drawing functions (one per layer plus helpers).
-- `data/palette.json` – optional colour overrides; removal triggers a gentle fallback notice.
+## Layer order (back to front)
+1. **Vesica field** &mdash; intersecting circle lattice spaced with 3/7/9/11 ratios to set the womb-of-forms foundation.
+2. **Tree-of-Life scaffold** &mdash; ten sephirot nodes linked by twenty-two paths, scaled by 33/99/144 denominators for clarity.
+3. **Fibonacci curve** &mdash; logarithmic spiral polyline sampled over 144 points with golden-ratio pacing for gentle growth.
+4. **Double-helix lattice** &mdash; two static sine strands with rungs every few samples (144 total points, 22 rungs) to echo the
+   requested lattice.
 
 ## Usage (offline)
-1. Open `index.html` directly in a modern browser (no server required).
-2. The header status reports whether the palette JSON was loaded or if the safe fallback colours were used.
-3. A 1440×900 canvas renders the four layers in order:
-   - **Layer 1** Vesica field – intersecting lenses spaced with 3/7/11 numerology.
-   - **Layer 2** Tree-of-Life – ten sephirot and twenty-two linking paths.
-   - **Layer 3** Fibonacci spiral – golden-ratio polyline sampling 33 segments.
-   - **Layer 4** Double-helix lattice – two sine strands with 22 static cross ties.
-4. If the palette file cannot be fetched (common under `file://`), the canvas draws a small notice in the corner and keeps the default colours.
+1. Open `cosmic-helix/index.html` directly in any modern browser (no server or network required).
+2. The status line reports whether `data/palette.json` loaded or if the fallback palette is active.
+3. The canvas renders the four layers once. If the palette file is missing under `file://` conditions, the renderer posts a small
+   notice on the canvas while keeping safe colours.
 
-## ND-safe design choices
-- One render pass, no animation, no autoplay, no flashing.
-- Muted palette and soft line widths protect sensory comfort.
-- Comments in code describe each safety decision for transparency.
-- Geometry proportions lean on the requested numerology constants: 3, 7, 9, 11, 22, 33, 99, and 144.
-
-## Customising safely
-- Adjust colours in `data/palette.json`; the file expects keys `bg`, `ink`, `muted`, and a six-entry `layers` array.
-- Add new geometry by creating additional pure helper functions in `js/helix-renderer.mjs` and calling them after the existing layers.
-- Keep new work static, ASCII-only, and well commented so the ND-safe covenant remains intact.
-Static, offline HTML + Canvas renderer that draws four calm layers of sacred geometry for the Cosmogenesis Learning Engine. The code is ND-safe: no animation, soft contrast, and every helper is a small pure function with comments explaining the safety choices.
-
-## Files
-- `index.html` — entry point. Double-click to render the canvas with no server or network access.
-- `js/helix-renderer.mjs` — ES module with layered drawing helpers.
-- `data/palette.json` — optional palette override; the renderer falls back gracefully when the file is absent.
-
-## Usage
-1. Open `index.html` directly in any modern browser.
-2. A 1440×900 canvas renders four ordered layers once: Vesica field, Tree-of-Life scaffold, Fibonacci curve, and a double-helix lattice.
-3. The header status text reports whether the palette file loaded or if the safe fallback is active. When the palette is missing, a quiet note also appears on the canvas itself.
-
-## ND-safe design choices
-- **No motion:** every layer draws in a single pass; no animation hooks or timers.
-- **Calm contrast:** muted defaults and palette validation prevent harsh colour spikes.
-- **Layered depth:** each layer draws in order so the geometry reads with depth without relying on motion.
-- **Commented intent:** in-code comments explain why each safety choice exists for future stewards.
-
-## Geometry & numerology
-- Vesica field spacing references constants 3, 7, 9, 11, 22, and 33 to echo the requested ratios.
-- Tree-of-Life layout uses the canonical ten sephirot with twenty-two connecting paths.
-- Fibonacci curve is a static golden spiral polyline sampled with 99 points.
-- Double-helix lattice samples 144 points across three sine cycles to keep the numerology visible.
-
-## Custom palette
-Edit `data/palette.json` to supply your own colours. Required keys:
+## Palette fallback
+Edit `data/palette.json` to supply custom colours:
 
 ```json
 {
@@ -99,138 +34,24 @@ Edit `data/palette.json` to supply your own colours. Required keys:
 }
 ```
 
-If the file is missing or malformed, the renderer keeps drawing with the bundled palette, records the fallback in the status line, and prints a small note on the canvas.
+If the JSON is missing or malformed, `index.html` falls back to these bundled colours, updates the status line, and paints the
+same notice on the canvas so nothing fails silently.
 
-## Extension guidance
-Add new geometry by introducing additional pure helper functions in `js/helix-renderer.mjs` and calling them after the existing layers. Maintain ASCII quotes, UTF-8 encoding, LF newlines, and explain any lore additions with comments so ND-safe intent stays intact.
-Static, offline HTML + Canvas renderer that layers vesica field, Tree-of-Life scaffold, Fibonacci curve, and a fixed double-helix lattice. Designed for ND-safe viewing with calm contrast and zero motion.
+## Numerology constants in use
+All geometry helpers receive a `NUM` object exposing the requested constants:
+- `3` seeds vesica symmetry.
+- `7` and `9` define grid counts and vertical spacing.
+- `11` drives margins and angle ratios.
+- `22` sets Tree-of-Life paths and helix rungs.
+- `33`, `99`, and `144` scale radii, sampling density, and curve pacing.
 
-## Files
-- `index.html` - entry point; double-click to run offline.
-- `js/helix-renderer.mjs` - pure drawing routines composed as ES module.
-- `data/palette.json` - optional palette override; a fallback palette is bundled.
+## ND-safe and trauma-informed choices
+- **No motion:** every layer renders once; no timers, requestAnimationFrame, or interaction hooks.
+- **Calm contrast:** palette validation prevents harsh spikes and keeps text readable.
+- **Layered depth:** geometry is rendered in ordered layers instead of flattening into a single outline.
+- **Commented intent:** code comments explain why each safety choice exists for future stewards.
 
-## Usage
-1. Open `index.html` in any modern browser (no server required).
-2. A 1440x900 canvas renders four static layers:
-   - Layer 1: Vesica field
-   - Layer 2: Tree-of-Life nodes and paths
-   - Layer 3: Fibonacci curve
-   - Layer 4: Double-helix lattice
-3. The header status reports whether the palette file was loaded or the fallback was used.
-
-## ND-safe choices
-- Static rendering only; no animation, autoplay, or flashing.
-- Muted contrast palette and generous spacing reduce sensory strain.
-- Layer order conveys depth without relying on motion cues.
-- Inline comments explain safety choices for future maintainers.
-
-## Numerology guidance
-Geometry proportions reference the requested constants 3, 7, 9, 11, 22, 33, 99, and 144. The constants steer grid spacing, path thickness, spiral turn count, and helix sample density.
-
-## Custom palette
-Edit `data/palette.json` to change colours. Expected keys:
-- `bg` - page and canvas background.
-- `ink` - caption and notice colour.
-- `muted` - optional chrome accent.
-- `layers` - array of six layer colours in back-to-front order.
-
-If the JSON file is missing or malformed, `index.html` displays a gentle notice and uses the bundled fallback palette so the render never fails.
-
-## Extending safely
-Add new geometry by composing additional pure draw functions inside `js/helix-renderer.mjs`. Keep the ND-safe covenant: static rendering, calm colours, progressive layering, and commentary that explains any lore additions.
-
-Seal motto: *Per Texturas Numerorum, Spira Loquitur.*
-Static, offline HTML + Canvas renderer honouring the layered geometry brief for Codex 144:99 (c99). The module draws four calm layers with no motion, no autoplay, and no external dependencies.
-
-## Files
-- `index.html` — entry point; loads the palette (if present) and renders the canvas.
-- `js/helix-renderer.mjs` — pure ES module with small drawing functions for each layer.
-- `data/palette.json` — optional palette override; missing data triggers a gentle fallback notice.
-
-## Usage
-1. Double-click `index.html` in any modern browser (no server or network required).
-2. A fixed 1440×900 canvas renders the layers in order:
-   - **Layer 1 — Vesica field:** intersecting circle lattice spaced by numerology constants.
-   - **Layer 2 — Tree-of-Life scaffold:** ten sephirot nodes linked by twenty-two calm paths.
-   - **Layer 3 — Fibonacci curve:** golden spiral polyline sampled across 144 points.
-   - **Layer 4 — Double-helix lattice:** two phase-shifted strands with static rungs.
-3. The status line reports whether the optional palette file was loaded or if the fallback palette is in use.
-
-## ND-safe + trauma-informed choices
-- One render pass only; no animation, flashing, audio, or autoplay.
-- Soft contrast palette with readable typography and clear status messaging.
-- Layer order communicates depth without motion; comments in code explain why.
-- Geometry is parameterised with 3, 7, 9, 11, 22, 33, 99, and 144 to keep numerology explicit.
-
-## Customising
-- Edit `data/palette.json` to change colours (keys: `bg`, `ink`, `muted`, and six `layers` entries).
-- Extend `js/helix-renderer.mjs` by adding new pure draw helpers after the existing layers. Document any lore or safety rationale directly in comments.
-
-## Troubleshooting
-- **Palette warning:** Browsers may block `fetch` over `file://`. The renderer already handles this, falls back to the bundled palette, and notes the change in the header and canvas.
-- **Blank canvas:** If a 2D context is unavailable, the header reports the issue. Try a current Firefox, Safari, or Chromium build.
-- **Overbright edits:** Keep hues mid-range and respect the ND-safe covenant when adjusting palettes or geometry.
-
-*Seal motto: Per Texturas Numerorum, Spira Loquitur.*
-Static, offline canvas scene that layers Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. The renderer lives inside `cosmic-helix/` so the wider cathedral entry point remains untouched — lore boundaries stay intact.
-
-## Files
-- `index.html` — entry point; double-click to run.
-- `js/helix-renderer.mjs` — pure drawing routines for the four layers.
-- `data/palette.json` — optional palette override; safe defaults cover missing files.
-
-## Usage
-1. Open `index.html` directly in a modern browser (no server or network required).
-2. A 1440x900 canvas renders four ordered layers:
-   - **Layer 1: Vesica field** — intersecting circle lenses arranged with 3/7/9/11 spacing.
-   - **Layer 2: Tree-of-Life scaffold** — ten sephirot linked by twenty-two paths.
-   - **Layer 3: Fibonacci curve** — calm golden spiral polyline.
-   - **Layer 4: Double-helix lattice** — two static strands with gentle cross ties.
-3. The header status reports whether the palette loaded or if the fallback palette was used.
-
-## ND-safe choices
-- Single render pass; no animation, autoplay, or flashing elements.
-- Soft contrast palette, generous margins, and inline notices to reduce sensory load.
-- Layer order preserves depth without requiring motion.
-- Comments inside the code explain each safety decision for future stewards.
-
-## Numerology alignment
-The geometry functions weave the requested constants (3, 7, 9, 11, 22, 33, 99, 144) into spacing, stroke widths, spiral turns, and helix sampling counts to keep the cosmology coherent.
-
-## Palette and fallback
-`data/palette.json` may override colours. When the JSON file is missing or blocked by the browser, the renderer applies bundled defaults, prints a status message, and paints a small notice in the canvas corner so the experience remains calm and predictable.
-
-## Extending safely
-Static, offline canvas scene that layers Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. The renderer lives inside `cosmic-helix/` so the wider cathedral entry point remains untouched — lore boundaries stay intact.
-
-## Files
-- `index.html` — entry point; double-click to run.
-- `js/helix-renderer.mjs` — pure drawing routines for the four layers.
-- `data/palette.json` — optional palette override; safe defaults cover missing files.
-
-## Usage
-1. Open `index.html` directly in a modern browser (no server or network required).
-2. A 1440x900 canvas renders four ordered layers:
-   - **Layer 1: Vesica field** — intersecting circle lenses arranged with 3/7/9/11 spacing.
-   - **Layer 2: Tree-of-Life scaffold** — ten sephirot linked by twenty-two paths.
-   - **Layer 3: Fibonacci curve** — calm golden spiral polyline.
-   - **Layer 4: Double-helix lattice** — two static strands with gentle cross ties.
-3. The header status reports whether the palette loaded or if the fallback palette was used.
-
-## ND-safe choices
-- Single render pass; no animation, autoplay, or flashing elements.
-- Soft contrast palette, generous margins, and inline notices to reduce sensory load.
-- Layer order preserves depth without requiring motion.
-- Comments inside the code explain each safety decision for future stewards.
-
-## Numerology alignment
-The geometry functions weave the requested constants (3, 7, 9, 11, 22, 33, 99, 144) into spacing, stroke widths, spiral turns, and helix sampling counts to keep the cosmology coherent.
-
-## Palette and fallback
-`data/palette.json` may override colours. When the JSON file is missing or blocked by the browser, the renderer applies bundled defaults, prints a status message, and paints a small notice in the canvas corner so the experience remains calm and predictable.
-
-## Extending safely
-Add new layers by composing additional pure helper functions in `js/helix-renderer.mjs`. Maintain the ND-safe covenant: static rendering, calm colours, ASCII quotes, LF newlines, and clear comments describing why new geometry supports the canon.
-
-_Per Texturas Numerorum, Spira Loquitur._
+## Extending carefully
+Add new geometry by composing additional pure helper functions in `js/helix-renderer.mjs`. Maintain the covenant: ASCII quotes
+only, UTF-8 with LF newlines, static rendering, calm palette, and inline commentary explaining any lore additions. Keep the module
+self-contained so it remains double-click runnable without build tools or network requests.

--- a/cosmic-helix/index.html
+++ b/cosmic-helix/index.html
@@ -5,33 +5,9 @@
   <title>Cosmic Helix Renderer (ND-safe, Offline)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
   <meta name="color-scheme" content="light dark">
-  <!-- Integration note: renderer lives in cosmic-helix/ so the primary index.html stays intact (why: preserves existing lore entry point). -->
-  <!-- Integration note: this renderer stays inside cosmic-helix/ so the primary index.html lore remains intact. -->
-  <!-- Kept inside cosmic-helix/ so the site root remains untouched; honours existing lore layout. -->
+  <!-- Lives under cosmic-helix/ so the root index keeps its lore-forward entry point (why: preserves established narrative flow). -->
   <style>
-    /* ND-safe: calm contrast, no motion, generous breathing room */
-  <!-- Layered geometry stays within cosmic-helix/ to respect the broader Codex 144:99 (c99) structure. -->
-  <style>
-    /* ND-safe chrome: calm contrast, generous spacing, no motion cues */
-    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
-    html, body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
-    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; background:linear-gradient(180deg,#10101a,#0000); }
-    .status { color:var(--muted); font-size:12px; margin-top:4px; }
-    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
-    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
-    .status { color:var(--muted); font-size:12px; }
-    #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; background:var(--bg); }
-    .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
-    code { background:#11111a; padding:2px 4px; border-radius:3px; }
-  <style>
-    /* ND-safe palette: calm contrast, no motion, generous spacing. */
-    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
-    html, body {
-  <!-- Integration note: lives in cosmic-helix/ so the wider cathedral index stays untouched; honours the lore boundaries. -->
-  <style>
-  <!-- Integration note: lives in cosmic-helix/ so the wider cathedral index stays untouched; honours the lore boundaries. -->
-  <style>
-    /* ND-safe: calm contrast, no motion, generous spacing */
+    /* ND-safe chrome: calm contrast, generous spacing, no motion cues. */
     :root {
       --bg: #0b0b12;
       --ink: #e8e8f0;
@@ -44,488 +20,73 @@
       padding: 0;
       background: var(--bg);
       color: var(--ink);
-      font: 14px/1.5 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-    }
       font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
     }
 
     header {
       padding: 12px 16px;
       border-bottom: 1px solid #1d1d2a;
+      background: linear-gradient(180deg, #10101a, transparent);
+    }
+
+    header strong {
+      font-weight: 600;
     }
 
     .status {
       color: var(--muted);
       font-size: 12px;
+      margin-top: 4px;
     }
+
     #stage {
       display: block;
       margin: 16px auto 24px;
+      width: 100%;
+      max-width: 1440px;
       box-shadow: 0 0 0 1px #1d1d2a;
       background: var(--bg);
     }
+
     .note {
       max-width: 900px;
       margin: 0 auto 24px;
       color: var(--muted);
-    }
-
-    #stage {
-      display: block;
-      margin: 16px auto;
-      box-shadow: 0 0 0 1px #1d1d2a;
-      background: var(--bg);
-    }
-
-    .note {
-      max-width: 900px;
-      margin: 0 auto 16px;
-      color: var(--muted);
+      padding: 0 16px 40px;
     }
 
     code {
       background: #11111a;
       padding: 2px 4px;
       border-radius: 3px;
-    html, body {
-      margin:0;
-      padding:0;
-      background:var(--bg);
-      color:var(--ink);
-      font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
-    }
-    header {
-      padding:12px 16px;
-      border-bottom:1px solid #1d1d2a;
-    }
-    header strong { font-weight:600; }
-    .status {
-      color:var(--muted);
-      font-size:12px;
-      margin-top:4px;
-    }
-    #stage {
-      display:block;
-      margin:16px auto;
-      box-shadow:0 0 0 1px #1d1d2a;
-      background:var(--bg);
-    }
-    .note {
-      max-width:900px;
-      margin:0 auto 16px;
-      color:var(--muted);
-    }
-    code {
-      background:#11111a;
-      padding:2px 4px;
-      border-radius:3px;
     }
   </style>
 </head>
 <body>
   <header>
-    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
-=====
-      <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
->>>>>>>+upstream/codex/
-  <div class="status" id="status" role="status" aria-live="polite">Loading palette...</div>
-  </header>
-
-  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-<<  <p class="note">Static rendering only: Vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice. No animation, no autoplay, no external libraries. Open this file directly.</p>
-    <div class="status" id="status" role="status" aria-live="polite">Loading palette…</div>
-  </header>
-    <div class="status" id="status" role="status" aria-live="polite">Loading palette…</div>
-  </header>
-
-  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">Static renderer for Vesica, Tree-of-Life, Fibonacci, and a double-helix lattice. No animation, no autoplay, no external libraries. Open this file directly.</p>
-
-  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">Static Vesica, Tree-of-Life, Fibonacci, and double-helix layers. No animation, no autoplay, no external libraries. Open this file directly.</p>
-    <div class="status" id="status" role="status" aria-live="polite">Loading palette…</div>
-  </header>
+    <div><strong>Cosmic Helix Renderer</strong> &mdash; layered sacred geometry (offline, ND-safe)</div>
     <div class="status" id="status" role="status" aria-live="polite">Loading palette...</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">Static renderer encoding Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libraries. Open this file directly.</p>
+  <p class="note">
+    Static renderer for Vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice. No animation,
+    no autoplay, no external libraries. Open this file directly; it works offline.
+  </p>
 
-  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">Vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice are rendered once with a calm palette. No animation, no external libraries. Open this file directly.</p>
->>>>>>>+main
-=
-  <p c  <p class="note">Static renderer encoding Vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice. No animation, no autoplay, no external libraries. Open this file directly.</p>
->>>>>>>+upstream/codex/
-ript type="module">
+  <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
 
-    const elStatus = document.getElementById("status");
+    const statusEl = document.getElementById("status");
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
 
-<<<<<<    if (!ctx) {
-      statusEl.textContent = "Canvas context unavailable; try a newer browser.";
-    }
-
-    const defaults = {
+    const FALLBACK = {
       palette: {
         bg: "#0b0b12",
         ink: "#e8e8f0",
         muted: "#a6a6c1",
         layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-      }
-    };
-
-    function applyPaletteColors(palette) {
-    async function loadJSON(path) {
-    // Offline-first loader: fetch may fail under file://, so errors fall back silently.
-    async function loadPalette(path) {
-      try {
-        const response = await fetch(path, { cache: "no-store" });
-        if (!response.ok) return null;
-        return await response.json();
-      } catch (error) {
-      } catch (err) {
-        return null;
-      }
-    }
-
-    function isValidPalette(candidate) {
-      if (!candidate || typeof candidate !== "object") return false;
-      if (!Array.isArray(candidate.layers)) return false;
-      return candidate.layers.length >= 6;
-    }
-
-    function applyPaletteToChrome(palette) {
-    function applyChromeColors(palette) {
-      const root = document.documentElement.style;
-      if (palette.bg) root.setProperty("--bg", palette.bg);
-      if (palette.ink) root.setProperty("--ink", palette.ink);
-      if (palette.muted) root.setProperty("--muted", palette.muted);
-    }
-
-    // Local-only fetch keeps the renderer offline; errors fall back silently.
-    const fallbackPalette = {
-      bg: "#0b0b12",
-      ink: "#e8e8f0",
-      muted: "#a6a6c1",
-      layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-    };
-
-    function applyChromePalette(palette) {
-      const root = document.documentElement.style;
-      root.setProperty("--bg", palette.bg || fallbackPalette.bg);
-      root.setProperty("--ink", palette.ink || fallbackPalette.ink);
-      root.setProperty("--muted", palette.muted || fallbackPalette.muted || fallbackPalette.ink);
->>>>>>>+main
-=
-    co    const FALLBACK_PALETTE = {
-      bg: "#0b0b12",
-      ink: "#e8e8f0",
-      muted: "#a6a6c1",
-      layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-    };
-
-    // Applies palette colours to the chrome so the UI mirrors the canvas calmly.
-    function applyPaletteColors(palette) {
-      const rootStyle = document.documentElement.style;
-      if (palette.bg) rootStyle.setProperty("--bg", palette.bg);
-      if (palette.ink) rootStyle.setProperty("--ink", palette.ink);
-      if (palette.muted) rootStyle.setProperty("--muted", palette.muted);
->>>>>>>+upstream/codex/
-
-    async function loadPalette(path) {
-      try {
-        const response = await fetch(path, { cache: "no-store" });
-        if (!response.ok) return null;
-        return await response.json();
-      } catch (error) {
-<<<<<<        return null;
-      }
-    }
-
-    const paletteData = await loadPalette("./data/palette.json");
-    const activePalette = paletteData || defaults.palette;
-    applyPaletteColors(activePalette);
-
-    const paletteNotice = paletteData ? "Palette loaded." : "Palette missing; using safe fallback.";
-    statusEl.textContent = paletteNotice;
-
-    if (ctx) {
-        return null; // Offline-first: browsers often block fetch under file://.
-      }
-    }
-
-    function validatePalette(data) {
-      if (!data) return false;
-      if (!Array.isArray(data.layers)) return false;
-      return data.layers.length >= 6;
-    }
-
-    if (!ctx) {
-      statusEl.textContent = "Canvas 2D context unavailable in this browser.";
-    } else {
-      const paletteData = await loadPalette("./data/palette.json");
-      const palette = validatePalette(paletteData) ? paletteData : null;
-      const activePalette = palette || fallbackPalette;
-      const notice = palette ? null : "Palette fallback active.";
-
-      applyChromePalette(activePalette);
-      statusEl.textContent = palette ? "Palette loaded." : "Palette unavailable; using safe fallback palette.";
-
-    const fetchedPalette = await loadJSON("./data/palette.json");
-    const palette = isValidPalette(fetchedPalette) ? fetchedPalette : defaults.palette;
-    applyPaletteToChrome(palette);
-
-    const usingFallback = !isValidPalette(fetchedPalette);
-    elStatus.textContent = usingFallback
-      ? "Palette missing or incomplete; using safe fallback."
-      : "Palette loaded.";
-
-    if (!ctx) {
-      elStatus.textContent += " Canvas context unavailable.";
-    } else {
->>>>>>>+main
-=
-              // file:// requests often throw; calm fallback keeps the render ND-safe.
-        return null;
-      }
-    }
-
-    const paletteData = await loadPalette("./data/palette.json");
-    const palette = paletteData && Array.isArray(paletteData.layers) ? paletteData : null;
-    const activePalette = palette || FALLBACK_PALETTE;
-
-    applyPaletteColors(activePalette);
-
-    const statusMessage = palette ? "Palette loaded." : "Palette missing; using safe fallback palette.";
-
-    if (!ctx) {
-      statusEl.textContent = statusMessage + " Canvas context unavailable; please try a modern browser.";
-    } else {
-      statusEl.textContent = statusMessage + " Geometry rendered.";
-
->>>>>>>+upstream/codex/
-const NUM = {
-        THREE: 3,
-        SEVEN: 7,
-        NINE: 9,
-        ELEVEN: 11,
-        TWENTYTWO: 22,
-        THIRTYTHREE: 33,
-        NINETYNINE: 99,
-        ONEFORTYFOUR: 144
-      };
-
-<<<<<<      const notice = paletteData ? null : "Palette missing; safe fallback applied.";
->>>>>>>+main
-=
-            // ND-safe rationale: render once with layered calm colours; show notice if palette is missing.
->>>>>>>+upstream/codex/
-renderHelix(ctx, {
-        width: canvas.width,
-        height: canvas.height,
-        palette: activePalette,
-        NUM,
-<<<<<<        notice
-      renderHelix(ctx, {
-        width: canvas.width,
-        height: canvas.height,
-        palette,
-        NUM,
-        notice: usingFallback ? "Fallback palette active." : ""
->>>>>>>+main
-=
-              notice: palette ? null : "Palette data missing; fallback colours applied."
->>>>>>>+upstream/codex/
-});
-    }
-  </script>
-</body>
-</html>
-    }
-  </style>
-</head>
-<body>
-  <header>
-<<<<<<<+main
-    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
-=====
-      <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
->>>>>>>+upstream/codex/
-  <div class="status" id="status" role="status" aria-live="polite">Loading palette...</div>
-  </header>
-
-  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-<<  <p class="note">Static rendering only: Vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice. No animation, no autoplay, no external libraries. Open this file directly.</p>
-    <div class="status" id="status" role="status" aria-live="polite">Loading palette…</div>
-  </header>
-
-  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">Static Vesica, Tree-of-Life, Fibonacci, and double-helix layers. No animation, no autoplay, no external libraries. Open this file directly.</p>
-    <div class="status" id="status" role="status" aria-live="polite">Loading palette…</div>
-  </header>
-
-  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">Vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice are rendered once with a calm palette. No animation, no external libraries. Open this file directly.</p>
->>>>>>>+main
-=
-  <p c  <p class="note">Static renderer encoding Vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice. No animation, no autoplay, no external libraries. Open this file directly.</p>
->>>>>>>+upstream/codex/
-ript type="module">
-    import { renderHelix } from "./js/helix-renderer.mjs";
-
-    const elStatus = document.getElementById("status");
-    const canvas = document.getElementById("stage");
-    const ctx = canvas.getContext("2d");
-
-<<<<<<    if (!ctx) {
-      statusEl.textContent = "Canvas context unavailable; try a newer browser.";
-    }
-
-    const defaults = {
-      palette: {
-        bg: "#0b0b12",
-        ink: "#e8e8f0",
-        muted: "#a6a6c1",
-        layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-      }
-    };
-
-    function applyPaletteColors(palette) {
-    async function loadJSON(path) {
-      try {
-        const response = await fetch(path, { cache: "no-store" });
-        if (!response.ok) return null;
-        return await response.json();
-      } catch (error) {
-        return null;
-      }
-    }
-
-    function isValidPalette(candidate) {
-      if (!candidate || typeof candidate !== "object") return false;
-      if (!Array.isArray(candidate.layers)) return false;
-      return candidate.layers.length >= 6;
-    }
-
-    function applyPaletteToChrome(palette) {
-      const root = document.documentElement.style;
-      if (palette.bg) root.setProperty("--bg", palette.bg);
-      if (palette.ink) root.setProperty("--ink", palette.ink);
-      if (palette.muted) root.setProperty("--muted", palette.muted);
-    }
-
-    // Local-only fetch keeps the renderer offline; errors fall back silently.
-    const fallbackPalette = {
-      bg: "#0b0b12",
-      ink: "#e8e8f0",
-      muted: "#a6a6c1",
-      layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-    };
-
-    function applyChromePalette(palette) {
-      const root = document.documentElement.style;
-      root.setProperty("--bg", palette.bg || fallbackPalette.bg);
-      root.setProperty("--ink", palette.ink || fallbackPalette.ink);
-      root.setProperty("--muted", palette.muted || fallbackPalette.muted || fallbackPalette.ink);
->>>>>>>+main
-=
-    co    const FALLBACK_PALETTE = {
-      bg: "#0b0b12",
-      ink: "#e8e8f0",
-      muted: "#a6a6c1",
-      layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-    };
-
-    // Applies palette colours to the chrome so the UI mirrors the canvas calmly.
-    function applyPaletteColors(palette) {
-      const rootStyle = document.documentElement.style;
-      if (palette.bg) rootStyle.setProperty("--bg", palette.bg);
-      if (palette.ink) rootStyle.setProperty("--ink", palette.ink);
-      if (palette.muted) rootStyle.setProperty("--muted", palette.muted);
->>>>>>>+upstream/codex/
-
-    async function loadPalette(path) {
-      try {
-        const response = await fetch(path, { cache: "no-store" });
-        if (!response.ok) return null;
-        return await response.json();
-      } catch (error) {
-<<<<<<        return null;
-      }
-    }
-
-    const paletteData = await loadPalette("./data/palette.json");
-    const activePalette = paletteData || defaults.palette;
-    applyPaletteColors(activePalette);
-
-    const paletteNotice = paletteData ? "Palette loaded." : "Palette missing; using safe fallback.";
-    statusEl.textContent = paletteNotice;
-
-    if (ctx) {
-        return null; // Offline-first: browsers often block fetch under file://.
-    (async () => {
-      const paletteData = await loadPalette("./data/palette.json");
-      const activePalette = paletteData || defaults.palette;
-      applyChromeColors(activePalette);
-
-      const notice = paletteData ? null : "Palette missing; using safe fallback palette.";
-      const statusPrefix = paletteData ? "Palette loaded." : "Fallback palette active.";
-
-      const NUM = {
-        THREE: 3,
-        SEVEN: 7,
-        NINE: 9,
-        ELEVEN: 11,
-        TWENTYTWO: 22,
-        THIRTYTHREE: 33,
-        NINETYNINE: 99,
-        ONEFORTYFOUR: 144
-      };
-
-      if (!ctx) {
-        statusEl.textContent = statusPrefix + " Canvas context unavailable; try a modern browser.";
-        return;
-      }
-    }
-
-    function validatePalette(data) {
-      if (!data) return false;
-      if (!Array.isArray(data.layers)) return false;
-      return data.layers.length >= 6;
-    }
-
-    if (!ctx) {
-      statusEl.textContent = "Canvas 2D context unavailable in this browser.";
-    } else {
-      const paletteData = await loadPalette("./data/palette.json");
-      const palette = validatePalette(paletteData) ? paletteData : null;
-      const activePalette = palette || fallbackPalette;
-      const notice = palette ? null : "Palette fallback active.";
-
-      applyChromePalette(activePalette);
-      statusEl.textContent = palette ? "Palette loaded." : "Palette unavailable; using safe fallback palette.";
-
-    const fetchedPalette = await loadJSON("./data/palette.json");
-    const palette = isValidPalette(fetchedPalette) ? fetchedPalette : defaults.palette;
-    applyPaletteToChrome(palette);
-
-    const usingFallback = !isValidPalette(fetchedPalette);
-    elStatus.textContent = usingFallback
-      ? "Palette missing or incomplete; using safe fallback."
-      : "Palette loaded.";
-
-    if (!ctx) {
-      elStatus.textContent += " Canvas context unavailable.";
-    } else {
->>>>>>>+main
-=
-              // file:// requests often throw; calm fallback keeps the render ND-safe.
-      }
-    };
-
       }
     };
 
@@ -540,111 +101,44 @@ ript type="module">
       ONEFORTYFOUR: 144
     };
 
-    function applyChrome(palette) {
-      const style = document.documentElement.style;
-      style.setProperty("--bg", palette.bg);
-      style.setProperty("--ink", palette.ink);
-      style.setProperty("--muted", palette.muted || defaults.palette.muted);
+    if (!ctx) {
+      statusEl.textContent = "Canvas context unavailable in this browser.";
+    } else {
+      initialise();
+    }
+
+    async function initialise() {
+      const palette = await loadPalette("./data/palette.json");
+      const usingFallback = !palette;
+      const activePalette = usingFallback ? FALLBACK.palette : palette;
+      const notice = usingFallback ? "Palette missing; using calm fallback colours." : "";
+
+      const result = renderHelix(ctx, {
+        width: canvas.width,
+        height: canvas.height,
+        palette: activePalette,
+        NUM,
+        notice
+      });
+
+      if (!result.ok) {
+        statusEl.textContent = "Renderer could not initialise (" + result.reason + ").";
+        return;
+      }
+
+      statusEl.textContent = usingFallback ? "Palette missing; safe fallback applied." : "Palette loaded.";
     }
 
     async function loadPalette(path) {
       try {
         const response = await fetch(path, { cache: "no-store" });
-        if (!response.ok) return null;
+        if (!response.ok) {
+          throw new Error(String(response.status));
+        }
         return await response.json();
       } catch (error) {
         return null;
       }
-    }
-
-    const paletteData = await loadPalette("./data/palette.json");
-    const palette = paletteData && Array.isArray(paletteData.layers) ? paletteData : null;
-    const activePalette = palette || FALLBACK_PALETTE;
-
-    applyPaletteColors(activePalette);
-
-    const statusMessage = palette ? "Palette loaded." : "Palette missing; using safe fallback palette.";
-    function isPaletteComplete(palette) {
-      return Boolean(
-        palette &&
-        Array.isArray(palette.layers) &&
-        palette.layers.length >= 6 &&
-        palette.bg &&
-        palette.ink
-      );
-    }
-
-    const paletteData = await loadPalette("./data/palette.json");
-    const paletteReady = isPaletteComplete(paletteData);
-    const activePalette = paletteReady ? paletteData : defaults.palette;
-
-    applyChrome(activePalette);
-
-    const paletteMessage = paletteReady
-      ? "Palette loaded."
-      : "Palette missing or blocked; safe fallback applied.";
-
-    if (!ctx) {
-      statusEl.textContent = statusMessage + " Canvas context unavailable; please try a modern browser.";
-    } else {
-      statusEl.textContent = statusMessage + " Geometry rendered.";
-
->>>>>>>+upstream/codex/
-const NUM = {
-        THREE: 3,
-        SEVEN: 7,
-        NINE: 9,
-        ELEVEN: 11,
-        TWENTYTWO: 22,
-        THIRTYTHREE: 33,
-        NINETYNINE: 99,
-        ONEFORTYFOUR: 144
-      };
-
-<<<<<<      const notice = paletteData ? null : "Palette missing; safe fallback applied.";
->>>>>>>+main
-=
-            // ND-safe rationale: render once with layered calm colours; show notice if palette is missing.
->>>>>>>+upstream/codex/
-renderHelix(ctx, {
-      const notice = paletteReady ? null : "Palette unavailable; using safe fallback.";
-      const result = renderHelix(ctx, {
-        width: canvas.width,
-        height: canvas.height,
-        palette: activePalette,
-        NUM,
-<<<<<<        notice
-      renderHelix(ctx, {
-        width: canvas.width,
-        height: canvas.height,
-        palette,
-        NUM,
-        notice: usingFallback ? "Fallback palette active." : ""
->>>>>>>+main
-=
-              notice: palette ? null : "Palette data missing; fallback colours applied."
->>>>>>>+upstream/codex/
-});
-    }
-      // ND-safe rationale: render once, preserve layer order, no motion.
-      const result = renderHelix(ctx, {
-        width: canvas.width,
-        height: canvas.height,
-        palette: activePalette,
-        NUM,
-        notice
-      });
-
-      statusEl.textContent = result.ok
-        ? statusPrefix + " Geometry rendered."
-        : "Rendering skipped: " + result.reason;
-    })();
-        notice
-      });
-
-      statusEl.textContent = result.ok
-        ? paletteMessage + " Geometry rendered."
-        : paletteMessage + " Render skipped: " + (result.reason || "unknown");
     }
   </script>
 </body>

--- a/cosmic-helix/js/helix-renderer.mjs
+++ b/cosmic-helix/js/helix-renderer.mjs
@@ -2,275 +2,101 @@
   helix-renderer.mjs
   ND-safe static renderer for layered sacred geometry.
 
-  Layers:
-    1) Vesica field (intersecting circle lattice)
-    2) Tree-of-Life scaffold (ten sephirot with twenty-two paths)
-    3) Fibonacci curve (golden spiral polyline)
-    4) Double-helix lattice (two still sine strands with cross ties)
+  Layers (rendered back to front):
+    1) Vesica field - intersecting circle lattice for the womb-of-forms motif.
+    2) Tree-of-Life scaffold - ten sephirot joined by twenty-two calm paths.
+    3) Fibonacci curve - logarithmic spiral polyline with golden-ratio pacing.
+    4) Double-helix lattice - two still strands with gentle cross ties.
 
   Rationale:
-    - No animation or flashing; the scene renders a single time on load.
-    - Muted palette and transparent strokes keep contrast gentle (trauma-informed).
-    - Numerology constants 3, 7, 9, 11, 22, 33, 99, and 144 guide spacing and counts.
+    - No animation: everything draws once on load to respect ND-safe pacing.
+    - Calm palette: soft contrast keeps lines readable without sensory spikes.
+    - Numerology constants (3, 7, 9, 11, 22, 33, 99, 144) guide proportions.
 */
 
-export function renderHelix(ctx, opts) {
-  if (!ctx || !opts) {
+const DEFAULT_NUM = {
+  THREE: 3,
+  SEVEN: 7,
+  NINE: 9,
+  ELEVEN: 11,
+  TWENTYTWO: 22,
+  THIRTYTHREE: 33,
+  NINETYNINE: 99,
+  ONEFORTYFOUR: 144
+};
+
+const DEFAULT_PALETTE = {
+  bg: "#0b0b12",
+  ink: "#e8e8f0",
+  muted: "#a6a6c1",
+  layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
+};
+
+export function renderHelix(ctx, options = {}) {
+  if (!ctx || typeof ctx.canvas === "undefined") {
     return { ok: false, reason: "missing-context" };
   }
-  Layers draw once in a stable order to honour the no-motion requirement.
-  Numerology constants (3, 7, 9, 11, 22, 33, 99, 144) guide proportions.
-*/
 
-export function renderHelix(ctx, options) {
-  if (!ctx || typeof ctx.moveTo !== "function") {
-    return { ok: false, reason: "no-context" };
-  }
+  const width = toNumber(options.width, ctx.canvas.width);
+  const height = toNumber(options.height, ctx.canvas.height);
 
-  const config = options || {};
-  const width = Number(config.width) || ctx.canvas.width;
-  const height = Number(config.height) || ctx.canvas.height;
-  const palette = config.palette || {};
-  const NUM = config.NUM || {};
-  const notice = typeof config.notice === "string" ? config.notice : "";
-
-  const defaults = normalizeConstants();
-  const { width, height } = opts;
-  const N = normalizeConstants(opts.NUM);
-  const palette = normalizePalette(opts.palette);
-  const layers = Array.isArray(palette.layers) ? palette.layers : [];
-  const fallbackLayers = ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"];
-  const ink = palette.ink || "#e8e8f0";
-
-  if (typeof width !== "number" || typeof height !== "number") {
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
     return { ok: false, reason: "invalid-dimensions" };
   }
 
-  const pickLayer = (index) => layers[index] || fallbackLayers[index] || ink;
-  const fallbackInk = palette.ink || "#e8e8f0";
-  const layerColor = (index) => layers[index] || fallbackLayers[index] || fallbackInk;
-  Layers (rendered back-to-front):
-    1) Vesica field (intersecting circle lattice)
-    2) Tree-of-Life scaffold (ten sephirot with twenty-two paths)
-    3) Fibonacci curve (golden spiral polyline)
-    4) Double-helix lattice (two calm strands with cross ties)
-
-  Rationale:
-    - No motion; every layer renders once to respect ND-safe pacing.
-    - Soft contrast palette keeps geometry readable without harsh edges.
-    - Numerology constants 3, 7, 9, 11, 22, 33, 99, 144 steer proportions.
-*/
-
-export function renderHelix(ctx, options = {}) {
-  if (!ctx) {
-    return { ok: false, reason: "missing-context" };
-  }
-
-  const width = options.width || ctx.canvas.width;
-  const height = options.height || ctx.canvas.height;
   const palette = normalisePalette(options.palette);
-  const N = normaliseNumerology(options.NUM);
+  const numerology = normaliseNumerology(options.NUM);
+  const notice = typeof options.notice === "string" ? options.notice.trim() : "";
 
   ctx.save();
-  ctx.fillStyle = palette.bg;
-  ctx.fillRect(0, 0, width, height);
+  fillBackground(ctx, width, height, palette.bg);
 
-  drawVesicaField(ctx, width, height, pickLayer(0), N);
-  drawTreeOfLife(ctx, width, height, pickLayer(1), pickLayer(2), N);
-  drawFibonacci(ctx, width, height, pickLayer(3), N);
-  drawHelix(ctx, width, height, pickLayer(4), pickLayer(5), N);
-  Layers (rendered back to front):
-    1) Vesica field - intersecting circle lenses keep the womb-of-forms visible.
-    2) Tree-of-Life scaffold - ten sephirot joined by twenty-two calm paths.
-    3) Fibonacci curve - logarithmic spiral polyline tuned to gentle growth.
-    4) Double-helix lattice - two static strands with soft cross ties.
-
-  ND-safe rationale:
-    - No motion or flashing; everything draws once per load.
-    - Muted palette keeps contrast gentle for neurodivergent viewers.
-    - Numerology constants (3, 7, 9, 11, 22, 33, 99, 144) steer proportions.
-*/
-
-const FALLBACK_LAYERS = ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"];
-
-export function renderHelix(ctx, opts) {
-  if (!ctx) {
-    return { ok: false, reason: "missing-context" };
-  }
-
-  const { width, height, palette, NUM: N, notice } = opts;
-  const cleaned = normalisePalette(palette);
-
-  ctx.save();
-  ctx.fillStyle = cleaned.bg;
-
-  const width = options.width || ctx.canvas.width;
-  const height = options.height || ctx.canvas.height;
-  const palette = normalisePalette(options.palette);
-  const N = normaliseNumerology(options.NUM);
-
-  ctx.save();
-  ctx.fillStyle = palette.bg;
-  ctx.fillRect(0, 0, width, height);
-
-  // Layer order from background to foreground keeps depth legible without motion.
-  drawVesicaField(ctx, width, height, cleaned.layers[0], N);
-  drawTreeOfLife(ctx, width, height, cleaned.layers[1], cleaned.layers[2], N);
-  drawFibonacci(ctx, width, height, cleaned.layers[3], N);
-  drawHelix(ctx, width, height, cleaned.layers[4], cleaned.layers[5], N);
-
-  if (opts.notice) {
-    ctx.save();
-    ctx.font = "14px system-ui, -apple-system, Segoe UI, sans-serif";
-    ctx.fillStyle = ink;
-    ctx.globalAlpha = 0.75;
-    ctx.fillText(opts.notice, 24, height - 24);
-    ctx.restore();
-  }
-
-  return { ok: true, constants: N, defaults };
-}
-
-function drawVesicaField(ctx, w, h, color, N) {
-  Layers render once in calm order to honour trauma-informed design.
-*/
-
-const FALLBACK_LAYERS = ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"];
-
-export function renderHelix(ctx, options) {
-  if (!ctx) {
-    return { ok: false, reason: "missing-context" };
-  }
-
-  const width = options.width;
-  const height = options.height;
-  const palette = ensurePalette(options.palette);
-  const N = options.NUM;
-  const notice = options.notice;
-
-  ctx.save();
-  clearCanvas(ctx, width, height, palette.background);
-
-  // Layer order moves from foundation to foreground without motion.
-  drawVesicaField(ctx, width, height, palette.layer(0), N);
-  drawTreeOfLife(ctx, width, height, palette.layer(1), palette.layer(2), N);
-  drawFibonacciSpiral(ctx, width, height, palette.layer(3), N);
-  drawDoubleHelix(ctx, width, height, palette.layer(4), palette.layer(5), N);
+  drawVesicaField(ctx, width, height, palette.layers[0], numerology);
+  drawTreeOfLife(ctx, width, height, palette.layers[1], palette.layers[2], numerology, palette.ink);
+  drawFibonacciCurve(ctx, width, height, palette.layers[3], numerology);
+  drawHelixLattice(ctx, width, height, palette.layers[4], palette.layers[5], numerology);
 
   if (notice) {
-    drawNotice(ctx, width, height, notice, palette.ink);
-  }
-
-  drawVesicaField(ctx, width, height, layerColor(0), NUM);
-  drawTreeOfLife(ctx, width, height, layerColor(1), layerColor(2), NUM);
-  drawFibonacci(ctx, width, height, layerColor(3), NUM);
-  drawHelix(ctx, width, height, layerColor(4), layerColor(5), NUM);
-  drawNotice(ctx, width, height, notice, fallbackInk);
-  Static, ND-safe renderer for layered sacred geometry bound to Codex 144:99 (c99).
-  Everything renders once on load; no motion, no autoplay, no external state.
-
-  Layer order (background to foreground):
-    1) Vesica field — intersecting circles with numerology spacing for calm depth.
-    2) Tree-of-Life scaffold — ten sephirot linked by twenty-two paths.
-    3) Fibonacci curve — golden spiral polyline sampled across 144 points.
-    4) Double-helix lattice — two static strands with gentle cross ties.
-*/
-
-export function renderHelix(ctx, options) {
-  if (!ctx) return { ok: false, reason: "missing-context" };
-
-  const { width, height, palette, NUM, notice } = options;
-  const safePalette = normalisePalette(palette);
-
-  ctx.save();
-  fillBackground(ctx, width, height, safePalette.bg);
-
-  // Layered order preserves depth without animation; comments explain why for future caretakers.
-  drawVesicaField(ctx, width, height, safePalette.layers[0], NUM);
-  drawTreeOfLife(ctx, width, height, safePalette.layers[1], safePalette.layers[2], NUM);
-  drawFibonacciCurve(ctx, width, height, safePalette.layers[3], NUM);
-  drawHelixLattice(ctx, width, height, safePalette.layers[4], safePalette.layers[5], NUM);
-
-  if (notice) drawNotice(ctx, width, height, safePalette.ink, notice);
-  // Layer order from base to foreground keeps depth legible without animation.
-  drawVesicaField(ctx, width, height, palette.layers[0], N);
-  drawTreeOfLife(ctx, width, height, palette.layers[1], palette.layers[2], N);
-  drawFibonacci(ctx, width, height, palette.layers[3], N);
-  drawHelix(ctx, width, height, palette.layers[4], palette.layers[5], palette.ink, N);
-
-  if (options.notice) {
-    ctx.save();
-    ctx.font = "14px system-ui, -apple-system, Segoe UI, sans-serif";
-    ctx.fillStyle = palette.ink;
-    ctx.globalAlpha = 0.8;
-    ctx.fillText(options.notice, 24, height - 24);
-    ctx.restore();
+    drawNotice(ctx, width, height, palette.ink, notice, numerology);
   }
 
   ctx.restore();
-  return { ok: true };
+  return { ok: true, palette, numerology };
 }
 
-function normalisePalette(raw = {}) {
-  const fallback = {
-    bg: "#0b0b12",
-    ink: "#e8e8f0",
-    layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-  };
-
-  const layers = Array.isArray(raw.layers) ? raw.layers : [];
-
-  return {
-    bg: raw.bg || fallback.bg,
-    ink: raw.ink || fallback.ink,
-    layers: fallback.layers.map((color, index) => layers[index] || color)
-  };
+function toNumber(value, fallback) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
 }
 
-function normaliseNumerology(raw = {}) {
-  const defaults = {
-    THREE: 3,
-    SEVEN: 7,
-    NINE: 9,
-    ELEVEN: 11,
-    TWENTYTWO: 22,
-    THIRTYTHREE: 33,
-    NINETYNINE: 99,
-    ONEFORTYFOUR: 144
-  };
-
-  return {
-    THREE: raw.THREE || defaults.THREE,
-    SEVEN: raw.SEVEN || defaults.SEVEN,
-    NINE: raw.NINE || defaults.NINE,
-    ELEVEN: raw.ELEVEN || defaults.ELEVEN,
-    TWENTYTWO: raw.TWENTYTWO || defaults.TWENTYTWO,
-    THIRTYTHREE: raw.THIRTYTHREE || defaults.THIRTYTHREE,
-    NINETYNINE: raw.NINETYNINE || defaults.NINETYNINE,
-    ONEFORTYFOUR: raw.ONEFORTYFOUR || defaults.ONEFORTYFOUR
-  };
-}
-
-function normalisePalette(palette) {
-  const fallback = {
-    bg: "#0b0b12",
-    ink: "#e8e8f0",
-    muted: "#a6a6c1",
-    layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-  };
-
-  const source = palette || {};
-  const safeLayers = fallback.layers.map((color, index) => {
-    if (source.layers && source.layers[index]) return source.layers[index];
-    return color;
+function normalisePalette(input) {
+  const source = input && typeof input === "object" ? input : {};
+  const candidateLayers = Array.isArray(source.layers) ? source.layers : [];
+  const layers = DEFAULT_PALETTE.layers.map((color, index) => {
+    const candidate = candidateLayers[index];
+    return typeof candidate === "string" && candidate.trim() ? candidate : color;
   });
 
   return {
-    bg: source.bg || fallback.bg,
-    ink: source.ink || fallback.ink,
-    muted: source.muted || fallback.muted,
-    layers: safeLayers
+    bg: pickColor(source.bg, DEFAULT_PALETTE.bg),
+    ink: pickColor(source.ink, DEFAULT_PALETTE.ink),
+    muted: pickColor(source.muted, DEFAULT_PALETTE.muted),
+    layers
   };
+}
+
+function pickColor(candidate, fallback) {
+  return typeof candidate === "string" && candidate.trim() ? candidate : fallback;
+}
+
+function normaliseNumerology(source) {
+  const data = source && typeof source === "object" ? source : {};
+  const result = {};
+  for (const key of Object.keys(DEFAULT_NUM)) {
+    const value = Number(data[key]);
+    result[key] = Number.isFinite(value) ? value : DEFAULT_NUM[key];
+  }
+  return result;
 }
 
 function fillBackground(ctx, width, height, color) {
@@ -280,1170 +106,265 @@ function fillBackground(ctx, width, height, color) {
   ctx.restore();
 }
 
-function ensurePalette(palette) {
-  const base = palette || {};
-  const layers = Array.isArray(base.layers) ? base.layers : [];
-  return {
-    background: base.bg || "#0b0b12",
-    ink: base.ink || "#e8e8f0",
-    layer(index) {
-      return layers[index] || FALLBACK_LAYERS[index] || "#ffffff";
-    }
-  };
-}
-
-function clearCanvas(ctx, width, height, color) {
-  ctx.save();
-  ctx.fillStyle = color;
-  ctx.fillRect(0, 0, width, height);
-  ctx.restore();
-}
-
-// Layer 1: Vesica field — overlapping circles evoke a womb of forms without motion.
-// Layer 1: Vesica field — calm lattice built from overlapping circles.
 function drawVesicaField(ctx, width, height, color, N) {
+  const columns = Math.max(3, Math.round(N.NINE));
+  const rows = Math.max(3, Math.round(N.SEVEN));
+  const xGap = width / (columns + 1);
+  const yGap = height / (rows + 1);
+  const radius = Math.min(xGap, yGap) * 0.66;
+  const lineWidth = Math.max(1, radius / (N.THIRTYTHREE || DEFAULT_NUM.THIRTYTHREE));
+
   ctx.save();
   ctx.strokeStyle = color;
-  ctx.lineWidth = 1;
+  ctx.lineWidth = lineWidth;
   ctx.globalAlpha = 0.35;
-=====
-      ctx.fillStyle = cleaned.notice;
-    ctx.textBaseline = "bottom";
-    ctx.fillText(notice, 24, height - 24);
-    ctx.restore();
-  }
-
-  return { ok: true };
-}
-
-function normalisePalette(palette) {
-  const input = palette || {};
-  const layers = Array.isArray(input.layers) ? input.layers : [];
-  return {
-    bg: input.bg || "#0b0b12",
-    notice: input.ink || "#e8e8f0",
-    layers: FALLBACK_LAYERS.map((fallbackColor, index) => layers[index] || fallbackColor)
-  };
-}
-
-// Layer 1: Vesica field builds a calm lens grid using 3/7/9/11 counts.
-
-  ctx.restore();
-  return { ok: true };
-}
-
-function normalisePalette(raw = {}) {
-  const fallback = {
-    bg: "#0b0b12",
-    ink: "#e8e8f0",
-    layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-  };
-
-  const layers = Array.isArray(raw.layers) ? raw.layers : [];
-
-  return {
-    bg: raw.bg || fallback.bg,
-    ink: raw.ink || fallback.ink,
-    layers: fallback.layers.map((color, index) => layers[index] || color)
-  };
-}
-
-function normaliseNumerology(raw = {}) {
-  const defaults = {
-    THREE: 3,
-    SEVEN: 7,
-    NINE: 9,
-    ELEVEN: 11,
-    TWENTYTWO: 22,
-    THIRTYTHREE: 33,
-    NINETYNINE: 99,
-    ONEFORTYFOUR: 144
-  };
-
-  return {
-    THREE: raw.THREE || defaults.THREE,
-    SEVEN: raw.SEVEN || defaults.SEVEN,
-    NINE: raw.NINE || defaults.NINE,
-    ELEVEN: raw.ELEVEN || defaults.ELEVEN,
-    TWENTYTWO: raw.TWENTYTWO || defaults.TWENTYTWO,
-    THIRTYTHREE: raw.THIRTYTHREE || defaults.THIRTYTHREE,
-    NINETYNINE: raw.NINETYNINE || defaults.NINETYNINE,
-    ONEFORTYFOUR: raw.ONEFORTYFOUR || defaults.ONEFORTYFOUR
-  };
-}
-
-// Layer 1: Vesica field builds a calm lattice using numerology counts.
-function drawVesicaField(ctx, w, h, color, N) {
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 1;
-  ctx.globalAlpha = 0.35; // gentle transparency keeps the grid quiet.
->>>>>>>+upstream/codex/
- const columns = N.ELEVEN;
-  const rows = N.NINE;
-  const spacingX = w / (columns + 2);
-  const spacingY = h / (rows + 2);
-<<  const radius = Math.min(spacingX, spacingY) * (N.SEVEN / N.TWENTYTWO);
-  const offset = radius / N.THREE;
+  // Gentle alpha keeps overlapping vesica forms soft for ND-safe viewing.
 
   for (let row = 0; row < rows; row += 1) {
-    const cy = spacingY * (row + 1.5);
-    const rowShift = (row % 2 === 0) ? 0 : spacingX / N.ELEVEN;
-
+    const cy = yGap + row * yGap;
     for (let col = 0; col < columns; col += 1) {
-      const cx = spacingX * (col + 1.5) + rowShift;
-      strokeCircle(ctx, cx - offset, cy, radius);
-      strokeCircle(ctx, cx + offset, cy, radius);
-
-      if (row < rows - 1 && col % 2 === 0) {
-        const nextCy = spacingY * (row + 2.5);
-        const midY = (cy + nextCy) / 2;
-        strokeCircle(ctx, cx, midY, radius * (N.SEVEN / N.NINE));
-  ctx.lineCap = "round";
-
-  const columns = N.ELEVEN; // Eleven pillars weave 3/7/11 numerology.
-  const rows = N.NINE;
-  const stepX = width / (columns + 1);
-  const stepY = height / (rows + 1);
-  const radius = Math.min(stepX, stepY) / 1.8;
-  const horizontalOffset = radius / N.THREE;
-  const verticalOffset = stepY / N.SEVEN;
-
-  for (let row = 0; row < rows; row += 1) {
-    const cy = stepY * (row + 1);
-    for (let col = 0; col < columns; col += 1) {
-      const cx = stepX * (col + 1);
-      strokeCircle(ctx, cx - horizontalOffset, cy, radius);
-      strokeCircle(ctx, cx + horizontalOffset, cy, radius);
-
-      if (row < rows - 1) {
-        const lensY = cy + verticalOffset;
-        strokeCircle(ctx, cx, lensY, radius);
-/* Layer 1 — Vesica field. Calm overlapping circles form a lens grid without motion. */
-function drawVesicaField(ctx, w, h, color, N) {
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 1;
-  ctx.globalAlpha = 0.35; // Soft opacity keeps the background from overpowering other layers.
-
-  const rows = clampPositive(N.NINE, 9);
-  const columns = clampPositive(N.ELEVEN, 11);
-  const marginX = w / clampPositive(N.TWENTYTWO, 22);
-  const marginY = h / clampPositive(N.THIRTYTHREE, 33);
-  const usableW = w - marginX * 2;
-  const usableH = h - marginY * 2;
-  const spacingX = usableW / Math.max(columns - 1, 1);
-  const spacingY = usableH / Math.max(rows - 1, 1);
-  const baseRadius = Math.min(spacingX, spacingY) / (clampPositive(N.THREE, 3) / 1.5);
-  const offset = baseRadius * (clampPositive(N.THREE, 3) / clampPositive(N.SEVEN, 7));
-
-  for (let row = 0; row < rows; row += 1) {
-    const cy = marginY + spacingY * row;
-    for (let col = 0; col < columns; col += 1) {
-      const cx = marginX + spacingX * col;
-      strokeCircle(ctx, cx - offset, cy, baseRadius);
-      strokeCircle(ctx, cx + offset, cy, baseRadius);
-
-      if (row < rows - 1 && col % 2 === 0) {
-        const nextCy = marginY + spacingY * (row + 1);
-// Layer 1: Vesica field builds a calm lattice using numerology counts.
-function drawVesicaField(ctx, w, h, color, N) {
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 1;
-  ctx.globalAlpha = 0.35; // ND-safe: softened grid to avoid visual overload.
-
-  const columns = Math.max(3, N.ELEVEN);
-  const rows = Math.max(3, N.NINE);
-  const marginX = w / N.THIRTYTHREE;
-  const marginY = h / N.THIRTYTHREE;
-  const gridWidth = w - marginX * 2;
-  const gridHeight = h - marginY * 2;
-  const spacingX = gridWidth / (columns - 1);
-  const spacingY = gridHeight / (rows - 1);
-  const radius = Math.min(spacingX, spacingY) * (N.THIRTYTHREE / (N.NINETYNINE / 2));
-  const offset = radius / N.THREE;
-
-  for (let row = 0; row < rows; row += 1) {
-    const cy = marginY + row * spacingY;
-    for (let col = 0; col < columns; col += 1) {
-      const cx = marginX + col * spacingX;
-      strokeCircle(ctx, cx - offset, cy, radius);
-      strokeCircle(ctx, cx + offset, cy, radius);
-
-      if (row < rows - 1) {
-        const nextCy = marginY + (row + 1) * spacingY;
-        const lensCy = (cy + nextCy) / 2;
-        strokeCircle(ctx, cx, lensCy, baseRadius);
->>>>>>>+main
-===
-  co  const baseRadius = Math.min(spacingX, spacingY) / (N.THREE / 2);
-  const offset = baseRadius / N.THREE;
-
-  for (let row = 0; row < rows; row += 1) {
-    const cy = spacingY * (row + 1.5);
-    for (let col = 0; col < columns; col += 1) {
-      const cx = spacingX * (col + 1.5);
-      strokeCircle(ctx, cx - offset, cy, baseRadius);
-      strokeCircle(ctx, cx + offset, cy, baseRadius);
-
-      if ((row + col) % N.THREE === 0 && row < rows - 1) {
-        const nextCy = spacingY * (row + 2.5);
-        strokeCircle(ctx, cx, (cy + nextCy) / 2, baseRadius * (N.SEVEN / N.NINE));
->>>>>>>+upstream/codex/
-  }
-  ctx.globalAlpha = 0.35; // Soft transparency keeps the grid gentle for ND-safe viewing.
-
-  const columns = N.ELEVEN; // 11 columns honour the sephirotic pillars.
-  const rows = N.NINE; // 9 rows echo the spiral layer.
-  const paddingX = width / N.THIRTYTHREE;
-  const paddingY = height / N.TWENTYTWO;
-  const spanX = width - paddingX * 2;
-  const spanY = height - paddingY * 2;
-  const spacingX = spanX / (columns - 1);
-  const spacingY = spanY / (rows - 1);
-  const radius = Math.min(spacingX, spacingY) / (1 + 1 / N.THREE);
-  const offset = radius / N.THREE; // 3 divides the vesica lens.
-
-  for (let row = 0; row < rows; row += 1) {
-    for (let col = 0; col < columns; col += 1) {
-      const cx = paddingX + col * spacingX;
-      const cy = paddingY + row * spacingY;
-      strokeCircle(ctx, cx - offset, cy, radius);
-      strokeCircle(ctx, cx + offset, cy, radius);
-
-      // Every third row adds a vertical lens to deepen the geometry without motion.
-      if (row < rows - 1 && col % N.THREE === 0) {
-        const nextCy = paddingY + (row + 1) * spacingY;
-        const midCy = (cy + nextCy) / 2;
-        strokeCircle(ctx, cx, midCy, radius);
-      }
+      const cx = xGap + col * xGap;
+      strokeCircle(ctx, cx, cy, radius);
+      strokeCircle(ctx, cx + xGap / 2, cy, radius);
+      strokeCircle(ctx, cx, cy + yGap / 2, radius);
     }
   }
 
   ctx.restore();
 }
 
-<<<<function drawTreeOfLife(ctx, w, h, pathColor, nodeColor, N) {
-// Layer 2: Tree-of-Life — ten sephirot with twenty-two gentle paths.
-function drawTreeOfLife(ctx, width, height, pathColor, nodeColor, N) {
-/* Layer 2 — Tree-of-Life. Thin paths and calm nodes respect ND-safe contrast. */
-function drawTreeOfLife(ctx, w, h, pathColor, nodeColor, N) {
-  const nodes = createTreeNodes(w, h);
-  const paths = createTreePaths();
-  const strokeWidth = clampPositive(N.TWENTYTWO, 22) / clampPositive(N.ELEVEN, 11);
-  const nodeRadius = Math.min(w, h) / (clampPositive(N.THIRTYTHREE, 33) * 2);
+function strokeCircle(ctx, cx, cy, radius) {
+  ctx.beginPath();
+  ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+  ctx.stroke();
+}
+
+function drawTreeOfLife(ctx, width, height, pathColor, nodeColor, N, ink) {
+  const topMargin = height / (N.ELEVEN || DEFAULT_NUM.ELEVEN);
+  const usableHeight = height - topMargin * 2;
+  const levelGap = usableHeight / (N.NINE || DEFAULT_NUM.NINE);
+  const centerX = width / 2;
+  const columnSpread = width / (N.THREE + N.SEVEN / 10);
+  const nodeRadius = Math.max(4, Math.min(width, height) / (N.NINETYNINE || DEFAULT_NUM.NINETYNINE));
+
+  const layout = [
+    { level: 0, shift: 0 },
+    { level: 1, shift: 1 },
+    { level: 1, shift: -1 },
+    { level: 3, shift: 0.9 },
+    { level: 3, shift: -0.9 },
+    { level: 4.5, shift: 0 },
+    { level: 6, shift: 0.85 },
+    { level: 6, shift: -0.85 },
+    { level: 7.4, shift: 0 },
+    { level: 9, shift: 0 }
+  ];
+
+  const nodes = layout.map((item) => ({
+    x: centerX + item.shift * columnSpread,
+    y: topMargin + item.level * levelGap
+  }));
+
+  const paths = [
+    [0, 1], [0, 2], [0, 5], [1, 2], [1, 5], [1, 3], [2, 5], [2, 4], [3, 4], [3, 5], [3, 6],
+    [4, 5], [4, 7], [5, 6], [5, 7], [6, 7], [6, 8], [7, 8], [5, 8], [8, 9], [6, 9], [7, 9]
+  ];
 
   ctx.save();
+  ctx.strokeStyle = pathColor;
+  ctx.lineWidth = Math.max(1, nodeRadius / (N.TWENTYTWO || DEFAULT_NUM.TWENTYTWO));
   ctx.globalAlpha = 0.6;
-  ctx.strokeStyle = pathColor;
-  ctx.lineWidth = Math.max(1, N.TWENTYTWO / N.ELEVEN); // 22 paths softened by pillar 11.
->>>>>>>+main
-// Layer// Layer 2: Tree-of-Life nodes and paths; gentle strokes avoid harsh edges.
-function drawTreeOfLife(ctx, w, h, pathColor, nodeColor, N) {
-  ctx.save();
-  ctx.strokeStyle = pathColor;
-  ctx.lineWidth = N.TWENTYTWO / N.ELEVEN; // equals 2 for soft yet readable lines.
->>>>>>>+upstream/codex/
-neCap = "round";
-  ctx.globalAlpha = 0.85;
+  // Calm line weight highlights twenty-two paths without overpowering the nodes.
 
-  const nodes = getTreeNodes(w, h, N);
-  const paths = getTreePaths();
-
-  paths.forEach(([a, b]) => {
-  ctx.lineJoin = "round";
-
-  const nodes = getTreeNodes(width, height);
-  const paths = getTreePaths();
-
-  paths.forEach(pair => {
-    const a = nodes[pair[0]];
-    const b = nodes[pair[1]];
-    if (!a || !b) return;
+  for (const [fromIndex, toIndex] of paths) {
+    const from = nodes[fromIndex];
+    const to = nodes[toIndex];
     ctx.beginPath();
-    ctx.moveTo(a.x, a.y);
-    ctx.lineTo(b.x, b.y);
-// Layer 2: Tree-of-Life — slim paths and calm nodes keep focus without harsh edges.
-function drawTreeOfLife(ctx, width, height, pathColor, nodeColor, N) {
-  ctx.save();
-  ctx.strokeStyle = pathColor;
-// Layer 2: Tree-of-Life scaffold — thin lines and soft nodes.
-function drawTreeOfLife(ctx, w, h, pathColor, nodeColor, N) {
-  ctx.save();
-  ctx.strokeStyle = pathColor;
-// Layer 2: Tree-of-Life scaffold — thin lines and soft nodes.
-function drawTreeOfLife(ctx, w, h, pathColor, nodeColor, N) {
-  ctx.save();
-  ctx.strokeStyle = pathColor;
-  ctx.lineWidth = N.TWENTYTWO / N.ELEVEN; // 22 paths softened by pillar 11.
-  ctx.lineCap = "round";
-  ctx.lineJoin = "round";
-
-  const nodes = getTreeNodes(width, height);
-  const paths = getTreePaths();
-
-  paths.forEach(([a, b]) => {
-    const start = nodes[a];
-    const end = nodes[b];
-    ctx.beginPath();
-    ctx.moveTo(start.x, start.y);
-    ctx.lineTo(end.x, end.y);
-  paths.forEach(([from, to]) => {
-    const a = nodes[from];
-    const b = nodes[to];
-    ctx.beginPath();
-    ctx.moveTo(a.x, a.y);
-    ctx.lineTo(b.x, b.y);
+    ctx.moveTo(from.x, from.y);
+    ctx.lineTo(to.x, to.y);
     ctx.stroke();
-  });
+  }
 
   ctx.globalAlpha = 0.9;
+  // Nodes stay opaque to anchor focus while paths remain translucent.
   ctx.fillStyle = nodeColor;
-<<<<<<<   const nodeRadius = (Math.min(w, h) / N.ONEFORTYFOUR) * (N.SEVEN / N.ELEVEN);
+  ctx.strokeStyle = ink;
+  ctx.lineWidth = Math.max(1, nodeRadius / (N.THIRTYTHREE || DEFAULT_NUM.THIRTYTHREE));
 
-  nodes.forEach((node) => {
-  ctx.strokeStyle = nodeColor;
-  const nodeRadius = Math.min(width, height) / N.NINETYNINE;
-
-  nodes.forEach(node => {
-    strokeCircle(ctx, node.x, node.y, nodeRadius);
->>>>>>>+main
-  const   const nodeRadius = N.NINE / 3;
-  nodes.forEach((node) => {
->>>>>>>+upstream/codex/
-beginPath();
-    ctx.arc(node.x, node.y, nodeRadius * 0.6, 0, Math.PI * 2);
-  ctx.globalAlpha = 0.95;
-  const nodeRadius = Math.min(width, height) / (N.THIRTYTHREE + N.NINE); // 33+9 = 42 keeps discs modest.
-  const nodeRadius = Math.max(3, Math.min(w, h) / N.NINETYNINE * (N.NINE / N.TWENTYTWO));
-
-  nodes.forEach(node => {
+  for (const node of nodes) {
     ctx.beginPath();
     ctx.arc(node.x, node.y, nodeRadius, 0, Math.PI * 2);
     ctx.fill();
-  ctx.lineWidth = strokeWidth;
-  ctx.globalAlpha = 0.8;
-  paths.forEach(([a, b]) => {
-    const start = nodes[a];
-    const end = nodes[b];
-    if (!start || !end) return;
-    ctx.beginPath();
-    ctx.moveTo(start.x, start.y);
-    ctx.lineTo(end.x, end.y);
     ctx.stroke();
-  });
-  ctx.globalAlpha = 1;
-  ctx.fillStyle = nodeColor;
-  nodes.forEach((node) => {
-    strokeCircle(ctx, node.x, node.y, nodeRadius, true);
-  });
-
-  ctx.restore();
-}
-
-<<<<<<< codex/add-canonical-alias-validation-check
-function drawFibonacci(ctx, w, h, color, N) {
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = N.THREE / N.THIRTYTHREE;
-
-  ctx.restore();
-}
-
-// Layer 3: Fibonacci spiral — golden curve drawn once for calm movement suggestion.
-function drawFibonacciSpiral(ctx, width, height, color, N) {
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = N.THREE / 2; // Equals 1.5px, subtle yet visible.
-  ctx.globalAlpha = 0.8;
-  ctx.lineCap = "round";
-  ctx.lineJoin = "round";
-  ctx.globalAlpha = 0.85;
-
-  const steps = N.ONEFORTYFOUR;
-  const quarterTurns = N.SEVEN;
-  const totalAngle = quarterTurns * (Math.PI / 2);
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const radiusBase = Math.min(w, h) / (N.THREE + N.SEVEN / N.NINE);
-  const centerX = w / 2;
-  const centerY = h / 2;
->>>>>>>+main
- ctx.res
-  ctx.restore();
-}
-
-function getTreeNodes(w, h) {
-  const verticalOffset = h * 0.05;
-  return [
-    { x: w / 2, y: verticalOffset + h * 0.00 },
-    { x: w * 0.28, y: verticalOffset + h * 0.12 },
-    { x: w * 0.72, y: verticalOffset + h * 0.12 },
-    { x: w * 0.28, y: verticalOffset + h * 0.32 },
-    { x: w * 0.72, y: verticalOffset + h * 0.32 },
-    { x: w / 2, y: verticalOffset + h * 0.44 },
-    { x: w * 0.28, y: verticalOffset + h * 0.64 },
-    { x: w * 0.72, y: verticalOffset + h * 0.64 },
-    { x: w / 2, y: verticalOffset + h * 0.76 },
-    { x: w / 2, y: verticalOffset + h * 0.92 }
-function getTreeNodes(width, height) {
-  // Ratios preserve the classic sephirotic arrangement while scaling to the canvas.
-  const anchors = [
-    { x: 0.5, y: 0.06 },  // Kether
-    { x: 0.28, y: 0.16 }, // Chokmah
-    { x: 0.72, y: 0.16 }, // Binah
-    { x: 0.28, y: 0.36 }, // Chesed
-    { x: 0.72, y: 0.36 }, // Geburah
-    { x: 0.5, y: 0.48 },  // Tiphereth
-    { x: 0.32, y: 0.66 }, // Netzach
-    { x: 0.68, y: 0.66 }, // Hod
-    { x: 0.5, y: 0.78 },  // Yesod
-    { x: 0.5, y: 0.92 }   // Malkuth
-function getTreeNodes(w, h) {
-  // Layout stays faithful to the ten sephirot while keeping generous spacing.
-  return [
-    { x: w / 2, y: h * 0.05 },   // Kether
-    { x: w * 0.3, y: h * 0.16 }, // Chokmah
-    { x: w * 0.7, y: h * 0.16 }, // Binah
-    { x: w * 0.3, y: h * 0.33 }, // Chesed
-    { x: w * 0.7, y: h * 0.33 }, // Geburah
-    { x: w / 2, y: h * 0.45 },   // Tiphereth
-    { x: w * 0.3, y: h * 0.63 }, // Netzach
-    { x: w * 0.7, y: h * 0.63 }, // Hod
-    { x: w / 2, y: h * 0.78 },   // Yesod
-    { x: w / 2, y: h * 0.92 }    // Malkuth
-  ];
-
-  return anchors.map(point => ({
-    x: point.x * width,
-    y: point.y * height
-  }));
-}
-
-function getTreePaths() {
-  // 22 paths: classic arrangement linking the ten nodes.
-  return [
-    [0, 1], [0, 2], [0, 5],
-    [1, 2], [1, 5], [2, 5],
-    [1, 3], [2, 4], [3, 4],
-    [3, 5], [4, 5], [3, 6],
-    [4, 7], [5, 6], [5, 7],
-    [6, 7], [6, 8], [7, 8],
-    [5, 8], [6, 9], [7, 9],
-    [8, 9]
-  ];
-}
-
-// Layer 3: Fibonacci curve - golden spiral polyline anchored at centre.
-function drawFibonacci(ctx, w, h, color, N) {
-    [0, 1], [0, 2], [0, 5], [1, 2], [1, 3], [2, 4],
-    [3, 4], [3, 5], [4, 5], [1, 5], [2, 5],
-    [3, 6], [4, 7], [5, 6], [5, 7], [6, 7],
-    [6, 8], [7, 8], [5, 8], [6, 9], [7, 9], [8, 9]
-  ];
-}
-
-// Layer 3: Fibonacci curve — golden spiral drawn as a calm polyline.
-function drawFibonacciCurve(ctx, width, height, color, N) {
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 2;
-  ctx.lineCap = "round";
-  ctx.globalAlpha = 0.85;
-
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const steps = N.ONEFORTYFOUR;
-  const turns = N.SEVEN; // seven quarter-turns keeps the spiral gentle.
-  const totalAngle = (Math.PI / 2) * turns;
-  const baseRadius = Math.min(w, h) / N.THREE;
-  const centerX = w * 0.44;
-  const centerY = h * 0.58;
->>>>>>>+upstream/codex/
-inPath();
-  for (let i = 0; i <= steps; i += 1) {
-    const t = i / steps;
-<<<<<<< ma    const angle = totalAngle * t;
-    const radius = radiusBase * Math.pow(phi, angle / (Math.PI / 2));
->>>>>>>+main
-  const     const angle = t * totalAngle;
-    const radius = (baseRadius / N.ELEVEN) * Math.pow(phi, angle / (Math.PI / 2));
->>>>>>>+upstream/codex/
-x = centerX + radius * Math.cos(angle);
-    const y = centerY + radius * Math.sin(angle);
-    if (i === 0) {
-      ctx.moveTo(x, y);
-    } else {
-      ctx.lineTo(x, y);
-    }
   }
-<<<<<<< ma/* Layer 3 — Fibonacci spiral approximated as a polyline to avoid flashing arcs. */
-function drawFibonacci(ctx, w, h, color, N) {
-  const cx = w / 2;
-  const cy = h / 2;
-  const points = createFibonacciPoints(cx, cy, w, h, N);
 
-  if (!points.length) return;
-
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 2;
-  ctx.globalAlpha = 0.85;
-  ctx.beginPath();
-  points.forEach((pt, index) => {
-    if (index === 0) {
-      ctx.moveTo(pt.x, pt.y);
-    } else {
-      ctx.lineTo(pt.x, pt.y);
-    }
-  });
->>>>>>>+main
->>> upstream/codex/add-weaving_symbols-documentation
-  ctx.stroke();
   ctx.restore();
 }
 
-<<<<<<< mainfunction drawHelix(ctx, w, h, strandColor, rungColor, N) {
+function drawFibonacciCurve(ctx, width, height, color, N) {
+  const phi = (1 + Math.sqrt(5)) / 2;
+  const steps = Math.max(12, Math.round(N.ONEFORTYFOUR || DEFAULT_NUM.ONEFORTYFOUR));
+  const rotations = (N.THIRTYTHREE || DEFAULT_NUM.THIRTYTHREE) / (N.ELEVEN || DEFAULT_NUM.ELEVEN);
+  const thetaMax = rotations * Math.PI * 2;
+
+  const rawPoints = [];
+  for (let index = 0; index < steps; index += 1) {
+    const t = steps <= 1 ? 0 : index / (steps - 1);
+    const theta = t * thetaMax;
+    const radius = Math.pow(phi, theta / Math.PI);
+    const rotatedTheta = theta - Math.PI / 2;
+    rawPoints.push({
+      x: radius * Math.cos(rotatedTheta),
+      y: radius * Math.sin(rotatedTheta)
+    });
+  }
+
+  const bounds = measureBounds(rawPoints);
+  const rangeX = bounds.maxX - bounds.minX || 1;
+  const rangeY = bounds.maxY - bounds.minY || 1;
+  const scale = 0.4 * Math.min(width / rangeX, height / rangeY);
+  const centerX = (bounds.minX + bounds.maxX) / 2;
+  const centerY = (bounds.minY + bounds.maxY) / 2;
+
+  const points = rawPoints.map((point) => ({
+    x: width / 2 + (point.x - centerX) * scale,
+    y: height / 2 + (point.y - centerY) * scale
+  }));
+
   ctx.save();
-  const segments = N.ONEFORTYFOUR;
-  const amplitude = Math.min(w, h) / (N.SEVEN + N.NINE);
-  const baseline = h / 2;
-  const frequency = N.THIRTYTHREE / N.ELEVEN;
-  const phase = Math.PI / N.THREE;
+  ctx.strokeStyle = color;
+  ctx.lineWidth = Math.max(1.5, Math.min(width, height) / (N.ONEFORTYFOUR || DEFAULT_NUM.ONEFORTYFOUR));
+  ctx.globalAlpha = 0.85;
+  // Polyline sampling is static, keeping the Fibonacci growth readable without motion.
+  drawPolyline(ctx, points);
 
-  ctx.lineWidth = N.THREE / N.ELEVEN;
-  ctx.lineCap = "round";
-  ctx.globalAlpha = 0.8;
-  ctx.strokeStyle = strandColor;
+  const markerInterval = Math.max(6, Math.floor(points.length / (N.TWENTYTWO || DEFAULT_NUM.TWENTYTWO)));
+  ctx.fillStyle = color;
+  ctx.globalAlpha = 0.75;
+  for (let index = 0; index < points.length; index += markerInterval) {
+    const point = points[index];
+    ctx.beginPath();
+    ctx.arc(point.x, point.y, Math.max(2, ctx.lineWidth * 0.9), 0, Math.PI * 2);
+    ctx.fill();
+  }
 
+  ctx.restore();
+}
+
+function measureBounds(points) {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const point of points) {
+    if (point.x < minX) minX = point.x;
+    if (point.x > maxX) maxX = point.x;
+    if (point.y < minY) minY = point.y;
+    if (point.y > maxY) maxY = point.y;
+  }
+  if (!points.length) {
+    minX = minY = maxX = maxY = 0;
+  }
+  return { minX, minY, maxX, maxY };
+}
+
+function drawPolyline(ctx, points) {
+  if (points.length < 2) {
+    return;
+  }
   ctx.beginPath();
-  for (let i = 0; i <= segments; i += 1) {
-    const t = i / segments;
-    const x = w * t;
-    const y = baseline + amplitude * Math.sin(frequency * Math.PI * t);
-    if (i === 0) {
-      ctx.moveTo(x, y);
-    } else {
-      ctx.lineTo(x, y);
-    }
->>>>>>>+main
-ayer 4: // Layer 4: Double-helix lattice - two strands plus calm cross ties.
-function drawHelix(ctx, w, h, strandColor, rungColor, N) {
-  ctx.save();
-  const centerY = h * 0.55;
-  const amplitude = h / N.NINETYNINE * N.ELEVEN;
-  const cycles = N.THREE; // three full twists keeps rhythm steady.
-  const steps = N.ONEFORTYFOUR;
+  ctx.moveTo(points[0].x, points[0].y);
+  for (let index = 1; index < points.length; index += 1) {
+    const point = points[index];
+    ctx.lineTo(point.x, point.y);
+  }
+  ctx.stroke();
+}
+
+function drawHelixLattice(ctx, width, height, colorA, colorB, N) {
+  const samples = Math.max(12, Math.round(N.ONEFORTYFOUR || DEFAULT_NUM.ONEFORTYFOUR));
+  const marginX = width / (N.ELEVEN || DEFAULT_NUM.ELEVEN);
+  const usableWidth = width - marginX * 2;
+  const centerY = height * 0.62;
+  const amplitude = height / (N.THREE + N.NINE / 9);
+  const angleScale = (N.THIRTYTHREE || DEFAULT_NUM.THIRTYTHREE) / (N.ELEVEN || DEFAULT_NUM.ELEVEN) * Math.PI;
 
   const strandA = [];
   const strandB = [];
-  for (let i = 0; i <= steps; i += 1) {
-    const t = i / steps;
-    const x = t * w;
-    const angle = t * cycles * Math.PI * 2;
-    const yA = centerY + Math.sin(angle) * amplitude;
-    const yB = centerY + Math.sin(angle + Math.PI) * amplitude;
+  for (let index = 0; index < samples; index += 1) {
+    const t = samples <= 1 ? 0 : index / (samples - 1);
+    const x = marginX + t * usableWidth;
+    const angle = t * angleScale;
+    const yA = centerY + Math.sin(angle) * amplitude * 0.3;
+    const yB = centerY + Math.sin(angle + Math.PI) * amplitude * 0.3;
     strandA.push({ x, y: yA });
     strandB.push({ x, y: yB });
   }
 
-  drawPolyline(ctx, strandA, strandColor, 2);
-  drawPolyline(ctx, strandB, strandColor, 2);
-  ctx.lineJoin = "round";
+  ctx.save();
+  ctx.lineWidth = Math.max(1.5, Math.min(width, height) / (N.NINETYNINE || DEFAULT_NUM.NINETYNINE));
+  ctx.globalAlpha = 0.75;
+  // Twin strands use small amplitude so the lattice reads clearly without overstimulation.
+  ctx.strokeStyle = colorA;
+  drawPolyline(ctx, strandA);
+  ctx.strokeStyle = colorB;
+  drawPolyline(ctx, strandB);
 
-  const center = { x: width / 2, y: height / 2 };
-  const points = buildSpiralPoints(center, Math.min(width, height), N);
-  drawPolyline(ctx, points);
-
-  ctx.strokeStyle = rungColor;
-  ctx.lineWidth = 1;
-  ctx.globalAlpha = 0.6;
-  const rungCount = N.TWENTYTWO;
-  for (let i = 0; i <= rungCount; i += 1) {
-    const index = Math.floor((i / rungCount) * steps);
+  const rungSpacing = Math.max(2, Math.floor(samples / (N.TWENTYTWO || DEFAULT_NUM.TWENTYTWO)));
+  ctx.globalAlpha = 0.55;
+  // Rungs bind the helix at a slow cadence (22 segments) to mirror the requested numerology.
+  ctx.strokeStyle = colorB;
+  for (let index = 0; index < samples; index += rungSpacing) {
     const a = strandA[index];
     const b = strandB[index];
     ctx.beginPath();
     ctx.moveTo(a.x, a.y);
     ctx.lineTo(b.x, b.y);
     ctx.stroke();
->>>>>>>+upstream/codex/
-eginPath();
-  for (let i = 0; i <= segments; i += 1) {
-    const t = i / segments;
-    const x = w * t;
-    const y = baseline + amplitude * Math.sin(frequency * Math.PI * t + phase);
-    [1, 3], [2, 4], [3, 4], [3, 5], [4, 5],
-    [3, 6], [4, 7], [5, 6], [5, 7], [6, 7],
-    [6, 8], [7, 8], [5, 8], [6, 9], [7, 9], [8, 9]
-  ];
-}
-
-// Layer 3: Fibonacci curve — static golden spiral polyline.
-function drawFibonacci(ctx, w, h, color, N) {
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 2;
-  ctx.globalAlpha = 0.9;
-
-  const centerX = w / 2;
-  const centerY = h / 2;
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const maxTheta = Math.PI * (N.NINE / N.THREE); // 3 full turns for calm pacing.
-  const steps = Math.max(N.ONEFORTYFOUR, 90);
-  const scale = Math.min(w, h) / 2.2;
-  const radiusFactor = Math.pow(phi, maxTheta / (Math.PI / 2));
-  const a = scale / radiusFactor;
-
-  ctx.beginPath();
-  for (let i = 0; i <= steps; i += 1) {
-    const t = (i / steps) * maxTheta;
-    const r = a * Math.pow(phi, t / (Math.PI / 2));
-    const x = centerX + r * Math.cos(t);
-    const y = centerY + r * Math.sin(t);
-    if (i === 0) {
-      ctx.moveTo(x, y);
-    } else {
-      ctx.lineTo(x, y);
-    }
-  }
-  ctx.stroke();
-
-  ctx.strokeStyle = rungColor;
-  ctx.globalAlpha = 0.65;
-  const rungCount = N.TWENTYTWO + N.ELEVEN;
-  for (let i = 0; i <= rungCount; i += 1) {
-    const t = i / rungCount;
-    const x = w * t;
-    const y1 = baseline + amplitude * Math.sin(frequency * Math.PI * t);
-    const y2 = baseline + amplitude * Math.sin(frequency * Math.PI * t + phase);
-    ctx.beginPath();
-    ctx.moveTo(x, y1);
-    ctx.lineTo(x, y2);
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const maxRadius = Math.hypot(width, height);
-  const baseRadius = Math.min(width, height) / N.SEVEN;
-  const originX = width * 0.36;
-  const originY = height * 0.58;
-  const points = [];
-
-  for (let i = 0; i <= N.THIRTYTHREE; i += 1) {
-    const angle = i * (Math.PI / N.NINE) * 1.5; // Gentle turn increments align with ninefold rhythm.
-    const radius = baseRadius * Math.pow(phi, i / N.SEVEN);
-    if (radius > maxRadius) break;
-    const x = originX + radius * Math.cos(angle);
-    const y = originY + radius * Math.sin(angle);
-    points.push({ x, y });
-  }
-
-  drawPolyline(ctx, points);
-  ctx.restore();
-}
-
-<<<<<<< main// Layer 4: Double helix lattice — static sine strands with cross ties.
-function drawDoubleHelix(ctx, width, height, strandColor, rungColor, N) {
-  ctx.save();
-  const steps = N.ONEFORTYFOUR; // Sample density ties to 144 for lattice stability.
-  const centerX = width * 0.68;
-  const amplitude = width / N.TWENTYTWO;
-  const verticalStep = height / steps;
-  const curveA = [];
-  const curveB = [];
-
-  for (let i = 0; i <= steps; i += 1) {
-    const y = i * verticalStep;
-    const angle = (i / N.THIRTYTHREE) * Math.PI * 2; // 33 harmonics through the strand.
-    const offset = Math.sin(angle) * amplitude;
-    curveA.push({ x: centerX - offset, y });
-    curveB.push({ x: centerX + offset, y });
-  }
-
-  ctx.globalAlpha = 0.7;
-  ctx.strokeStyle = strandColor;
-  ctx.lineWidth = 2;
-  ctx.lineCap = "round";
-  drawPolyline(ctx, curveA);
-
-  ctx.globalAlpha = 0.45;
-  drawPolyline(ctx, curveB);
-
-  ctx.globalAlpha = 0.4;
-  ctx.strokeStyle = rungColor;
-  ctx.lineWidth = 1.5;
-  const rungCount = N.TWENTYTWO;
-  const rungInterval = Math.max(1, Math.floor(steps / rungCount));
-
-  for (let i = 0; i <= steps; i += rungInterval) {
-    const a = curveA[i];
-    const b = curveB[i];
-    if (!a || !b) continue;
-    ctx.beginPath();
-    ctx.moveTo(a.x, a.y);
-    ctx.lineTo(b.x, b.y);
-    ctx.stroke();
   }
 
   ctx.restore();
-/* Layer 4 — Double helix lattice. Two sine strands with static cross ties. */
-function drawHelix(ctx, w, h, primaryColor, secondaryColor, N) {
-  const sampleCount = clampPositive(N.ONEFORTYFOUR, 144);
-  const cycles = clampPositive(N.THREE, 3);
-  const baseline = h / 2;
-  const amplitude = h / clampPositive(N.SEVEN, 7);
-  const pointsA = [];
-  const pointsB = [];
+}
 
-  for (let i = 0; i < sampleCount; i += 1) {
-    const t = i / (sampleCount - 1 || 1);
-    const x = t * w;
-    const theta = cycles * 2 * Math.PI * t;
-    const yA = baseline + amplitude * Math.sin(theta);
-    const yB = baseline + amplitude * Math.sin(theta + Math.PI);
-    pointsA.push({ x, y: yA });
-    pointsB.push({ x, y: yB });
-  }
+function drawNotice(ctx, width, height, ink, text, N) {
+  const margin = width / (N.TWENTYTWO || DEFAULT_NUM.TWENTYTWO);
+  const lineHeight = 16;
+  const lines = wrapNotice(text, 44);
 
   ctx.save();
-  ctx.lineWidth = 2;
-  ctx.globalAlpha = 0.9;
-  strokePolyline(ctx, pointsA, primaryColor);
-  strokePolyline(ctx, pointsB, secondaryColor);
-
-  const tieStep = Math.max(1, Math.floor(sampleCount / clampPositive(N.TWENTYTWO, 22)));
-  ctx.globalAlpha = 0.45;
-  ctx.strokeStyle = secondaryColor;
-  for (let i = 0; i < sampleCount; i += tieStep) {
-    const a = pointsA[i];
-    const b = pointsB[i];
-    if (!a || !b) continue;
-    ctx.beginPath();
-    ctx.moveTo(a.x, a.y);
-    ctx.lineTo(b.x, b.y);
-    ctx.stroke();
-  }
->>>>>>>+main
- drawPolyline(ctx, points, color, width) {
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = width;
-  ctx.lineCap = "round";
-  ctx.globalAlpha = 0.85;
-
-  ctx.beginPath();
-  points.forEach((point, index) => {
-    if (index === 0) {
-      ctx.moveTo(point.x, point.y);
-    } else {
-      ctx.lineTo(point.x, point.y);
-    }
-  });
-  ctx.stroke();
->>>>>>> upstream/codex/add-weaving_symbols-documentation
-
-  ctx.restore();
-}
-
-function drawNotice(ctx, w, h, message, color) {
-  if (!message) return;
-  ctx.save();
-  ctx.font = "14px system-ui, -apple-system, 'Segoe UI', sans-serif";
-  ctx.fillStyle = color;
-  ctx.globalAlpha = 0.8;
-  ctx.fillText(message, 24, h - 24);
-  ctx.restore();
-}
-
-function strokeCircle(ctx, x, y, radius, filled) {
-  ctx.beginPath();
-  ctx.arc(x, y, Math.max(radius, 0), 0, Math.PI * 2);
-  if (filled) {
-    ctx.fill();
-  } else {
-    ctx.stroke();
-  }
-}
-<<<<<<< main
-
-function strokePolyline(ctx, points, color) {
-  if (!points.length) return;
-  ctx.beginPath();
-  ctx.strokeStyle = color;
-  points.forEach((pt, index) => {
-    if (index === 0) {
-      ctx.moveTo(pt.x, pt.y);
-    } else {
-      ctx.lineTo(pt.x, pt.y);
-    }
-  });
-  ctx.stroke();
-}
-
-function clampPositive(value, fallback) {
-  const num = Number(value);
-  if (!Number.isFinite(num) || num <= 0) return fallback;
-  return num;
-}
-
-function createTreeNodes(w, h) {
-  const positions = [
-    { x: 0.5, y: 0.08 }, // Keter
-    { x: 0.72, y: 0.18 }, // Chokmah
-    { x: 0.28, y: 0.18 }, // Binah
-    { x: 0.76, y: 0.36 }, // Chesed
-    { x: 0.24, y: 0.36 }, // Geburah
-    { x: 0.5, y: 0.5 },  // Tiphareth
-    { x: 0.74, y: 0.68 }, // Netzach
-    { x: 0.26, y: 0.68 }, // Hod
-    { x: 0.5, y: 0.84 },  // Yesod
-    { x: 0.5, y: 0.94 }   // Malkuth
-  ];
-    [1, 3], [2, 4], [3, 4], [3, 5], [4, 5],
-    [3, 6], [4, 7], [5, 6], [5, 7], [6, 7],
-    [6, 8], [7, 8], [5, 8], [6, 9], [7, 9], [8, 9]
-  ];
-}
-
-// Layer 3: Fibonacci curve — static golden spiral polyline.
-function drawFibonacci(ctx, w, h, color, N) {
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 2;
-  ctx.globalAlpha = 0.9;
-
-function getTreeNodes(w, h, N) {
-  const topMargin = h / N.ELEVEN;
-  const bottomMargin = h - topMargin;
-  const verticalSpan = bottomMargin - topMargin;
-  const verticalStep = verticalSpan / N.NINE;
-  const centerX = w / 2;
-  const pillarOffset = w / (N.THREE + N.SEVEN / N.NINE);
-  const innerOffset = pillarOffset / (N.TWENTYTWO / N.ELEVEN);
-  const outerOffset = pillarOffset;
-function buildSpiralPoints(center, span, N) {
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const turns = N.SEVEN / N.THREE; // ~2.33 turns keep the spiral calm yet present.
-  const steps = N.ONEFORTYFOUR; // 144 samples for smoothness tied to Codex 144:99.
-  const startRadius = span / (N.SEVEN + N.NINE); // 16 slices cradle the opening arc.
-  const growth = Math.pow(phi, N.ELEVEN / N.NINE); // 11 and 9 pace the outward bloom.
-  const points = [];
-
-  for (let i = 0; i < steps; i += 1) {
-    const t = i / (steps - 1);
-    const angle = -Math.PI / 2 + turns * 2 * Math.PI * t;
-    const radius = startRadius * Math.pow(growth, t);
-    points.push({
-      x: center.x + Math.cos(angle) * radius,
-      y: center.y + Math.sin(angle) * radius
-    });
-  }
-  const maxTheta = Math.PI * (N.NINE / N.THREE); // 3 full turns for calm pacing.
-  const steps = Math.max(N.ONEFORTYFOUR, 90);
-  const scale = Math.min(w, h) / 2.2;
-  const radiusFactor = Math.pow(phi, maxTheta / (Math.PI / 2));
-  const a = scale / radiusFactor;
-
-  return points;
-}
-
-function drawPolyline(ctx, points) {
-  if (!points.length) return;
-  ctx.beginPath();
-  ctx.moveTo(points[0].x, points[0].y);
-  for (let i = 1; i < points.length; i += 1) {
-    const point = points[i];
-    ctx.lineTo(point.x, point.y);
-  for (let i = 0; i <= steps; i += 1) {
-    const t = (i / steps) * maxTheta;
-    const r = a * Math.pow(phi, t / (Math.PI / 2));
-    const x = centerX + r * Math.cos(t);
-    const y = centerY + r * Math.sin(t);
-    if (i === 0) {
-      ctx.moveTo(x, y);
-    } else {
-      ctx.lineTo(x, y);
-    }
-  }
-  ctx.stroke();
-}
-
-// Layer 4: Double-helix lattice — two steady strands with measured cross ties.
-function drawHelixLattice(ctx, width, height, strandColor, rungColor, N) {
-  ctx.save();
-  ctx.lineCap = "round";
-  ctx.lineJoin = "round";
-
-  const left = width / N.ELEVEN;
-  const right = width - left;
-  const steps = N.ONEFORTYFOUR; // 144 sample points across the lattice.
-  const amplitude = height / N.SEVEN; // Calm wave height from the number 7.
-  const frequency = N.THIRTYTHREE / N.ELEVEN; // 33/11 = 3 full waves across the span.
-  const phaseShift = Math.PI / N.THREE; // Staggered strands honour the vesica triad.
-  const baseline = height / 2;
-  const strandA = [];
-  const strandB = [];
-
-  for (let i = 0; i < steps; i += 1) {
-    const t = i / (steps - 1);
-    const x = left + (right - left) * t;
-    const angle = frequency * 2 * Math.PI * t;
-    const yA = baseline + Math.sin(angle) * amplitude;
-    const yB = baseline + Math.sin(angle + phaseShift) * amplitude;
-    strandA.push({ x, y: yA });
-    strandB.push({ x, y: yB });
-// Layer 4: Double-helix lattice — static strands with gentle cross ties.
-function drawHelix(ctx, w, h, strandA, strandB, tieColor, N) {
-  ctx.save();
-  const centerY = h * 0.62;
-  const amplitude = h / (N.ELEVEN * 1.2);
-  const cycles = N.THREE;
-  const steps = N.ONEFORTYFOUR;
-
-  ctx.lineWidth = 2;
-  ctx.strokeStyle = strandA;
-  ctx.beginPath();
-  for (let i = 0; i <= steps; i += 1) {
-    const progress = i / steps;
-    const theta = progress * cycles * Math.PI * 2;
-    const x = progress * w;
-    const y = centerY - amplitude * Math.sin(theta);
-    if (i === 0) {
-      ctx.moveTo(x, y);
-    } else {
-      ctx.lineTo(x, y);
-    }
-  }
-
-  ctx.strokeStyle = strandColor;
-  ctx.lineWidth = 2;
-  drawPolyline(ctx, strandA);
-  drawPolyline(ctx, strandB);
-
-  ctx.strokeStyle = rungColor;
-  ctx.lineWidth = 1.5;
-
-  const rungEvery = Math.max(2, Math.floor(steps / N.THIRTYTHREE)); // 33 ties across the width.
-  for (let i = 0; i < steps; i += rungEvery) {
-    const a = strandA[i];
-    const b = strandB[i];
-    if (!a || !b) continue;
-    ctx.beginPath();
-    ctx.moveTo(a.x, a.y);
-    ctx.lineTo(b.x, b.y);
-// Layer 4: Double-helix lattice — static strands with gentle cross ties.
-function drawHelix(ctx, w, h, strandA, strandB, tieColor, N) {
-  ctx.save();
-  const centerY = h * 0.62;
-  const amplitude = h / (N.ELEVEN * 1.2);
-  const cycles = N.THREE;
-  const steps = N.ONEFORTYFOUR;
-
-  ctx.lineWidth = 2;
-  ctx.strokeStyle = strandA;
-  ctx.beginPath();
-  for (let i = 0; i <= steps; i += 1) {
-    const progress = i / steps;
-    const theta = progress * cycles * Math.PI * 2;
-    const x = progress * w;
-    const y = centerY - amplitude * Math.sin(theta);
-  ctx.strokeStyle = strandB;
-  ctx.beginPath();
-  for (let i = 0; i <= steps; i += 1) {
-    const progress = i / steps;
-    const theta = progress * cycles * Math.PI * 2 + Math.PI;
-    const x = progress * w;
-    const y = centerY + amplitude * Math.sin(theta);
-    if (i === 0) {
-      ctx.moveTo(x, y);
-    } else {
-      ctx.lineTo(x, y);
-    }
-  }
-  ctx.stroke();
-
-  ctx.strokeStyle = strandB;
-  ctx.beginPath();
-  for (let i = 0; i <= steps; i += 1) {
-    const progress = i / steps;
-    const theta = progress * cycles * Math.PI * 2 + Math.PI;
-    const x = progress * w;
-    const y = centerY + amplitude * Math.sin(theta);
-    if (i === 0) {
-      ctx.moveTo(x, y);
-    } else {
-      ctx.lineTo(x, y);
-    }
-  }
-  ctx.stroke();
-
-  ctx.globalAlpha = 0.35;
-  ctx.lineWidth = 1;
-  ctx.strokeStyle = tieColor;
-  const rungInterval = Math.max(4, Math.floor(steps / N.TWENTYTWO));
-
-
-  ctx.globalAlpha = 0.35;
-  ctx.lineWidth = 1;
-  ctx.strokeStyle = tieColor;
-  const rungInterval = Math.max(4, Math.floor(steps / N.TWENTYTWO));
-
-  for (let i = 0; i <= steps; i += rungInterval) {
-    const progress = i / steps;
-    const theta = progress * cycles * Math.PI * 2;
-    const x = progress * w;
-    const yTop = centerY - amplitude * Math.sin(theta);
-    const yBottom = centerY + amplitude * Math.sin(theta);
-    ctx.beginPath();
-    ctx.moveTo(x, yTop);
-    ctx.lineTo(x, yBottom);
-    ctx.stroke();
-  }
-
-  return [
-    { x: centerX, y: topMargin },
-    { x: centerX - innerOffset, y: topMargin + verticalStep },
-    { x: centerX + innerOffset, y: topMargin + verticalStep },
-    { x: centerX - outerOffset, y: topMargin + verticalStep * 3 },
-    { x: centerX + outerOffset, y: topMargin + verticalStep * 3 },
-    { x: centerX, y: topMargin + verticalStep * (N.NINE / 2) },
-    { x: centerX - outerOffset, y: topMargin + verticalStep * 6 },
-    { x: centerX + outerOffset, y: topMargin + verticalStep * 6 },
-    { x: centerX, y: topMargin + verticalStep * 7 },
-    { x: centerX, y: bottomMargin }
-function drawNotice(ctx, width, height, text, color) {
-  if (!text) return;
-  ctx.save();
-  ctx.globalAlpha = 0.7;
-  ctx.fillStyle = color;
-  ctx.font = "12px system-ui, -apple-system, Segoe UI, sans-serif";
-  ctx.textBaseline = "bottom";
-  ctx.fillText(text, 24, height - 24);
-  ctx.restore();
-}
-
-function getTreeNodes(width, height) {
-  const layout = [
-    { x: 0.5, y: 0.08 },
-    { x: 0.28, y: 0.2 },
-    { x: 0.72, y: 0.2 },
-    { x: 0.28, y: 0.38 },
-    { x: 0.72, y: 0.38 },
-    { x: 0.5, y: 0.52 },
-    { x: 0.28, y: 0.68 },
-    { x: 0.72, y: 0.68 },
-    { x: 0.5, y: 0.82 },
-    { x: 0.5, y: 0.94 }
-  return positions.map((pos) => ({ x: pos.x * w, y: pos.y * h }));
-}
-
-function createTreePaths() {
-  return [
-    [0, 1], [0, 2], [0, 5],
-    [1, 2], [1, 3], [1, 5],
-    [2, 3], [2, 4], [2, 5],
-    [3, 4], [3, 5], [3, 6],
-    [4, 5], [4, 7],
-    [5, 6], [5, 7], [6, 7],
-    [6, 8], [6, 9], [7, 8], [7, 9],
-    [8, 9]
-  ];
-  return layout.map(point => ({ x: point.x * width, y: point.y * height }));
-}
-
-function getTreePaths() {
-  return [
-    [0, 1], [0, 2], [0, 5], [1, 2], [1, 5], [2, 5],
-    [1, 3], [2, 4], [3, 4], [3, 5], [4, 5],
-    [3, 6], [4, 7], [5, 6], [5, 7], [6, 7],
-    [6, 8], [7, 8], [5, 8], [6, 9], [7, 9], [8, 9]
-  ];
-}
-
-function normalizePalette(raw) {
-  if (!raw || typeof raw !== "object") {
-    return { bg: "#0b0b12", ink: "#e8e8f0", layers: [] };
-  }
-  return {
-    bg: typeof raw.bg === "string" ? raw.bg : "#0b0b12",
-    ink: typeof raw.ink === "string" ? raw.ink : "#e8e8f0",
-    layers: Array.isArray(raw.layers) ? raw.layers : []
-  };
-}
-
-function normalizeConstants(values) {
-  const defaults = {
-    THREE: 3,
-    SEVEN: 7,
-    NINE: 9,
-    ELEVEN: 11,
-    TWENTYTWO: 22,
-    THIRTYTHREE: 33,
-    NINETYNINE: 99,
-    ONEFORTYFOUR: 144
-  };
-  if (!values || typeof values !== "object") {
-    return defaults;
-  }
-  const result = { ...defaults };
-  Object.keys(defaults).forEach((key) => {
-    if (typeof values[key] === "number") {
-      result[key] = values[key];
-    }
-  });
-  return result;
-function drawPolyline(ctx, points) {
-  if (!points || points.length < 2) return;
-  ctx.beginPath();
-  ctx.moveTo(points[0].x, points[0].y);
-  for (let i = 1; i < points.length; i += 1) {
-    ctx.lineTo(points[i].x, points[i].y);
-  }
-  ctx.stroke();
-}
-
-function strokeCircle(ctx, x, y, radius) {
-  ctx.beginPath();
-  ctx.arc(x, y, radius, 0, Math.PI * 2);
-  ctx.stroke();
-function createFibonacciPoints(cx, cy, w, h, N) {
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const samples = clampPositive(N.NINETYNINE, 99);
-  const turns = clampPositive(N.THREE, 3);
-  const maxTheta = turns * Math.PI;
-  const baseRadius = Math.min(w, h) / clampPositive(N.ELEVEN, 11);
-
-  const rawPoints = [];
-  for (let i = 0; i <= samples; i += 1) {
-    const t = (maxTheta * i) / samples;
-    const growth = Math.pow(phi, t / (Math.PI / 2));
-    rawPoints.push({
-      x: cx + baseRadius * growth * Math.cos(t),
-      y: cy + baseRadius * growth * Math.sin(t)
-    });
-  }
-
-  const maxDistance = rawPoints.reduce((acc, pt) => {
-    const distance = Math.hypot(pt.x - cx, pt.y - cy);
-    return Math.max(acc, distance);
-  }, 0) || 1;
-
-  const limit = Math.min(w, h) / (clampPositive(N.THREE, 3) - 1 / clampPositive(N.THIRTYTHREE, 33));
-  const scale = limit / maxDistance;
-
-  return rawPoints.map((pt) => ({
-    x: cx + (pt.x - cx) * scale,
-    y: cy + (pt.y - cy) * scale
-  }));
-}
-
-function drawNotice(ctx, width, height, color, text) {
-  ctx.save();
-  ctx.fillStyle = color;
-  ctx.globalAlpha = 0.8;
+  ctx.fillStyle = ink;
+  ctx.globalAlpha = 0.75;
+  // Notice text offers gentle feedback if external data is missing.
   ctx.font = "14px system-ui, -apple-system, Segoe UI, sans-serif";
-  ctx.fillText(text, 24, height - 32);
+  ctx.textBaseline = "alphabetic";
+
+  lines.forEach((line, index) => {
+    const y = height - margin - (lines.length - 1 - index) * lineHeight;
+    ctx.fillText(line, margin, y);
+  });
+
   ctx.restore();
 }
-function strokeCircle(ctx, cx, cy, radius) {
-  ctx.beginPath();
-  ctx.arc(cx, cy, radius, 0, Math.PI * 2);
-  ctx.stroke();
+
+function wrapNotice(text, maxChars) {
+  const safeText = text.trim();
+  if (!safeText) {
+    return [];
+  }
+  const words = safeText.split(/\s+/);
+  const lines = [];
+  let current = "";
+  for (const word of words) {
+    const candidate = current ? current + " " + word : word;
+    if (candidate.length > maxChars && current) {
+      lines.push(current);
+      current = word;
+    } else {
+      current = candidate;
+    }
+  }
+  if (current) {
+    lines.push(current);
+  }
+  return lines;
 }

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,16 @@
+# netlify.toml - cosmogenesis-learning-engine
+[build]
+  publish = "."               # change to core or dist if that is where index.html lives
+  # command = "npm run build" # uncomment only if you add a build step later
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "SAMEORIGIN"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "strict-origin-when-cross-origin"


### PR DESCRIPTION
## Summary
- rebuild the cosmic-helix entry point to load palettes with fallbacks, seed numerology constants, and surface ND-safe status messaging
- refactor the helix renderer module into documented pure helpers for the vesica field, Tree-of-Life, Fibonacci spiral, and double helix layers
- refresh the renderer README and add a netlify.toml so deployment headers and redirects live in version control

## Testing
- npm run lint *(fails: ESLint could not find eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68cb13946ab883289db63a1b481fc19d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Offline-first helix page with single static render, clear status messages, and automatic palette fallback when palette.json is unavailable.
  - Improved canvas layout and header with ND-safe visuals; optional notice text rendered on the canvas.

- Refactor
  - Streamlined rendering into four layers for consistent, motion-free output with stronger validation and error handling.

- Documentation
  - Rewrote renderer README to emphasize offline usage, file layout, layer order, palette fallback behavior, numerology constants, and safety notes.

- Chores
  - Added Netlify configuration for SPA hosting with catch-all redirect and security headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->