### PR TITLE
Refine cosmic helix renderer for offline ND-safe spec

### DIFF
--- a/cosmic-helix/README_RENDERER.md
+++ b/cosmic-helix/README_RENDERER.md
@@ -1,95 +1,38 @@
-# Cosmic Helix Research Atlas (Offline, ND-safe)
+# Cosmic Helix Renderer (Offline, ND-safe)
 
-
-Static HTML + Canvas renderer that now pulls geometry, navigation, and module datasets from JSON files. The canvas still draws the requested four-layer cosmology on a fixed 1440×900 stage, while the surrounding interface renders the nodal modules, pattern cards, healing palette, and journal copy.
+Static HTML + Canvas capsule that renders the layered cosmology without motion. Double-clicking `index.html` paints a 1440x900
+canvas with four calm layers: vesica grid, Tree-of-Life scaffold, Fibonacci curve, and a double-helix lattice. Everything runs
+offline with no build tools or external libraries.
 
 ## Files
-- `index.html` – offline entry point with calm chrome, dataset status messaging, and interface population helpers.
-- `js/helix-renderer.mjs` – ES module of pure drawing helpers; now parameterised by the geometry dataset.
-- `data/palette.json` – optional palette override; safe defaults are bundled when the file is missing.
-- `data/geometry.json` – vesica lattice counts, sephirot layout, Fibonacci curve parameters, and helix lattice settings.
-- `data/modules.json` – Tree-of-Life navigation data, research module cards, pattern board, healing palette, and journal entry.
+- `index.html` - offline entry point that loads the palette (with fallback), seeds numerology constants, and invokes the
+  renderer.
+- `js/helix-renderer.mjs` - ES module of small pure drawing helpers. Each helper documents why the ND-safe order matters.
+- `data/palette.json` - optional palette override. If missing, the renderer keeps a safe fallback and paints a notice on the
+  canvas.
 
 ## Usage (offline)
-1. Double-click `index.html` in any modern browser. No server or network connection is required.
-2. The header status reports whether each dataset loaded (`palette`, `geometry`, and `module` data). Missing files trigger calm fallbacks and add a notice string to the canvas corner.
-3. The canvas renders the four layers exactly once:
-   - **Layer 1 — Vesica field:** intersecting circle lattice spaced with the numerology constants 3/7/9/11 (rows/columns come from `geometry.json`).
-   - **Layer 2 — Tree-of-Life scaffold:** ten sephirot linked by twenty-two calm paths. Node positions, labels, and edges are read from `geometry.json` so you can remap the pillars without editing JS.
-   - **Layer 3 — Fibonacci curve:** golden spiral polyline sampled across 144 points for smooth, static growth. The `phi`, `turns`, and `baseRadiusDivisor` live in the dataset for easy tuning.
-   - **Layer 4 — Double-helix lattice:** two phase-shifted strands with thirty-three cross ties. Amplitude, phase offset, and cross-tie density are dataset-driven.
-
-If any JSON cannot be fetched (common under `file://`), the renderer automatically falls back to bundled data, updates the status line, and prints a gentle notice on the canvas.
-
-## ND-safe + trauma-informed choices
-- Single render pass only — there are no animations, timers, or autoplay hooks.
-- Muted palette and generous spacing keep contrast comfortable for neurodivergent viewers.
-- Layered depth is preserved without flattening geometry; comments explain why each layer draws in that order.
-- Geometry routines reference numerology constants (3, 7, 9, 11, 22, 33, 99, 144) and accept dataset overrides so symbolism stays explicit and editable.
-
-## Customising datasets
-- Update `data/palette.json` to swap colours. Keys remain `bg`, `ink`, `muted`, and `layers` (array of six hex codes).
-- Adjust `data/geometry.json` to move sephirot nodes, alter vesica spacing, or tweak helix density. All numbers are plain integers/floats so they can be versioned easily.
-- Edit `data/modules.json` to add or remove modules, patterns, healing swatches, or journal entries. The UI auto-renders any additional entries.
-
-Removing or renaming any dataset is safe — the renderer displays a small fallback notice and keeps drawing with the bundled defaults.
-
-## Extending safely
-When adding new geometry, compose additional pure helper functions inside `js/helix-renderer.mjs` and call them after the existing layers. Keep the ND-safe covenant in place: static rendering, ASCII quotes, UTF-8 with LF newlines, and inline comments that explain any lore additions or accessibility decisions. New datasets should follow the same calm fallback approach: load if present, otherwise fall back quietly and inform the status banner.
-=======
-Static HTML + Canvas renderer that draws the requested four-layer cosmology on a 1440x900 canvas. The module lives inside
-`cosmic-helix/` so the root index keeps its established lore-first entry point (why: preserves the wider narrative while adding
-this focused research plate).
-
-## Files in this capsule
-- `index.html` &mdash; entry point that loads the palette (with fallback), seeds numerology constants, and invokes the renderer.
-- `js/helix-renderer.mjs` &mdash; ES module of small pure drawing functions (one helper per layer plus utilities).
-- `data/palette.json` &mdash; optional colour overrides. Missing data triggers a calm fallback and a gentle notice.
+1. Open `cosmic-helix/index.html` directly in any modern browser. No server or network connection is required.
+2. The header status reports whether the palette loaded. Missing data keeps the fallback colours and adds a gentle notice to the
+   canvas corner.
+3. The canvas renders the four layers once using the numerology constants (3, 7, 9, 11, 22, 33, 99, 144) baked into the helper
+   functions.
 
 ## Layer order (back to front)
-1. **Vesica field** &mdash; intersecting circle lattice spaced with 3/7/9/11 ratios to set the womb-of-forms foundation.
-2. **Tree-of-Life scaffold** &mdash; ten sephirot nodes linked by twenty-two paths, scaled by 33/99/144 denominators for clarity.
-3. **Fibonacci curve** &mdash; logarithmic spiral polyline sampled over 144 points with golden-ratio pacing for gentle growth.
-4. **Double-helix lattice** &mdash; two static sine strands with rungs every few samples (144 total points, 22 rungs) to echo the
-   requested lattice.
-
-## Usage (offline)
-1. Open `cosmic-helix/index.html` directly in any modern browser (no server or network required).
-2. The status line reports whether `data/palette.json` loaded or if the fallback palette is active.
-3. The canvas renders the four layers once. If the palette file is missing under `file://` conditions, the renderer posts a small
-   notice on the canvas while keeping safe colours.
-
-## Palette fallback
-Edit `data/palette.json` to supply custom colours:
-
-```json
-{
-  "bg": "#0b0b12",
-  "ink": "#e8e8f0",
-  "muted": "#a6a6c1",
-  "layers": ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-}
-```
-
-If the JSON is missing or malformed, `index.html` falls back to these bundled colours, updates the status line, and paints the
-same notice on the canvas so nothing fails silently.
-
-## Numerology constants in use
-All geometry helpers receive a `NUM` object exposing the requested constants:
-- `3` seeds vesica symmetry.
-- `7` and `9` define grid counts and vertical spacing.
-- `11` drives margins and angle ratios.
-- `22` sets Tree-of-Life paths and helix rungs.
-- `33`, `99`, and `144` scale radii, sampling density, and curve pacing.
+1. **Vesica field** - intersecting circle lattice spaced with 9x11 divisions to honour womb-of-forms geometry.
+2. **Tree-of-Life scaffold** - ten sephirot nodes joined by twenty-two steady paths, scaled by the numerology denominators for
+   clarity.
+3. **Fibonacci curve** - static logarithmic spiral sampled over 144 points with golden ratio pacing.
+4. **Double-helix lattice** - two phase-shifted strands with thirty-three cross ties and no motion.
 
 ## ND-safe and trauma-informed choices
-- **No motion:** every layer renders once; no timers, requestAnimationFrame, or interaction hooks.
-- **Calm contrast:** palette validation prevents harsh spikes and keeps text readable.
-- **Layered depth:** geometry is rendered in ordered layers instead of flattening into a single outline.
-- **Commented intent:** code comments explain why each safety choice exists for future stewards.
+- No animation or timers; everything draws once per load to avoid sensory spikes.
+- Calm palette defaults with status messaging explain fallbacks so nothing fails silently.
+- Comments explain why each layer order and spacing choice preserves depth without flattening geometry.
+- ASCII quotes, UTF-8, and LF newlines keep the module portable across offline environments.
 
-## Extending carefully
-Add new geometry by composing additional pure helper functions in `js/helix-renderer.mjs`. Maintain the covenant: ASCII quotes
-only, UTF-8 with LF newlines, static rendering, calm palette, and inline commentary explaining any lore additions. Keep the module
-self-contained so it remains double-click runnable without build tools or network requests.
+## Customising safely
+- Adjust `data/palette.json` to change colours. Keys remain `bg`, `ink`, `muted`, and `layers` (array of six hex strings).
+- Pass a custom geometry object when calling `renderHelix` if deeper tuning is required; the function validates numbers and
+  keeps the ND-safe structure intact.
 

--- a/cosmic-helix/index.html
+++ b/cosmic-helix/index.html
@@ -2,88 +2,29 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Cosmic Helix Research Atlas</title>
+  <title>Cosmic Helix Renderer (ND-safe, Offline)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
   <meta name="color-scheme" content="light dark">
-
   <style>
-    /* ND-safe: calm gradients, no motion, generous breathing room */
-
-  <!-- Lives under cosmic-helix/ so the root index keeps its lore-forward entry point (why: preserves established narrative flow). -->
-  <style>
-    /* ND-safe chrome: calm contrast, generous spacing, no motion cues. */
-
+    /* ND-safe chrome: calm contrast, no motion, layered depth preserved (why: reduces sensory load). */
     :root {
-      --bg: #070710;
-      --surface: rgba(17, 17, 28, 0.88);
-      --surface-soft: rgba(20, 20, 34, 0.72);
-      --outline: #2d2d46;
-      --ink: #f3f3ff;
-      --muted: #b4b4d4;
-      --accent: #ffd700;
-      --accent-soft: #6b46c1;
-      --tag-bg: rgba(107, 70, 193, 0.3);
-      --tag-border: rgba(240, 240, 255, 0.25);
-      --swatch-border: rgba(255, 215, 0, 0.4);
-    }
-
-    @media (prefers-color-scheme: light) {
-      :root {
-        --bg: #f8f5ff;
-        --surface: rgba(244, 240, 255, 0.92);
-        --surface-soft: rgba(240, 236, 255, 0.8);
-        --outline: #d5cffe;
-        --ink: #1c1634;
-        --muted: #514a7a;
-        --tag-bg: rgba(107, 70, 193, 0.1);
-        --tag-border: rgba(107, 70, 193, 0.4);
-        --swatch-border: rgba(107, 70, 193, 0.5);
-      }
-    }
-
-    *, *::before, *::after {
-      box-sizing: border-box;
+      --bg: #0b0b12;
+      --ink: #e8e8f0;
+      --muted: #a6a6c1;
+      --outline: #1d1d2a;
     }
 
     html, body {
       margin: 0;
       padding: 0;
-      background: radial-gradient(circle at top left, rgba(107, 70, 193, 0.35), transparent 55%),
-        radial-gradient(circle at bottom right, rgba(15, 52, 96, 0.35), transparent 50%),
-        var(--bg);
+      background: var(--bg);
       color: var(--ink);
-
-      font: 15px/1.6 "Segoe UI", system-ui, -apple-system, Roboto, sans-serif;
-    }
-
-    header {
-      padding: 16px 20px;
-      border-bottom: 1px solid var(--outline);
-      background: linear-gradient(180deg, rgba(255, 215, 0, 0.08), rgba(0, 0, 0, 0));
-    }
-
-    header h1 {
-      margin: 0;
-      font-size: 1.35rem;
-      letter-spacing: 0.08em;
-    }
-
-    header p {
-      margin: 6px 0 0;
-      color: var(--muted);
-      max-width: 960px;
-    }
-
-    .status {
-      margin-top: 12px;
-      font-size: 0.85rem;
-
-      font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+      font: 14px/1.4 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
     }
 
     header {
       padding: 12px 16px;
-      border-bottom: 1px solid #1d1d2a;
+      border-bottom: 1px solid var(--outline);
       background: linear-gradient(180deg, #10101a, transparent);
     }
 
@@ -92,284 +33,26 @@
     }
 
     .status {
-      color: var(--muted);
-      font-size: 12px;
       margin-top: 4px;
+      font-size: 12px;
+      color: var(--muted);
     }
 
     #stage {
       display: block;
-      margin: 16px auto 24px;
+      margin: 16px auto;
       width: 100%;
       max-width: 1440px;
-      box-shadow: 0 0 0 1px #1d1d2a;
+      box-shadow: 0 0 0 1px var(--outline);
       background: var(--bg);
     }
 
     .note {
       max-width: 900px;
-      margin: 0 auto 24px;
-
+      margin: 0 auto 16px;
+      padding: 0 16px 24px;
       color: var(--muted);
-      padding: 0 16px 40px;
     }
-
-
-    main {
-      max-width: 1220px;
-      margin: 0 auto;
-      padding: 24px;
-      display: grid;
-      gap: 24px;
-    }
-
-    .section {
-      background: var(--surface);
-      border: 1px solid var(--outline);
-      border-radius: 18px;
-      padding: 24px;
-      display: grid;
-      gap: 18px;
-    }
-
-    .section h2 {
-      margin: 0;
-      font-size: 1.1rem;
-      letter-spacing: 0.05em;
-    }
-
-    .section p {
-      margin: 0;
-    }
-
-    .tree-nav {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-      gap: 12px;
-    }
-
-    .sephirot-card {
-      background: var(--surface-soft);
-      border: 1px solid var(--outline);
-      border-radius: 14px;
-      padding: 12px 14px;
-      display: grid;
-      gap: 6px;
-      text-align: center;
-    }
-
-    .sephirot-symbol {
-      font-size: 1.8rem;
-      line-height: 1;
-    }
-
-    .sephirot-title {
-      font-weight: 600;
-      letter-spacing: 0.05em;
-    }
-
-    .module-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-      gap: 16px;
-    }
-
-    .module-card {
-      background: var(--surface-soft);
-      border: 1px solid var(--outline);
-      border-radius: 16px;
-      padding: 18px;
-      display: grid;
-      gap: 12px;
-    }
-
-    .module-symbol {
-      font-size: 1.7rem;
-      line-height: 1;
-    }
-
-    .module-title {
-      margin: 0;
-      font-size: 1.05rem;
-    }
-
-    .module-summary {
-      color: var(--muted);
-      font-size: 0.95rem;
-    }
-
-    .module-tags {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 8px;
-    }
-
-    .tag {
-      padding: 4px 10px;
-      border-radius: 999px;
-      background: var(--tag-bg);
-      border: 1px solid var(--tag-border);
-      font-size: 0.82rem;
-    }
-
-    .control-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-      gap: 12px;
-    }
-
-    .control-card {
-      background: var(--surface-soft);
-      border: 1px solid var(--outline);
-      border-radius: 14px;
-      padding: 12px 14px;
-      display: grid;
-      gap: 6px;
-    }
-
-    .control-label {
-      font-weight: 600;
-    }
-
-    .control-range {
-      color: var(--muted);
-      font-size: 0.85rem;
-    }
-
-    .canvas-block {
-      text-align: center;
-    }
-
-    #stage {
-      display: block;
-      margin: 0 auto;
-      max-width: 100%;
-      height: auto;
-      box-shadow: 0 0 0 1px var(--outline);
-      background: #0b0b12;
-    }
-
-    .note {
-      color: var(--muted);
-      font-size: 0.9rem;
-    }
-
-    .pattern-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-      gap: 16px;
-    }
-
-    .pattern-card {
-      background: var(--surface-soft);
-      border: 1px solid var(--outline);
-      border-radius: 14px;
-      padding: 14px;
-      text-align: center;
-      display: grid;
-      gap: 8px;
-    }
-
-    .pattern-icon {
-      font-size: 2rem;
-    }
-
-    .frequency-display {
-      font-size: 2rem;
-      text-align: center;
-      letter-spacing: 0.1em;
-    }
-
-    .color-palette {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
-      gap: 14px;
-    }
-
-    .color-swatch {
-      border-radius: 50%;
-      aspect-ratio: 1;
-      border: 3px solid var(--swatch-border);
-      display: grid;
-      place-items: center;
-      font-size: 0.85rem;
-      color: var(--ink);
-    }
-
-    .journal-entry {
-      background: var(--surface-soft);
-      border: 1px solid var(--outline);
-      border-radius: 16px;
-      padding: 18px;
-      display: grid;
-      gap: 8px;
-    }
-
-    .journal-meta {
-      color: var(--muted);
-      font-size: 0.85rem;
-    }
-
-    @media (max-width: 720px) {
-      header {
-        padding: 16px 16px 20px;
-      }
-
-      main {
-        padding: 16px;
-      }
-    }
-  </style>
-</head>
-<body>
-  <header>
-    <h1>Cosmic Helix Research Atlas</h1>
-    <p>Modular, nodal cosmogenesis interface. ND-safe, offline, and data-driven. Canvas renders sacred geometry while the surrounding panels load from JSON datasets.</p>
-    <p class="status" id="status" role="status" aria-live="polite">Preparing datasets…</p>
-  </header>
-
-  <main>
-    <section class="section">
-      <h2>Tree of Life Navigation</h2>
-      <ul class="tree-nav" id="sephirot-nav" role="list"></ul>
-    </section>
-
-    <section class="section">
-      <h2>Research Modules</h2>
-      <div class="module-grid" id="module-grid"></div>
-    </section>
-
-    <section class="section">
-      <h2 id="workspace-title">Sacred Geometry Laboratory</h2>
-      <p class="note">Control set remains static for calm viewing; values document the preferred numerology alignment.</p>
-      <div class="control-grid" id="workspace-controls"></div>
-    </section>
-
-    <section class="section canvas-block">
-      <h2>Layered Geometry Canvas</h2>
-      <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas" role="img"></canvas>
-      <p class="note">Layers render once: Vesica field, Tree-of-Life scaffold, Fibonacci curve, and double-helix lattice. No motion, no network calls.</p>
-    </section>
-
-    <section class="section">
-      <h2>Pattern Recognition</h2>
-      <div class="pattern-grid" id="pattern-grid"></div>
-    </section>
-
-    <section class="section">
-      <h2>Frequency &amp; Color Healing</h2>
-      <div class="frequency-display" id="frequency-display">432 Hz</div>
-      <div class="color-palette" id="color-palette" role="list"></div>
-    </section>
-
-    <section class="section">
-      <h2>Research Journal</h2>
-      <div id="journal"></div>
-    </section>
-  </main>
 
     code {
       background: #11111a;
@@ -380,200 +63,38 @@
 </head>
 <body>
   <header>
-    <div><strong>Cosmic Helix Renderer</strong> &mdash; layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status" role="status" aria-live="polite">Loading palette...</div>
+    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette...</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">
-    Static renderer for Vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice. No animation,
-    no autoplay, no external libraries. Open this file directly; it works offline.
-  </p>
-
+  <p class="note">Static renderer for vesica grid, Tree-of-Life nodes, Fibonacci curve, and a double-helix lattice. Open this file directly (no server, no animation, ND-safe palette).</p>
 
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
 
-
-    const statusElement = document.getElementById("status");
-    const canvas = document.getElementById("stage");
-    const context = canvas.getContext("2d");
-
-    const defaults = {
-
-    const statusEl = document.getElementById("status");
+    const elStatus = document.getElementById("status");
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
 
-    const FALLBACK = {
+    async function loadPalette(path) {
+      try {
+        const response = await fetch(path, { cache: "no-store" });
+        if (!response.ok) {
+          throw new Error(String(response.status));
+        }
+        return await response.json();
+      } catch (error) {
+        return null;
+      }
+    }
 
+    const defaults = {
       palette: {
         bg: "#0b0b12",
         ink: "#e8e8f0",
         muted: "#a6a6c1",
         layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-
-      },
-      geometry: {
-        vesica: {
-          rows: 9,
-          columns: 11,
-          paddingDivisor: 11,
-          radiusFactor: 1.5,
-          strokeDivisor: 99,
-          alpha: 0.55
-        },
-        treeOfLife: {
-          marginDivisor: 11,
-          radiusDivisor: 22,
-          labelOffset: -24,
-          labelFont: "13px system-ui, -apple-system, Segoe UI, sans-serif",
-          nodes: [
-            { id: "kether", title: "Kether", meaning: "Crown", level: 0, xFactor: 0.5 },
-            { id: "chokmah", title: "Chokmah", meaning: "Wisdom", level: 1, xFactor: 0.7 },
-            { id: "binah", title: "Binah", meaning: "Understanding", level: 1, xFactor: 0.3 },
-            { id: "chesed", title: "Chesed", meaning: "Mercy", level: 2, xFactor: 0.68 },
-            { id: "geburah", title: "Geburah", meaning: "Severity", level: 2, xFactor: 0.32 },
-            { id: "tiphareth", title: "Tiphareth", meaning: "Beauty", level: 3, xFactor: 0.5 },
-            { id: "netzach", title: "Netzach", meaning: "Victory", level: 4, xFactor: 0.66 },
-            { id: "hod", title: "Hod", meaning: "Glory", level: 4, xFactor: 0.34 },
-            { id: "yesod", title: "Yesod", meaning: "Foundation", level: 5, xFactor: 0.5 },
-            { id: "malkuth", title: "Malkuth", meaning: "Kingdom", level: 6, xFactor: 0.5 }
-          ],
-          edges: [
-            ["kether", "chokmah"],
-            ["kether", "binah"],
-            ["kether", "tiphareth"],
-            ["chokmah", "binah"],
-            ["chokmah", "tiphareth"],
-            ["chokmah", "chesed"],
-            ["chokmah", "netzach"],
-            ["binah", "tiphareth"],
-            ["binah", "geburah"],
-            ["binah", "hod"],
-            ["chesed", "geburah"],
-            ["chesed", "tiphareth"],
-            ["chesed", "netzach"],
-            ["geburah", "tiphareth"],
-            ["geburah", "hod"],
-            ["tiphareth", "netzach"],
-            ["tiphareth", "hod"],
-            ["tiphareth", "yesod"],
-            ["netzach", "hod"],
-            ["netzach", "yesod"],
-            ["hod", "yesod"],
-            ["yesod", "malkuth"]
-          ]
-        },
-        fibonacci: {
-          sampleCount: 144,
-          turns: 3,
-          baseRadiusDivisor: 3,
-          phi: 1.618033988749895,
-          alpha: 0.85
-        },
-        helix: {
-          sampleCount: 144,
-          cycles: 3,
-          amplitudeDivisor: 3,
-          phaseOffset: 180,
-          crossTieCount: 33,
-          strandAlpha: 0.85,
-          rungAlpha: 0.6
-        }
-      },
-      interface: {
-        sephirot: [
-          { id: "kether", emoji: "👑", title: "Kether", meaning: "Crown" },
-          { id: "chokmah", emoji: "🔮", title: "Chokmah", meaning: "Wisdom" },
-          { id: "binah", emoji: "🌙", title: "Binah", meaning: "Understanding" },
-          { id: "chesed", emoji: "💙", title: "Chesed", meaning: "Mercy" },
-          { id: "geburah", emoji: "🔥", title: "Geburah", meaning: "Severity" },
-          { id: "tiphareth", emoji: "☀️", title: "Tiphareth", meaning: "Beauty" },
-          { id: "netzach", emoji: "🌿", title: "Netzach", meaning: "Victory" },
-          { id: "hod", emoji: "📖", title: "Hod", meaning: "Glory" },
-          { id: "yesod", emoji: "🌛", title: "Yesod", meaning: "Foundation" },
-          { id: "malkuth", emoji: "🌍", title: "Malkuth", meaning: "Kingdom" }
-        ],
-        modules: [
-          {
-            id: "cosmogenesis",
-            symbol: "🌌",
-            title: "Cosmogenesis Patterns",
-            summary: "Explore creation myths through neurodivergent pattern recognition. Map the sacred geometry of universe birthing across cultures.",
-            tags: ["Sacred Geometry", "Creation Myths", "ND Cognition"]
-          },
-          {
-            id: "harmonic-research",
-            symbol: "🎵",
-            title: "Harmonic Resonance Lab",
-            summary: "Investigate Schumann resonances, planetary frequencies, and solfeggio healing tones. Create custom frequency environments for research.",
-            tags: ["Sound Healing", "Frequency", "Binaural"]
-          },
-          {
-            id: "symbolic-cognition",
-            symbol: "⚛️",
-            title: "Symbolic Cognition Archive",
-            summary: "Channel art-science fusion naturally. Study Jung's Red Book, temple geometry, and synesthetic artist archives.",
-            tags: ["Jung", "Symbolism", "ND Minds"]
-          },
-          {
-            id: "trauma-environments",
-            symbol: "🛡️",
-            title: "Trauma-Safe Spaces",
-            summary: "Design healing environments using polyvagal theory, biophilic patterns, and RPG mechanics for nervous system regulation.",
-            tags: ["PTSD", "Healing", "Safe Space"]
-          },
-          {
-            id: "alchemical-psychology",
-            symbol: "⚗️",
-            title: "Alchemical Psychology",
-            summary: "Following Dion Fortune, Paul Foster Case, and Agrippa. Transform lead consciousness into golden awareness.",
-            tags: ["Alchemy", "Theosophy", "Mysticism"]
-          },
-          {
-            id: "living-arcana",
-            symbol: "🃏",
-            title: "Living Arcana System",
-            summary: "Dynamic tarot correspondences mapped to Tree of Life. Real-time archetypal pattern recognition and synthesis.",
-            tags: ["Tarot", "Qabalah", "Hermetic"]
-          }
-        ],
-        patterns: [
-          { icon: "🌀", title: "Fibonacci Spirals", caption: "Nature's growth pattern" },
-          { icon: "⬢", title: "Metatron's Cube", caption: "Sacred geometry matrix" },
-          { icon: "✡", title: "Star Tetrahedron", caption: "Merkaba activation" }
-        ],
-        workspace: {
-          title: "Sacred Geometry Laboratory",
-          controls: [
-            { id: "recursion", label: "Recursion Depth", min: 1, max: 12, value: 6 },
-            { id: "phi", label: "Golden Ratio φ", min: 0, max: 100, value: 61 },
-            { id: "rotation", label: "Rotation Speed", min: 0, max: 100, value: 30 },
-            { id: "complexity", label: "Fractal Complexity", min: 3, max: 24, value: 12 }
-          ]
-        },
-        healing: {
-          baseFrequency: 432,
-          swatches: [
-            { color: "#FF0000", frequency: 428, label: "Root" },
-            { color: "#FFA500", frequency: 480, label: "Sacral" },
-            { color: "#FFFF00", frequency: 510, label: "Solar" },
-            { color: "#00FF00", frequency: 528, label: "Heart" },
-            { color: "#00FFFF", frequency: 600, label: "Throat" },
-            { color: "#0000FF", frequency: 660, label: "Third Eye" },
-            { color: "#8B00FF", frequency: 720, label: "Crown" }
-          ]
-        },
-        journal: [
-          {
-            id: "entry-144",
-            title: "Entry 144",
-            timestamp: "Now",
-            body: "The living engine awakens. Patterns emerge from the intersection of ancient wisdom and quantum possibility. The Tree of Life serves as our navigation system through consciousness layers. Each node connects to infinite others in a holographic dance of meaning. The Codex 144:99 represents completion meeting infinity."
-          }
-        ]
-
       }
     };
 
@@ -588,242 +109,26 @@
       ONEFORTYFOUR: 144
     };
 
-
-    async function loadJSON(path) {
-      try {
-        const response = await fetch(path, { cache: "no-store" });
-        if (!response.ok) {
-          throw new Error(String(response.status));
-        }
-        return await response.json();
-      } catch (error) {
-        return null;
-      }
-    }
-
-    function updateStatus(messages) {
-      statusElement.textContent = messages.join(" • ");
-    }
-
-    function populateSephirot(nav, entries) {
-      nav.innerHTML = "";
-      entries.forEach((node) => {
-        const item = document.createElement("li");
-        item.className = "sephirot-card";
-        const symbol = document.createElement("span");
-        symbol.className = "sephirot-symbol";
-        symbol.setAttribute("aria-hidden", "true");
-        symbol.textContent = node.emoji;
-        const title = document.createElement("span");
-        title.className = "sephirot-title";
-        title.textContent = node.title;
-        const meaning = document.createElement("span");
-        meaning.className = "sephirot-meaning";
-        meaning.textContent = node.meaning;
-        item.appendChild(symbol);
-        item.appendChild(title);
-        item.appendChild(meaning);
-        nav.appendChild(item);
-      });
-    }
-
-    function populateModules(container, modules) {
-      container.innerHTML = "";
-      modules.forEach((module) => {
-        const card = document.createElement("article");
-        card.className = "module-card";
-        card.id = module.id;
-        const symbol = document.createElement("span");
-        symbol.className = "module-symbol";
-        symbol.setAttribute("aria-hidden", "true");
-        symbol.textContent = module.symbol;
-        const title = document.createElement("h3");
-        title.className = "module-title";
-        title.textContent = module.title;
-        const summary = document.createElement("p");
-        summary.className = "module-summary";
-        summary.textContent = module.summary;
-        const tagList = document.createElement("div");
-        tagList.className = "module-tags";
-        module.tags.forEach((tag) => {
-          const badge = document.createElement("span");
-          badge.className = "tag";
-          badge.textContent = tag;
-          tagList.appendChild(badge);
-        });
-        card.appendChild(symbol);
-        card.appendChild(title);
-        card.appendChild(summary);
-        card.appendChild(tagList);
-        container.appendChild(card);
-      });
-    }
-
-    function populateWorkspace(titleElement, controlContainer, workspace) {
-      titleElement.textContent = workspace.title;
-      controlContainer.innerHTML = "";
-      workspace.controls.forEach((control) => {
-        const card = document.createElement("div");
-        card.className = "control-card";
-        const label = document.createElement("span");
-        label.className = "control-label";
-        label.textContent = control.label;
-        const range = document.createElement("span");
-        range.className = "control-range";
-        range.textContent = `Range ${control.min}–${control.max}; preferred ${control.value}`;
-        card.appendChild(label);
-        card.appendChild(range);
-        controlContainer.appendChild(card);
-      });
-    }
-
-    function populatePatterns(container, patterns) {
-      container.innerHTML = "";
-      patterns.forEach((pattern) => {
-        const card = document.createElement("div");
-        card.className = "pattern-card";
-        const icon = document.createElement("span");
-        icon.className = "pattern-icon";
-        icon.setAttribute("aria-hidden", "true");
-        icon.textContent = pattern.icon;
-        const title = document.createElement("span");
-        title.className = "pattern-title";
-        title.textContent = pattern.title;
-        const caption = document.createElement("span");
-        caption.className = "pattern-caption";
-        caption.textContent = pattern.caption;
-        card.appendChild(icon);
-        card.appendChild(title);
-        card.appendChild(caption);
-        container.appendChild(card);
-      });
-    }
-
-    function populateHealing(display, paletteContainer, healing) {
-      display.textContent = `${healing.baseFrequency} Hz`;
-      paletteContainer.innerHTML = "";
-      healing.swatches.forEach((swatch) => {
-        const item = document.createElement("div");
-        item.className = "color-swatch";
-        item.style.background = swatch.color;
-        item.setAttribute("role", "listitem");
-        item.title = `${swatch.label}: ${swatch.frequency} Hz`;
-        const text = document.createElement("span");
-        text.textContent = swatch.label;
-        item.appendChild(text);
-        paletteContainer.appendChild(item);
-
-    if (!ctx) {
-      statusEl.textContent = "Canvas context unavailable in this browser.";
-    } else {
-      initialise();
-    }
-
-    async function initialise() {
+    (async () => {
       const palette = await loadPalette("./data/palette.json");
-      const usingFallback = !palette;
-      const activePalette = usingFallback ? FALLBACK.palette : palette;
-      const notice = usingFallback ? "Palette missing; using calm fallback colours." : "";
+      const activePalette = palette || defaults.palette;
+      const notice = palette ? "" : "Palette missing; using ND-safe fallback.";
+      elStatus.textContent = palette ? "Palette loaded." : "Palette missing; fallback active.";
 
-      const result = renderHelix(ctx, {
+      if (!ctx) {
+        elStatus.textContent = "Canvas unavailable in this browser.";
+        return;
+      }
+
+      // ND-safe order: draw once, preserve calm layering, flag fallbacks visually.
+      renderHelix(ctx, {
         width: canvas.width,
         height: canvas.height,
         palette: activePalette,
         NUM,
         notice
-
       });
-    }
-
-
-    function populateJournal(container, entries) {
-      container.innerHTML = "";
-      entries.forEach((entry) => {
-        const article = document.createElement("article");
-        article.className = "journal-entry";
-        const meta = document.createElement("div");
-        meta.className = "journal-meta";
-        meta.textContent = `${entry.title} — ${entry.timestamp}`;
-        const body = document.createElement("p");
-        body.textContent = entry.body;
-        article.appendChild(meta);
-        article.appendChild(body);
-        container.appendChild(article);
-      });
-    }
-
-    if (!context) {
-      updateStatus(["Canvas context unavailable; renderer cannot initialise."]);
-    } else {
-      (async () => {
-        const statusMessages = [];
-        const noticeMessages = [];
-
-        const paletteData = await loadJSON("./data/palette.json");
-        const palette = paletteData || defaults.palette;
-        statusMessages.push(paletteData ? "Palette loaded" : "Palette fallback active");
-        if (!paletteData) {
-          noticeMessages.push("Palette file missing");
-        }
-
-        const geometryData = await loadJSON("./data/geometry.json");
-        const geometry = geometryData || defaults.geometry;
-        statusMessages.push(geometryData ? "Geometry dataset loaded" : "Geometry fallback active");
-        if (!geometryData) {
-          noticeMessages.push("Geometry dataset missing");
-        }
-
-        const interfaceData = await loadJSON("./data/modules.json");
-        const interfaceSet = interfaceData || defaults.interface;
-        statusMessages.push(interfaceData ? "Module dataset loaded" : "Interface fallback active");
-        if (!interfaceData) {
-          noticeMessages.push("Interface dataset missing");
-        }
-
-        updateStatus(statusMessages);
-
-        const renderResult = renderHelix(context, {
-          width: canvas.width,
-          height: canvas.height,
-          palette,
-          NUM,
-          geometry,
-          notice: noticeMessages.join(" — ")
-        });
-
-        if (!renderResult.ok) {
-          statusMessages.push(`Renderer issue: ${renderResult.reason}`);
-          updateStatus(statusMessages);
-        }
-
-        populateSephirot(document.getElementById("sephirot-nav"), interfaceSet.sephirot);
-        populateModules(document.getElementById("module-grid"), interfaceSet.modules);
-        populateWorkspace(document.getElementById("workspace-title"), document.getElementById("workspace-controls"), interfaceSet.workspace);
-        populatePatterns(document.getElementById("pattern-grid"), interfaceSet.patterns);
-        populateHealing(document.getElementById("frequency-display"), document.getElementById("color-palette"), interfaceSet.healing);
-        populateJournal(document.getElementById("journal"), interfaceSet.journal);
-      })();
-=
-      if (!result.ok) {
-        statusEl.textContent = "Renderer could not initialise (" + result.reason + ").";
-        return;
-      }
-
-      statusEl.textContent = usingFallback ? "Palette missing; safe fallback applied." : "Palette loaded.";
-    }
-
-    async function loadPalette(path) {
-      try {
-        const response = await fetch(path, { cache: "no-store" });
-        if (!response.ok) {
-          throw new Error(String(response.status));
-        }
-        return await response.json();
-      } catch (error) {
-        return null;
-      }
-
-    }
+    })();
   </script>
 </body>
 </html>

--- a/cosmic-helix/js/helix-renderer.mjs
+++ b/cosmic-helix/js/helix-renderer.mjs
@@ -1,16 +1,16 @@
 /*
   helix-renderer.mjs
-  ND-safe static renderer for layered sacred geometry requested for Codex 144:99.
-
+  Static renderer for the Cosmic Helix canvas. All helpers are pure functions so the
+  module stays predictable and ND-safe (why: keeps rendering single-pass and calm).
 
   Layer order (back to front):
-    1) Vesica field — intersecting circle lattice referencing numerology spacing.
-    2) Tree-of-Life scaffold — ten sephirot linked by twenty-two calm paths.
-    3) Fibonacci curve — golden spiral polyline sampled across 144 points.
-    4) Double-helix lattice — two static strands with gentle cross ties.
+    1) Vesica field - intersecting circles establishing the womb-of-forms grid.
+    2) Tree-of-Life scaffold - ten sephirot linked by twenty-two steady paths.
+    3) Fibonacci curve - logarithmic spiral encoded with golden ratio pacing.
+    4) Double-helix lattice - two static strands with gentle cross ties.
 
-  Every helper below is a small pure function. The renderer draws once per load,
-  avoiding motion or flashing to respect the ND-safe covenant.
+  Numerology constants (3, 7, 9, 11, 22, 33, 99, 144) shape spacing, sampling,
+  and proportions throughout the helpers to honour the requested symbolism.
 */
 
 const FALLBACK_PALETTE = {
@@ -19,20 +19,6 @@ const FALLBACK_PALETTE = {
   muted: "#a6a6c1",
   layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
 };
-
-
-  Layers (rendered back to front):
-    1) Vesica field - intersecting circle lattice for the womb-of-forms motif.
-    2) Tree-of-Life scaffold - ten sephirot joined by twenty-two calm paths.
-    3) Fibonacci curve - logarithmic spiral polyline with golden-ratio pacing.
-    4) Double-helix lattice - two still strands with gentle cross ties.
-
-  Rationale:
-    - No animation: everything draws once on load to respect ND-safe pacing.
-    - Calm palette: soft contrast keeps lines readable without sensory spikes.
-    - Numerology constants (3, 7, 9, 11, 22, 33, 99, 144) guide proportions.
-*/
-
 
 const DEFAULT_NUM = {
   THREE: 3,
@@ -45,8 +31,8 @@ const DEFAULT_NUM = {
   ONEFORTYFOUR: 144
 };
 
-
 const FALLBACK_GEOMETRY = {
+  // Vesica lattice references 9x11 grid divisions (why: ties to 9/11 numerology).
   vesica: {
     rows: 9,
     columns: 11,
@@ -55,6 +41,7 @@ const FALLBACK_GEOMETRY = {
     strokeDivisor: 99,
     alpha: 0.55
   },
+  // Tree-of-Life scaffold uses ten nodes with 22 connective paths.
   treeOfLife: {
     marginDivisor: 11,
     radiusDivisor: 22,
@@ -116,45 +103,26 @@ const FALLBACK_GEOMETRY = {
 };
 
 export function renderHelix(ctx, options = {}) {
-  if (!ctx || typeof ctx.moveTo !== "function") {
-    return { ok: false, reason: "missing-context" };
-  }
-
-  const width = typeof options.width === "number" ? options.width : ctx.canvas.width;
-  const height = typeof options.height === "number" ? options.height : ctx.canvas.height;
-  if (!width || !height) {
-
-const DEFAULT_PALETTE = {
-  bg: "#0b0b12",
-  ink: "#e8e8f0",
-  muted: "#a6a6c1",
-  layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-};
-
-export function renderHelix(ctx, options = {}) {
   if (!ctx || typeof ctx.canvas === "undefined") {
     return { ok: false, reason: "missing-context" };
   }
 
   const width = toNumber(options.width, ctx.canvas.width);
   const height = toNumber(options.height, ctx.canvas.height);
-
   if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
-
     return { ok: false, reason: "invalid-dimensions" };
   }
 
   const palette = normalisePalette(options.palette);
   const numerology = normaliseNumerology(options.NUM);
-
   const geometry = normaliseGeometry(options.geometry);
-
   const notice = typeof options.notice === "string" ? options.notice.trim() : "";
 
   ctx.save();
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
   fillBackground(ctx, width, height, palette.bg);
 
-  // Layer order preserves depth without motion (why: ND-safe, trauma-informed viewing).
+  // Layer sequencing preserves depth without motion (why: layered geometry, ND-safe).
   drawVesicaField(ctx, width, height, palette.layers[0], numerology, geometry.vesica);
   drawTreeOfLife(ctx, width, height, palette.layers[1], palette.layers[2], palette.ink, numerology, geometry.treeOfLife);
   drawFibonacciCurve(ctx, width, height, palette.layers[3], numerology, geometry.fibonacci);
@@ -170,7 +138,7 @@ export function renderHelix(ctx, options = {}) {
 
 function normalisePalette(input) {
   if (!input || typeof input !== "object") {
-    return { ...FALLBACK_PALETTE, layers: [...FALLBACK_PALETTE.layers] };
+    return clonePalette(FALLBACK_PALETTE);
   }
 
   const result = {
@@ -180,13 +148,22 @@ function normalisePalette(input) {
     layers: []
   };
 
-  const requestedLayers = Array.isArray(input.layers) ? input.layers : [];
+  const sourceLayers = Array.isArray(input.layers) ? input.layers : [];
   for (let index = 0; index < FALLBACK_PALETTE.layers.length; index += 1) {
-    const candidate = requestedLayers[index];
+    const candidate = sourceLayers[index];
     result.layers.push(typeof candidate === "string" ? candidate : FALLBACK_PALETTE.layers[index]);
   }
 
   return result;
+}
+
+function clonePalette(palette) {
+  return {
+    bg: palette.bg,
+    ink: palette.ink,
+    muted: palette.muted,
+    layers: [...palette.layers]
+  };
 }
 
 function normaliseNumerology(input) {
@@ -227,9 +204,9 @@ function normaliseTree(data) {
   const safe = data && typeof data === "object" ? data : {};
   const fallbackNodes = fallback.nodes;
   const providedNodes = Array.isArray(safe.nodes) && safe.nodes.length > 0 ? safe.nodes : fallbackNodes;
-  const normalisedNodes = providedNodes.map((node, index) => {
+  const nodes = providedNodes.map((node, index) => {
     const base = typeof node === "object" && node !== null ? node : {};
-    const reference = fallbackNodes.find((fallbackNode) => fallbackNode.id === base.id) || fallbackNodes[index % fallbackNodes.length];
+    const reference = fallbackNodes.find((item) => item.id === base.id) || fallbackNodes[index % fallbackNodes.length];
     return {
       id: typeof base.id === "string" && base.id ? base.id : reference.id,
       title: typeof base.title === "string" && base.title ? base.title : reference.title,
@@ -239,10 +216,10 @@ function normaliseTree(data) {
     };
   });
 
-  const nodeIds = new Set(normalisedNodes.map((node) => node.id));
-  const edgesSource = Array.isArray(safe.edges) && safe.edges.length > 0 ? safe.edges : fallback.edges;
-  const normalisedEdges = edgesSource
-    .map((edge) => Array.isArray(edge) ? edge.slice(0, 2) : [])
+  const nodeIds = new Set(nodes.map((node) => node.id));
+  const sourceEdges = Array.isArray(safe.edges) && safe.edges.length > 0 ? safe.edges : fallback.edges;
+  const edges = sourceEdges
+    .map((edge) => (Array.isArray(edge) ? edge.slice(0, 2) : []))
     .filter((edge) => edge.length === 2 && nodeIds.has(edge[0]) && nodeIds.has(edge[1]));
 
   return {
@@ -250,8 +227,8 @@ function normaliseTree(data) {
     radiusDivisor: positiveNumber(safe.radiusDivisor, fallback.radiusDivisor),
     labelOffset: finiteNumber(safe.labelOffset, fallback.labelOffset),
     labelFont: typeof safe.labelFont === "string" && safe.labelFont ? safe.labelFont : fallback.labelFont,
-    nodes: normalisedNodes,
-    edges: normalisedEdges
+    nodes,
+    edges
   };
 }
 
@@ -290,8 +267,10 @@ function drawVesicaField(ctx, width, height, color, N, settings) {
   const rows = Math.max(2, settings.rows);
   const columns = Math.max(2, settings.columns);
   const padding = Math.min(width, height) / settings.paddingDivisor;
-  const stepX = columns > 1 ? (width - padding * 2) / (columns - 1) : 0;
-  const stepY = rows > 1 ? (height - padding * 2) / (rows - 1) : 0;
+  const horizontalSpan = width - padding * 2;
+  const verticalSpan = height - padding * 2;
+  const stepX = columns > 1 ? horizontalSpan / (columns - 1) : 0;
+  const stepY = rows > 1 ? verticalSpan / (rows - 1) : 0;
   const radius = Math.min(stepX, stepY) / settings.radiusFactor;
   const strokeWidth = Math.max(1, Math.min(width, height) / settings.strokeDivisor);
 
@@ -302,245 +281,115 @@ function drawVesicaField(ctx, width, height, color, N, settings) {
 
   for (let row = 0; row < rows; row += 1) {
     const offset = row % 2 === 0 ? 0 : stepX / 2;
-    for (let col = 0; col < columns; col += 1) {
-      const x = padding + offset + col * stepX;
-      if (x < padding || x > width - padding) {
-        continue;
-      }
+    for (let column = 0; column < columns; column += 1) {
+      const x = padding + offset + column * stepX;
       const y = padding + row * stepY;
       ctx.beginPath();
       ctx.arc(x, y, radius, 0, Math.PI * 2);
       ctx.stroke();
-
-  drawVesicaField(ctx, width, height, palette.layers[0], numerology);
-  drawTreeOfLife(ctx, width, height, palette.layers[1], palette.layers[2], numerology, palette.ink);
-  drawFibonacciCurve(ctx, width, height, palette.layers[3], numerology);
-  drawHelixLattice(ctx, width, height, palette.layers[4], palette.layers[5], numerology);
-
-  if (notice) {
-    drawNotice(ctx, width, height, palette.ink, notice, numerology);
+    }
   }
 
   ctx.restore();
-  return { ok: true, palette, numerology };
 }
 
-function toNumber(value, fallback) {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : fallback;
-}
+function drawTreeOfLife(ctx, width, height, edgeColor, nodeColor, labelColor, N, settings) {
+  const margin = Math.min(width, height) / settings.marginDivisor;
+  const top = margin;
+  const bottom = height - margin;
+  const left = margin;
+  const right = width - margin;
+  const verticalSpan = bottom - top;
+  const horizontalSpan = right - left;
+  const radius = Math.max(4, Math.min(width, height) / settings.radiusDivisor);
+  const lineWidth = Math.max(1, Math.min(width, height) / N.NINETYNINE);
 
-function normalisePalette(input) {
-  const source = input && typeof input === "object" ? input : {};
-  const candidateLayers = Array.isArray(source.layers) ? source.layers : [];
-  const layers = DEFAULT_PALETTE.layers.map((color, index) => {
-    const candidate = candidateLayers[index];
-    return typeof candidate === "string" && candidate.trim() ? candidate : color;
+  const maxLevel = settings.nodes.reduce((acc, node) => Math.max(acc, node.level), 0);
+  const levelStep = maxLevel > 0 ? verticalSpan / maxLevel : 0;
+
+  const positions = new Map();
+  settings.nodes.forEach((node) => {
+    const x = left + clamp01(node.xFactor) * horizontalSpan;
+    const y = top + node.level * levelStep;
+    positions.set(node.id, { x, y, node });
   });
 
-  return {
-    bg: pickColor(source.bg, DEFAULT_PALETTE.bg),
-    ink: pickColor(source.ink, DEFAULT_PALETTE.ink),
-    muted: pickColor(source.muted, DEFAULT_PALETTE.muted),
-    layers
-  };
-}
-
-function pickColor(candidate, fallback) {
-  return typeof candidate === "string" && candidate.trim() ? candidate : fallback;
-}
-
-function normaliseNumerology(source) {
-  const data = source && typeof source === "object" ? source : {};
-  const result = {};
-  for (const key of Object.keys(DEFAULT_NUM)) {
-    const value = Number(data[key]);
-    result[key] = Number.isFinite(value) ? value : DEFAULT_NUM[key];
-  }
-  return result;
-}
-
-function fillBackground(ctx, width, height, color) {
+  // Calm connective lines first (why: keeps lattice behind node glyphs).
   ctx.save();
-  ctx.fillStyle = color;
-  ctx.fillRect(0, 0, width, height);
-  ctx.restore();
-}
-
-function drawVesicaField(ctx, width, height, color, N) {
-  const columns = Math.max(3, Math.round(N.NINE));
-  const rows = Math.max(3, Math.round(N.SEVEN));
-  const xGap = width / (columns + 1);
-  const yGap = height / (rows + 1);
-  const radius = Math.min(xGap, yGap) * 0.66;
-  const lineWidth = Math.max(1, radius / (N.THIRTYTHREE || DEFAULT_NUM.THIRTYTHREE));
-
-  ctx.save();
-  ctx.strokeStyle = color;
+  ctx.strokeStyle = edgeColor;
   ctx.lineWidth = lineWidth;
-  ctx.globalAlpha = 0.35;
-  // Gentle alpha keeps overlapping vesica forms soft for ND-safe viewing.
-
-  for (let row = 0; row < rows; row += 1) {
-    const cy = yGap + row * yGap;
-    for (let col = 0; col < columns; col += 1) {
-      const cx = xGap + col * xGap;
-      strokeCircle(ctx, cx, cy, radius);
-      strokeCircle(ctx, cx + xGap / 2, cy, radius);
-      strokeCircle(ctx, cx, cy + yGap / 2, radius);
-
-    }
-  }
-
-  ctx.restore();
-}
-
-function drawTreeOfLife(ctx, width, height, pathColor, nodeColor, labelColor, N, tree) {
-  const marginY = height / tree.marginDivisor;
-  const radius = Math.min(width, height) / tree.radiusDivisor;
-
-  const uniqueLevels = Array.from(new Set(tree.nodes.map((node) => node.level))).sort((a, b) => a - b);
-  const levelCount = uniqueLevels.length;
-  const usableHeight = height - marginY * 2;
-  const levelPositions = new Map();
-  uniqueLevels.forEach((level, index) => {
-    const ratio = levelCount > 1 ? index / (levelCount - 1) : 0;
-    levelPositions.set(level, marginY + usableHeight * ratio);
-  });
-
-  const positionedNodes = tree.nodes.map((node) => {
-    const y = levelPositions.get(node.level) ?? (height / 2);
-    const x = clamp01(node.xFactor) * width;
-    return { ...node, x, y };
-  });
-
-  const nodeMap = new Map(positionedNodes.map((node) => [node.id, node]));
-
-  ctx.save();
-  ctx.strokeStyle = pathColor;
-  ctx.lineWidth = Math.max(1.5, Math.min(width, height) / N.NINETYNINE * 1.5);
   ctx.globalAlpha = 0.75;
-
-  for (const [fromId, toId] of tree.edges) {
-    const fromNode = nodeMap.get(fromId);
-    const toNode = nodeMap.get(toId);
-    if (!fromNode || !toNode) {
-      continue;
+  ctx.lineCap = "round";
+  settings.edges.forEach((edge) => {
+    const start = positions.get(edge[0]);
+    const end = positions.get(edge[1]);
+    if (!start || !end) {
+      return;
     }
     ctx.beginPath();
-    ctx.moveTo(fromNode.x, fromNode.y);
-    ctx.lineTo(toNode.x, toNode.y);
+    ctx.moveTo(start.x, start.y);
+    ctx.lineTo(end.x, end.y);
     ctx.stroke();
-  }
+  });
+  ctx.restore();
 
+  // Nodes overlay edges so depth stays readable.
+  ctx.save();
   ctx.fillStyle = nodeColor;
-  ctx.globalAlpha = 1;
-  for (const node of positionedNodes) {
-=======
-function strokeCircle(ctx, cx, cy, radius) {
-  ctx.beginPath();
-  ctx.arc(cx, cy, radius, 0, Math.PI * 2);
-  ctx.stroke();
-}
-
-function drawTreeOfLife(ctx, width, height, pathColor, nodeColor, N, ink) {
-  const topMargin = height / (N.ELEVEN || DEFAULT_NUM.ELEVEN);
-  const usableHeight = height - topMargin * 2;
-  const levelGap = usableHeight / (N.NINE || DEFAULT_NUM.NINE);
-  const centerX = width / 2;
-  const columnSpread = width / (N.THREE + N.SEVEN / 10);
-  const nodeRadius = Math.max(4, Math.min(width, height) / (N.NINETYNINE || DEFAULT_NUM.NINETYNINE));
-
-  const layout = [
-    { level: 0, shift: 0 },
-    { level: 1, shift: 1 },
-    { level: 1, shift: -1 },
-    { level: 3, shift: 0.9 },
-    { level: 3, shift: -0.9 },
-    { level: 4.5, shift: 0 },
-    { level: 6, shift: 0.85 },
-    { level: 6, shift: -0.85 },
-    { level: 7.4, shift: 0 },
-    { level: 9, shift: 0 }
-  ];
-
-  const nodes = layout.map((item) => ({
-    x: centerX + item.shift * columnSpread,
-    y: topMargin + item.level * levelGap
-  }));
-
-  const paths = [
-    [0, 1], [0, 2], [0, 5], [1, 2], [1, 5], [1, 3], [2, 5], [2, 4], [3, 4], [3, 5], [3, 6],
-    [4, 5], [4, 7], [5, 6], [5, 7], [6, 7], [6, 8], [7, 8], [5, 8], [8, 9], [6, 9], [7, 9]
-  ];
+  ctx.strokeStyle = labelColor;
+  ctx.lineWidth = Math.max(1, lineWidth * 0.75);
+  settings.nodes.forEach((node) => {
+    const point = positions.get(node.id);
+    if (!point) {
+      return;
+    }
+    ctx.beginPath();
+    ctx.arc(point.x, point.y, radius, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.stroke();
+  });
+  ctx.restore();
 
   ctx.save();
-  ctx.strokeStyle = pathColor;
-  ctx.lineWidth = Math.max(1, nodeRadius / (N.TWENTYTWO || DEFAULT_NUM.TWENTYTWO));
-  ctx.globalAlpha = 0.6;
-  // Calm line weight highlights twenty-two paths without overpowering the nodes.
-
-  for (const [fromIndex, toIndex] of paths) {
-    const from = nodes[fromIndex];
-    const to = nodes[toIndex];
-    ctx.beginPath();
-    ctx.moveTo(from.x, from.y);
-    ctx.lineTo(to.x, to.y);
-    ctx.stroke();
-  }
-
-  ctx.globalAlpha = 0.9;
-  // Nodes stay opaque to anchor focus while paths remain translucent.
-  ctx.fillStyle = nodeColor;
-  ctx.strokeStyle = ink;
-  ctx.lineWidth = Math.max(1, nodeRadius / (N.THIRTYTHREE || DEFAULT_NUM.THIRTYTHREE));
-
-  for (const node of nodes) {
-
-    ctx.beginPath();
-    ctx.arc(node.x, node.y, radius, 0, Math.PI * 2);
-    ctx.fill();
-
-  }
-
   ctx.fillStyle = labelColor;
-  ctx.globalAlpha = 0.85;
-  ctx.font = tree.labelFont;
+  ctx.font = settings.labelFont;
   ctx.textAlign = "center";
   ctx.textBaseline = "middle";
-  for (const node of positionedNodes) {
-    const label = node.meaning || node.title;
-    const labelY = node.y + tree.labelOffset;
-    ctx.fillText(label, node.x, labelY);
-
-    ctx.stroke();
-
-  }
-
+  settings.nodes.forEach((node) => {
+    const point = positions.get(node.id);
+    if (!point) {
+      return;
+    }
+    const labelY = point.y + settings.labelOffset;
+    ctx.fillText(node.title, point.x, labelY);
+  });
   ctx.restore();
 }
 
-
 function drawFibonacciCurve(ctx, width, height, color, N, settings) {
-  const sampleCount = Math.max(2, settings.sampleCount);
-  const centerX = width / 2;
-  const centerY = height / 2;
-  const baseRadius = Math.min(width, height) / settings.baseRadiusDivisor;
+  const count = Math.max(2, settings.sampleCount);
   const turns = settings.turns;
   const phi = settings.phi;
+  const angleTotal = turns * Math.PI * 2;
+  const growth = Math.pow(phi, turns);
+  const maxRadius = Math.min(width, height) / settings.baseRadiusDivisor;
+  const baseRadius = maxRadius / growth;
+  const centerX = width / 2;
+  const centerY = height / 2;
+  const strokeWidth = Math.max(1, Math.min(width, height) / N.NINETYNINE);
 
   ctx.save();
   ctx.strokeStyle = color;
-  ctx.lineWidth = Math.max(1.5, Math.min(width, height) / N.NINETYNINE * 1.2);
+  ctx.lineWidth = strokeWidth;
   ctx.globalAlpha = settings.alpha;
   ctx.beginPath();
 
-  for (let index = 0; index < sampleCount; index += 1) {
-    const t = index / (sampleCount - 1);
-    const angle = t * turns * Math.PI * 2;
-    const radius = baseRadius * Math.pow(phi, angle / (Math.PI * 2));
-    const x = centerX + radius * Math.cos(angle);
-    const y = centerY + radius * Math.sin(angle);
+  for (let index = 0; index < count; index += 1) {
+    const t = count > 1 ? index / (count - 1) : 0;
+    const angle = t * angleTotal;
+    const radius = baseRadius * Math.pow(phi, t * turns);
+    const x = centerX + Math.cos(angle) * radius;
+    const y = centerY + Math.sin(angle) * radius;
     if (index === 0) {
       ctx.moveTo(x, y);
     } else {
@@ -553,150 +402,87 @@ function drawFibonacciCurve(ctx, width, height, color, N, settings) {
 }
 
 function drawHelixLattice(ctx, width, height, strandColor, rungColor, N, settings) {
-  const samples = Math.max(2, settings.sampleCount);
-  const marginX = width / DEFAULT_NUM.ELEVEN;
-  const usableWidth = width - marginX * 2;
-  const centerY = height / 2;
-  const amplitude = height / settings.amplitudeDivisor;
+  const count = Math.max(2, settings.sampleCount);
   const cycles = settings.cycles;
-  const strandThickness = Math.max(1.5, Math.min(width, height) / N.NINETYNINE * 1.4);
-  const rungStep = Math.max(2, Math.floor(samples / Math.max(1, settings.crossTieCount)));
-  const phaseRadians = (settings.phaseOffset * Math.PI) / 180;
-
+  const amplitude = Math.min(width, height) / settings.amplitudeDivisor;
+  const phase = (settings.phaseOffset * Math.PI) / 180;
+  const topMargin = Math.min(width, height) / N.NINE;
+  const bottomMargin = topMargin;
+  const usableHeight = height - topMargin - bottomMargin;
+  const strokeWidth = Math.max(1, Math.min(width, height) / N.NINETYNINE);
   const strandA = [];
   const strandB = [];
-  for (let index = 0; index < samples; index += 1) {
-    const t = index / (samples - 1);
-    const x = marginX + t * usableWidth;
+
+  for (let index = 0; index < count; index += 1) {
+    const t = count > 1 ? index / (count - 1) : 0;
     const angle = t * cycles * Math.PI * 2;
-    const yA = centerY + Math.sin(angle) * amplitude * 0.4;
-    const yB = centerY + Math.sin(angle + phaseRadians) * amplitude * 0.4;
-    strandA.push({ x, y: yA });
-    strandB.push({ x, y: yB });
+    const y = topMargin + t * usableHeight;
+    const centerX = width / 2;
+    const xA = centerX + Math.sin(angle) * amplitude;
+    const xB = centerX + Math.sin(angle + phase) * amplitude;
+    strandA.push({ x: xA, y });
+    strandB.push({ x: xB, y });
   }
 
   ctx.save();
-  ctx.lineWidth = strandThickness;
-  ctx.strokeStyle = strandColor;
+  ctx.lineWidth = strokeWidth;
   ctx.globalAlpha = settings.strandAlpha;
-  strokePolyline(ctx, strandA);
-  strokePolyline(ctx, strandB);
+  ctx.strokeStyle = strandColor;
+  drawPolyline(ctx, strandA);
+  drawPolyline(ctx, strandB);
+  ctx.restore();
 
-  ctx.strokeStyle = rungColor;
-  ctx.lineWidth = Math.max(1, strandThickness * 0.6);
+  const rungCount = settings.crossTieCount;
+  ctx.save();
+  ctx.lineWidth = strokeWidth * 0.85;
   ctx.globalAlpha = settings.rungAlpha;
-  for (let index = 0; index < samples; index += rungStep) {
-    const a = strandA[index];
-    const b = strandB[index];
-    if (!a || !b) {
+  ctx.strokeStyle = rungColor;
+  for (let rung = 0; rung < rungCount; rung += 1) {
+    const t = rungCount > 1 ? rung / (rungCount - 1) : 0;
+    const index = Math.floor(t * (count - 1));
+    const start = strandA[index];
+    const end = strandB[index];
+    if (!start || !end) {
       continue;
     }
     ctx.beginPath();
-    ctx.moveTo(a.x, a.y);
-    ctx.lineTo(b.x, b.y);
+    ctx.moveTo(start.x, start.y);
+    ctx.lineTo(end.x, end.y);
     ctx.stroke();
-
-function drawFibonacciCurve(ctx, width, height, color, N) {
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const steps = Math.max(12, Math.round(N.ONEFORTYFOUR || DEFAULT_NUM.ONEFORTYFOUR));
-  const rotations = (N.THIRTYTHREE || DEFAULT_NUM.THIRTYTHREE) / (N.ELEVEN || DEFAULT_NUM.ELEVEN);
-  const thetaMax = rotations * Math.PI * 2;
-
-  const rawPoints = [];
-  for (let index = 0; index < steps; index += 1) {
-    const t = steps <= 1 ? 0 : index / (steps - 1);
-    const theta = t * thetaMax;
-    const radius = Math.pow(phi, theta / Math.PI);
-    const rotatedTheta = theta - Math.PI / 2;
-    rawPoints.push({
-      x: radius * Math.cos(rotatedTheta),
-      y: radius * Math.sin(rotatedTheta)
-    });
   }
-
-  const bounds = measureBounds(rawPoints);
-  const rangeX = bounds.maxX - bounds.minX || 1;
-  const rangeY = bounds.maxY - bounds.minY || 1;
-  const scale = 0.4 * Math.min(width / rangeX, height / rangeY);
-  const centerX = (bounds.minX + bounds.maxX) / 2;
-  const centerY = (bounds.minY + bounds.maxY) / 2;
-
-  const points = rawPoints.map((point) => ({
-    x: width / 2 + (point.x - centerX) * scale,
-    y: height / 2 + (point.y - centerY) * scale
-  }));
-
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = Math.max(1.5, Math.min(width, height) / (N.ONEFORTYFOUR || DEFAULT_NUM.ONEFORTYFOUR));
-  ctx.globalAlpha = 0.85;
-  // Polyline sampling is static, keeping the Fibonacci growth readable without motion.
-  drawPolyline(ctx, points);
-
-  const markerInterval = Math.max(6, Math.floor(points.length / (N.TWENTYTWO || DEFAULT_NUM.TWENTYTWO)));
-  ctx.fillStyle = color;
-  ctx.globalAlpha = 0.75;
-  for (let index = 0; index < points.length; index += markerInterval) {
-    const point = points[index];
-    ctx.beginPath();
-    ctx.arc(point.x, point.y, Math.max(2, ctx.lineWidth * 0.9), 0, Math.PI * 2);
-    ctx.fill();
-
-  }
-
   ctx.restore();
-}
-
-function strokePolyline(ctx, points) {
-  if (!Array.isArray(points) || points.length === 0) {
-    return;
-  }
-  ctx.beginPath();
-  ctx.moveTo(points[0].x, points[0].y);
-  for (let index = 1; index < points.length; index += 1) {
-    ctx.lineTo(points[index].x, points[index].y);
-
-function measureBounds(points) {
-  let minX = Infinity;
-  let minY = Infinity;
-  let maxX = -Infinity;
-  let maxY = -Infinity;
-  for (const point of points) {
-    if (point.x < minX) minX = point.x;
-    if (point.x > maxX) maxX = point.x;
-    if (point.y < minY) minY = point.y;
-    if (point.y > maxY) maxY = point.y;
-  }
-  if (!points.length) {
-    minX = minY = maxX = maxY = 0;
-  }
-  return { minX, minY, maxX, maxY };
 }
 
 function drawPolyline(ctx, points) {
-  if (points.length < 2) {
+  if (!points || points.length === 0) {
     return;
   }
   ctx.beginPath();
-  ctx.moveTo(points[0].x, points[0].y);
-  for (let index = 1; index < points.length; index += 1) {
-    const point = points[index];
-    ctx.lineTo(point.x, point.y);
-
-  }
+  points.forEach((point, index) => {
+    if (index === 0) {
+      ctx.moveTo(point.x, point.y);
+    } else {
+      ctx.lineTo(point.x, point.y);
+    }
+  });
   ctx.stroke();
 }
 
-
-function drawNotice(ctx, width, height, ink, message) {
+function drawNotice(ctx, width, height, color, message) {
+  const padding = 12;
   ctx.save();
-  ctx.fillStyle = ink;
-  ctx.globalAlpha = 0.75;
-  ctx.font = "14px system-ui, -apple-system, Segoe UI, sans-serif";
+  ctx.globalAlpha = 0.9;
+  ctx.fillStyle = color;
+  ctx.font = "12px system-ui, -apple-system, Segoe UI, sans-serif";
   ctx.textAlign = "left";
   ctx.textBaseline = "bottom";
-  ctx.fillText(message, width / 33, height - height / 22);
+  ctx.fillText(message, padding, height - padding);
   ctx.restore();
+}
+
+function toNumber(value, fallback) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : Number(fallback);
 }
 
 function positiveNumber(value, fallback) {
@@ -705,8 +491,8 @@ function positiveNumber(value, fallback) {
 }
 
 function positiveInteger(value, fallback) {
-  const number = Math.floor(Number(value));
-  return Number.isFinite(number) && number > 0 ? number : fallback;
+  const number = Number(value);
+  return Number.isInteger(number) && number > 0 ? number : fallback;
 }
 
 function finiteNumber(value, fallback) {
@@ -714,112 +500,30 @@ function finiteNumber(value, fallback) {
   return Number.isFinite(number) ? number : fallback;
 }
 
+function clamp01(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    return 0;
+  }
+  if (number < 0) {
+    return 0;
+  }
+  if (number > 1) {
+    return 1;
+  }
+  return number;
+}
+
 function clampAlpha(value, fallback) {
   const number = Number(value);
-  if (Number.isFinite(number)) {
-    return clamp(number, 0, 1);
+  if (!Number.isFinite(number)) {
+    return fallback;
   }
-  return clamp(fallback, 0, 1);
-}
-
-function clamp01(value) {
-  return clamp(value, 0, 1);
-}
-
-function clamp(value, min, max) {
-  if (value < min) {
-    return min;
+  if (number < 0) {
+    return 0;
   }
-  if (value > max) {
-    return max;
+  if (number > 1) {
+    return 1;
   }
-  return value;
-
-function drawHelixLattice(ctx, width, height, colorA, colorB, N) {
-  const samples = Math.max(12, Math.round(N.ONEFORTYFOUR || DEFAULT_NUM.ONEFORTYFOUR));
-  const marginX = width / (N.ELEVEN || DEFAULT_NUM.ELEVEN);
-  const usableWidth = width - marginX * 2;
-  const centerY = height * 0.62;
-  const amplitude = height / (N.THREE + N.NINE / 9);
-  const angleScale = (N.THIRTYTHREE || DEFAULT_NUM.THIRTYTHREE) / (N.ELEVEN || DEFAULT_NUM.ELEVEN) * Math.PI;
-
-  const strandA = [];
-  const strandB = [];
-  for (let index = 0; index < samples; index += 1) {
-    const t = samples <= 1 ? 0 : index / (samples - 1);
-    const x = marginX + t * usableWidth;
-    const angle = t * angleScale;
-    const yA = centerY + Math.sin(angle) * amplitude * 0.3;
-    const yB = centerY + Math.sin(angle + Math.PI) * amplitude * 0.3;
-    strandA.push({ x, y: yA });
-    strandB.push({ x, y: yB });
-  }
-
-  ctx.save();
-  ctx.lineWidth = Math.max(1.5, Math.min(width, height) / (N.NINETYNINE || DEFAULT_NUM.NINETYNINE));
-  ctx.globalAlpha = 0.75;
-  // Twin strands use small amplitude so the lattice reads clearly without overstimulation.
-  ctx.strokeStyle = colorA;
-  drawPolyline(ctx, strandA);
-  ctx.strokeStyle = colorB;
-  drawPolyline(ctx, strandB);
-
-  const rungSpacing = Math.max(2, Math.floor(samples / (N.TWENTYTWO || DEFAULT_NUM.TWENTYTWO)));
-  ctx.globalAlpha = 0.55;
-  // Rungs bind the helix at a slow cadence (22 segments) to mirror the requested numerology.
-  ctx.strokeStyle = colorB;
-  for (let index = 0; index < samples; index += rungSpacing) {
-    const a = strandA[index];
-    const b = strandB[index];
-    ctx.beginPath();
-    ctx.moveTo(a.x, a.y);
-    ctx.lineTo(b.x, b.y);
-    ctx.stroke();
-  }
-
-  ctx.restore();
-}
-
-function drawNotice(ctx, width, height, ink, text, N) {
-  const margin = width / (N.TWENTYTWO || DEFAULT_NUM.TWENTYTWO);
-  const lineHeight = 16;
-  const lines = wrapNotice(text, 44);
-
-  ctx.save();
-  ctx.fillStyle = ink;
-  ctx.globalAlpha = 0.75;
-  // Notice text offers gentle feedback if external data is missing.
-  ctx.font = "14px system-ui, -apple-system, Segoe UI, sans-serif";
-  ctx.textBaseline = "alphabetic";
-
-  lines.forEach((line, index) => {
-    const y = height - margin - (lines.length - 1 - index) * lineHeight;
-    ctx.fillText(line, margin, y);
-  });
-
-  ctx.restore();
-}
-
-function wrapNotice(text, maxChars) {
-  const safeText = text.trim();
-  if (!safeText) {
-    return [];
-  }
-  const words = safeText.split(/\s+/);
-  const lines = [];
-  let current = "";
-  for (const word of words) {
-    const candidate = current ? current + " " + word : word;
-    if (candidate.length > maxChars && current) {
-      lines.push(current);
-      current = word;
-    } else {
-      current = candidate;
-    }
-  }
-  if (current) {
-    lines.push(current);
-  }
-  return lines;
-
+  return number;
 }


### PR DESCRIPTION
## Summary
- replace the cosmic helix index with a lean offline entry point that loads the palette, reports fallback status, and invokes the renderer once
- rebuild the helix renderer module with pure helpers for vesica, tree-of-life, fibonacci, and helix layers plus safe fallbacks
- refresh the renderer README to document usage, layer order, and ND-safe choices

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb5e7969088328acec9bd0aa9bce87

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Offline, single-pass Cosmic Helix Renderer with a simplified palette system and fallback when palette.json is missing (status notice shown).
  - Clear layer order rendering: Vesica field, Tree-of-Life, Fibonacci curve, and Double-helix lattice.
- Refactor
  - Replaced multi-section UI with a lean page: header, status, and a single canvas.
  - Streamlined initialization and rendering flow; no external data dependencies.
- Style
  - Minimal theme variables (bg, ink, muted, outline) and lighter visuals.
- Documentation
  - README updated to reflect offline capsule usage and safe customization options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->