### PR TITLE
Implement ND-safe renderer and calm-mode homepage

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,28 +1,27 @@
 # Cosmic Helix Renderer
 
-
-Static, offline renderer that layers Vesica geometry, Tree-of-Life scaffolding, a Fibonacci-inspired curve, and a static double-helix lattice. Designed for ND-safe review: calm palette, no animation, generous spacing, and comments that explain numerology-driven decisions.
+Static, offline-first canvas renderer that layers Vesica geometry, the Tree-of-Life scaffold, a Fibonacci-inspired curve, and a static double-helix lattice. Designed for ND-safe review: calm palette, no motion, generous spacing, and inline comments that explain the numerology-driven proportions.
 
 ## Files
 
-- `index.html` — entry point. Open directly in any modern browser (double-click). Loads palette data when available and falls back safely if the JSON cannot be read.
-- `js/helix-renderer.mjs` — pure ES module with the drawing routines. Accepts a canvas 2D context plus palette and numerology constants.
-- `data/palette.json` — optional local palette override. Edit colors to suit the atelier; renderer falls back to built-in hues if this file is missing or blocked by the browser.
+- `index.html` - entry point. Open directly in any modern browser (double-click). Loads palette data when available and falls back safely if the JSON cannot be read.
+- `js/helix-renderer.mjs` - pure ES module with the drawing routines. Accepts a canvas 2D context plus palette and numerology constants.
+- `data/palette.json` - optional local palette override. Edit colors to suit the atelier; the renderer falls back to built-in hues if this file is missing or blocked by the browser.
 
 ## Usage
 
 1. Download or clone the repository.
 2. Double-click `index.html` (no server, no build step).
-3. If you edit `data/palette.json`, refresh the page. Browsers that restrict `fetch` over the `file://` protocol will automatically use the fallback palette and display a notice in the header.
+3. If you edit `data/palette.json`, refresh the page. Browsers that restrict `fetch` over the `file://` protocol automatically use the fallback palette and display a notice in the header.
 
 ## Layer order
 
-1. **Vesica field** — Seven by three lattice of intersecting circles, softened alpha to avoid visual overload.
-2. **Tree-of-Life scaffold** — Ten sephirot nodes with twenty-two paths mapped to numerology constants.
-3. **Fibonacci curve** — Static polyline grown from Fibonacci numbers up to 144, preserving a harmonic spiral without motion.
-4. **Double-helix lattice** — Two offset strands with lattice rungs rendered at regular intervals; no animation.
+1. **Vesica field** - seven by three lattice of intersecting circles, softened alpha to avoid visual overload.
+2. **Tree-of-Life scaffold** - ten sephirot nodes with twenty-two paths mapped to numerology constants.
+3. **Fibonacci curve** - static polyline grown from Fibonacci numbers up to 144, preserving a harmonic spiral without motion.
+4. **Double-helix lattice** - two offset strands with lattice rungs rendered at regular intervals; no animation.
 
-Each routine uses the constants `{3, 7, 9, 11, 22, 33, 99, 144}` so the geometry remains parameterized by the numerology canon.
+Each routine uses the constants {3, 7, 9, 11, 22, 33, 99, 144} so the geometry remains parameterised by the numerology canon.
 
 ## Accessibility & ND-safe rationale
 
@@ -36,41 +35,3 @@ Each routine uses the constants `{3, 7, 9, 11, 22, 33, 99, 144}` so the geometry
 - Change the palette by editing `data/palette.json` (hex strings). All colors cascade through the four layers.
 - Adjust numerology constants in `index.html` before calling `renderHelix` if alternative sacred ratios are needed.
 - Geometry logic is modular; duplicate and adapt the helper functions in `js/helix-renderer.mjs` to compose new scenes while keeping layers discrete.
-=======
-Static, offline-first canvas renderer expressing the layered cosmology brief. This module has no dependencies, no build step, and respects ND-safe requirements (calm palette, no motion, readable contrast).
-
-## Files
-
-- `index.html` — entry point with inline module loader and status messaging.
-- `js/helix-renderer.mjs` — pure ES module that renders the four geometry layers.
-- `data/palette.json` — optional palette override loaded locally; safe fallback is used when missing.
-
-## Run Locally (Offline)
-
-1. Ensure the three files above remain in the same relative directories.
-2. Double-click `index.html` (or open via `File → Open` in any modern browser).
-3. The canvas renders at 1440×900 pixels; resizing the window preserves aspect by letterboxing.
-
-No servers, bundlers, or network connections are required.
-
-## Geometry Layers
-
-1. **Vesica Field** — intersecting circles and 22 translucent petals establish the vesica matrix.
-2. **Tree of Life** — 10 sephirot nodes linked by 22 paths, positioned with numerology-friendly spacing.
-3. **Fibonacci Curve** — static log-spiral polyline scaled with the golden ratio and numerology constants.
-4. **Double Helix Lattice** — two sine-wave rails plus 22 cross-braces form a steady lattice, no animation.
-
-The renderer uses numerology constants \(3, 7, 9, 11, 22, 33, 99, 144\) to drive proportions, segment counts, and lattice density. Comments within the module explain how each layer applies these values.
-
-## Palette and Accessibility
-
-- Modify `data/palette.json` to tune the palette while keeping ND-safe contrast.
-- If the JSON file is missing or invalid, the inline script logs a gentle notice and falls back to a safe palette.
-- All drawing functions prioritise soft gradients, moderate line weights, and static composition to avoid sensory overload.
-
-## Extending Safely
-
-- Add new layers by composing additional pure functions in `helix-renderer.mjs` and calling them from `renderHelix`.
-- Keep any geometry static and document the intent inline so future maintainers understand the ND-safe choices.
-- Avoid introducing external libraries, build tooling, or animated effects.
-

--- a/data/palette.json
+++ b/data/palette.json
@@ -8,22 +8,5 @@
     "#f7c687",
     "#e3a4ff",
     "#bfc3e6"
-
-  "fuchs_palette": {
-    "gold": [219, 184, 67],
-    "violet": [108, 52, 131],
-    "turquoise": [26, 188, 156],
-    "sapphire": [41, 128, 185]
-  },
-  "bg": "#080914",
-  "ink": "#f4f7ff",
-  "layers": [
-    "#7fa8ff",
-    "#6fe1f3",
-    "#8ef0c1",
-    "#ffd79b",
-    "#f3aefc",
-    "#d5d8ff"
-
   ]
 }

--- a/index.html
+++ b/index.html
@@ -6,84 +6,20 @@
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
   <meta name="color-scheme" content="light dark">
   <style>
-
     /* ND-safe: calm contrast, no motion, generous spacing */
     :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
-    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
     header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
-    .status { color:var(--muted); font-size:12px; margin-top:4px; }
+    .status { color:var(--muted); font-size:12px; }
     #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
-    .note { max-width:900px; margin:0 auto 16px; color:var(--muted); padding:0 16px; }
+    .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
     code { background:#11111a; padding:2px 4px; border-radius:3px; }
-
-    /* ND-safe: calm contrast, no motion, layered layout for gentle focus */
-    :root {
-      --bg:#0b0b12;
-      --ink:#e8e8f0;
-      --muted:#a6a6c1;
-      --panel:#111120;
-      --ring:#1b1b2d;
-    }
-    html, body {
-      margin:0;
-      padding:0;
-      background:var(--bg);
-      color:var(--ink);
-      font:15px/1.5 system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
-    }
-    header {
-      padding:16px 20px 12px;
-      border-bottom:1px solid var(--ring);
-      background:linear-gradient(180deg,#16162a,#0b0b12);
-      box-shadow:0 6px 24px rgba(0,0,0,0.35);
-    }
-    header h1 {
-      margin:0 0 4px;
-      font-size:1.08rem;
-    }
-    header p {
-      margin:0;
-      color:var(--muted);
-      max-width:720px;
-      font-size:0.95rem;
-    }
-    .status-line {
-      margin-top:8px;
-      color:var(--muted);
-      font-size:0.85rem;
-    }
-    main {
-      padding:20px;
-      display:grid;
-      gap:18px;
-      justify-items:center;
-    }
-    canvas {
-      display:block;
-      width:100%;
-      max-width:1440px;
-      box-shadow:0 0 0 1px var(--ring),0 24px 80px rgba(0,0,0,0.45);
-    }
-    .notice {
-      color:var(--muted);
-      font-size:0.85rem;
-      max-width:960px;
-      text-align:center;
-    }
-    code {
-      padding:1px 5px;
-      border-radius:4px;
-      background:#1a1a2d;
-      color:var(--ink);
-    }
-
   </style>
 </head>
 <body>
   <header>
-
-    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Loading palette…</div>
+    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette...</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
@@ -92,123 +28,37 @@
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
 
-    const statusEl = document.getElementById("status");
+    const elStatus = document.getElementById("status");
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
 
     async function loadJSON(path) {
       try {
-        const response = await fetch(path, { cache: "no-store" });
-        if (!response.ok) throw new Error(String(response.status));
-        return await response.json();
-      } catch (error) {
+        const res = await fetch(path, { cache: "no-store" });
+        if (!res.ok) throw new Error(String(res.status));
+        return await res.json();
+      } catch (err) {
         return null;
       }
     }
 
     const defaults = {
       palette: {
-        bg: "#0b0b12",
-        ink: "#e8e8f0",
-        layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
+        bg:"#0b0b12",
+        ink:"#e8e8f0",
+        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
       }
     };
 
     const palette = await loadJSON("./data/palette.json");
-    const activePalette = palette || defaults.palette;
-    statusEl.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
-    const rootStyle = document.documentElement.style;
-    rootStyle.setProperty("--bg", activePalette.bg);
-    rootStyle.setProperty("--ink", activePalette.ink);
+    const active = palette || defaults.palette;
+    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
 
+    // Numerology constants used by geometry routines
+    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
 
-    <h1>Cosmic Helix Renderer</h1>
-    <p>Static, layered sacred geometry fusing Vesica, Tree-of-Life, Fibonacci, and helix lattice forms. ND-safe palette, zero motion, offline-first.</p>
-    <div class="status-line" id="status" role="status" aria-live="polite">Loading palette…</div>
-  </header>
-  <main>
-    <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-    <p class="notice" id="notice">Open <code>index.html</code> directly; no servers or external networks are required.</p>
-  </main>
-  <script type="module">
-    import { renderHelix } from "./js/helix-renderer.mjs";
-
-    const elStatus = document.getElementById("status");
-    const elNotice = document.getElementById("notice");
-    const canvas = document.getElementById("stage");
-    const ctx = canvas.getContext("2d");
-
-    function setStatus(message) {
-      elStatus.textContent = message;
-    }
-
-    function setNotice(message) {
-      elNotice.textContent = message;
-    }
-
-    async function loadJSON(path) {
-      try {
-        const response = await fetch(path, { cache: "no-store" });
-        if (!response.ok) {
-          throw new Error(`HTTP ${response.status}`);
-        }
-        return await response.json();
-      } catch (error) {
-        console.warn("Palette load fallback", error);
-        return null;
-      }
-    }
-
-    const FALLBACK = {
-      bg: "#0b0b12",
-      ink: "#e8e8f0",
-      layers: ["#8fb8ff", "#7ae6ff", "#9df5c8", "#ffd493", "#f4aaff", "#d8d8f6"]
-    };
-
-
-    const NUM = {
-      THREE: 3,
-      SEVEN: 7,
-      NINE: 9,
-      ELEVEN: 11,
-      TWENTYTWO: 22,
-      THIRTYTHREE: 33,
-      NINETYNINE: 99,
-      ONEFORTYFOUR: 144
-    };
-
-
-    try {
-      renderHelix(ctx, { width: canvas.width, height: canvas.height, palette: activePalette, NUM });
-      statusEl.textContent += " Rendering complete.";
-    } catch (error) {
-      statusEl.textContent = "Renderer error; see console for details.";
-      console.error("Cosmic Helix render error", error);
-
-
-    if (!ctx) {
-      setStatus("Canvas rendering is unavailable in this browser.");
-    } else {
-      const paletteData = await loadJSON("./data/palette.json");
-      const palette = paletteData || FALLBACK;
-      setStatus(paletteData ? "Palette loaded from data/palette.json." : "Palette missing; using safe fallback.");
-      if (!paletteData) {
-        setNotice("Palette data missing — rendering with fallback ND-safe hues.");
-      }
-
-      const result = renderHelix(ctx, {
-        width: canvas.width,
-        height: canvas.height,
-        palette,
-        NUM,
-        notice: paletteData ? null : "Fallback palette in use"
-      });
-
-      if (result && result.summary) {
-        setStatus(`${elStatus.textContent} ${result.summary}`.trim());
-      }
-
-    }
+    // ND-safe rationale: no motion, high readability, soft colors, layered order
+    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
   </script>
 </body>
 </html>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -6,82 +6,45 @@
     1) Vesica field (intersecting circles)
     2) Tree-of-Life scaffold (10 sephirot + 22 paths; simplified layout)
     3) Fibonacci curve (log spiral polyline; static)
-
     4) Double-helix lattice (two phase-shifted strands with lattice rungs)
 
-  Why: encodes layered cosmology with calm colors, zero animation, and clear
-  ordering so each stratum can be visually parsed without overwhelm.
+  Why: encodes layered cosmology with calm colors, zero animation, and
+  comments explaining numerology-driven choices for offline review.
 */
 
-export function renderHelix(ctx, options = {}) {
+const DEFAULT_PALETTE = {
+  bg: "#0b0b12",
+  ink: "#e8e8f0",
+  layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
+};
+
+const DEFAULT_NUMBERS = {
+  THREE: 3,
+  SEVEN: 7,
+  NINE: 9,
+  ELEVEN: 11,
+  TWENTYTWO: 22,
+  THIRTYTHREE: 33,
+  NINETYNINE: 99,
+  ONEFORTYFOUR: 144
+};
+
+export function renderHelix(ctx, input = {}) {
   if (!ctx || typeof ctx.canvas === "undefined") {
     throw new Error("renderHelix requires a 2D canvas context.");
   }
 
-  const dims = normaliseDimensions(ctx, options);
-  const palette = normalisePalette(options.palette);
-  const numbers = normaliseNumbers(options.NUM);
-
+  const config = normaliseConfig(ctx, input);
   ctx.save();
-  ctx.clearRect(0, 0, dims.width, dims.height);
+  clearStage(ctx, config.dims, config.palette.bg);
 
-  paintBackground(ctx, dims, palette);
-  drawVesicaField(ctx, dims, palette, numbers);
-  drawTreeOfLife(ctx, dims, palette, numbers);
-  drawFibonacciCurve(ctx, dims, palette, numbers);
-  drawHelixLattice(ctx, dims, palette, numbers);
+  const vesicaStats = drawVesicaField(ctx, config.dims, config.palette, config.numbers);
+  const treeStats = drawTreeOfLife(ctx, config.dims, config.palette, config.numbers);
+  const fibonacciStats = drawFibonacciCurve(ctx, config.dims, config.palette, config.numbers);
+  const helixStats = drawHelixLattice(ctx, config.dims, config.palette, config.numbers);
 
-  ctx.restore();
-}
-
-function normaliseDimensions(ctx, options) {
-  const width = typeof options.width === "number" ? options.width : ctx.canvas.width;
-  const height = typeof options.height === "number" ? options.height : ctx.canvas.height;
-  return { width, height };
-}
-
-function normalisePalette(rawPalette) {
-  const fallback = {
-    bg: "#0b0b12",
-    ink: "#e8e8f0",
-    layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-  };
-  if (!rawPalette) {
-    return fallback;
-  }
-  const layers = Array.isArray(rawPalette.layers) && rawPalette.layers.length > 0
-    ? rawPalette.layers.slice()
-    : fallback.layers.slice();
-  return {
-    bg: typeof rawPalette.bg === "string" ? rawPalette.bg : fallback.bg,
-    ink: typeof rawPalette.ink === "string" ? rawPalette.ink : fallback.ink,
-
-    4) Double-helix lattice (two phase-shifted sinusoids with cross-braces)
-
-  Geometry is parameterised with numerology constants: 3, 7, 9, 11, 22, 33, 99, 144.
-  All routines are pure and side-effect free aside from drawing to the provided context.
-*/
-
-const DEFAULT_PALETTE = {
-  bg: '#0b0b12',
-  ink: '#e8e8f0',
-  layers: ['#8fb8ff', '#7ae6ff', '#9df5c8', '#ffd493', '#f4aaff', '#d8d8f6']
-};
-
-export function renderHelix(ctx, input) {
-  const { width, height, palette, NUM, notice } = normaliseConfig(input);
-  const dims = { width, height };
-
-  ctx.save();
-  clearStage(ctx, dims, palette.bg);
-
-  const vesicaStats = drawVesicaField(ctx, dims, palette.layers[0], palette.layers[1], NUM);
-  const treeStats = drawTreeOfLife(ctx, dims, palette.layers[2], palette.layers[1], palette.ink, NUM);
-  const fibonacciStats = drawFibonacciCurve(ctx, dims, palette.layers[3], NUM);
-  const helixStats = drawHelixLattice(ctx, dims, palette.layers[4], palette.layers[5], palette.ink, NUM);
-
-  if (notice) {
-    drawCanvasNotice(ctx, dims, palette.ink, notice);
+  if (config.notice) {
+    drawCanvasNotice(ctx, config.dims, config.palette.ink, config.notice);
   }
 
   ctx.restore();
@@ -91,77 +54,60 @@ export function renderHelix(ctx, input) {
   };
 }
 
-function normaliseConfig(input) {
-  const width = typeof input.width === 'number' ? input.width : 1440;
-  const height = typeof input.height === 'number' ? input.height : 900;
+function normaliseConfig(ctx, input) {
+  const width = typeof input.width === "number" ? input.width : ctx.canvas.width;
+  const height = typeof input.height === "number" ? input.height : ctx.canvas.height;
+  const dims = { width, height };
   const palette = mergePalette(input.palette || {});
-  const NUM = input.NUM || defaultNumerology();
-  return { width, height, palette, NUM, notice: input.notice || null };
+  const numbers = mergeNumbers(input.NUM || {});
+  const notice = typeof input.notice === "string" ? input.notice : null;
+  return { dims, palette, numbers, notice };
 }
 
 function mergePalette(candidate) {
-  const baseLayers = DEFAULT_PALETTE.layers;
-  const candidateLayers = Array.isArray(candidate.layers) ? candidate.layers : [];
-  const layers = baseLayers.map((fallback, index) => candidateLayers[index] || fallback);
+  const layers = Array.isArray(candidate.layers) && candidate.layers.length > 0
+    ? candidate.layers.slice(0, DEFAULT_PALETTE.layers.length)
+    : DEFAULT_PALETTE.layers.slice();
+  while (layers.length < DEFAULT_PALETTE.layers.length) {
+    layers.push(DEFAULT_PALETTE.layers[layers.length]);
+  }
   return {
-    bg: candidate.bg || DEFAULT_PALETTE.bg,
-    ink: candidate.ink || DEFAULT_PALETTE.ink,
-
+    bg: typeof candidate.bg === "string" ? candidate.bg : DEFAULT_PALETTE.bg,
+    ink: typeof candidate.ink === "string" ? candidate.ink : DEFAULT_PALETTE.ink,
     layers
   };
 }
 
-
-function normaliseNumbers(raw) {
-  const fallback = {
-
-function defaultNumerology() {
-  return {
-
-    THREE: 3,
-    SEVEN: 7,
-    NINE: 9,
-    ELEVEN: 11,
-    TWENTYTWO: 22,
-    THIRTYTHREE: 33,
-    NINETYNINE: 99,
-    ONEFORTYFOUR: 144
-  };
-
-  if (!raw) {
-    return fallback;
-  }
-  const result = { ...fallback };
-  for (const key of Object.keys(fallback)) {
-    if (typeof raw[key] === "number" && Number.isFinite(raw[key])) {
-      result[key] = raw[key];
+function mergeNumbers(candidate) {
+  const merged = { ...DEFAULT_NUMBERS };
+  for (const key of Object.keys(DEFAULT_NUMBERS)) {
+    if (typeof candidate[key] === "number" && Number.isFinite(candidate[key])) {
+      merged[key] = candidate[key];
     }
   }
-  return result;
+  return merged;
 }
 
-function paintBackground(ctx, dims, palette) {
-  ctx.save();
-  ctx.fillStyle = palette.bg;
+function clearStage(ctx, dims, bg) {
+  ctx.fillStyle = bg;
   ctx.fillRect(0, 0, dims.width, dims.height);
-  ctx.restore();
 }
 
-function drawVesicaField(ctx, dims, palette, NUM) {
+function drawVesicaField(ctx, dims, palette, numbers) {
   ctx.save();
   ctx.globalAlpha = 0.65; // ND-safe softness keeps layer readable without glare.
-  ctx.strokeStyle = getLayerColor(palette, 0, "#b1c7ff");
-  ctx.lineWidth = Math.max(1, dims.width / (NUM.ONEFORTYFOUR * 1.8));
+  ctx.strokeStyle = palette.layers[0];
+  ctx.lineWidth = Math.max(1, dims.width / (numbers.ONEFORTYFOUR * 1.8));
 
-  const rows = NUM.SEVEN;
-  const cols = NUM.THREE;
-  const margin = dims.width / NUM.THIRTYTHREE;
+  const rows = numbers.SEVEN;
+  const cols = numbers.THREE;
+  const margin = dims.width / numbers.THIRTYTHREE;
   const innerWidth = dims.width - margin * 2;
   const innerHeight = dims.height - margin * 2;
   const horizontalStep = cols > 1 ? innerWidth / (cols - 1) : 0;
   const verticalStep = rows > 1 ? innerHeight / (rows - 1) : 0;
-  const radius = Math.min(horizontalStep, verticalStep) * (NUM.NINE / NUM.TWENTYTWO);
-  const offset = radius * (NUM.ELEVEN / NUM.TWENTYTWO);
+  const radius = Math.min(horizontalStep, verticalStep) * (numbers.NINE / numbers.TWENTYTWO);
+  const offset = radius * (numbers.ELEVEN / numbers.TWENTYTWO);
 
   for (let row = 0; row < rows; row += 1) {
     for (let col = 0; col < cols; col += 1) {
@@ -172,6 +118,7 @@ function drawVesicaField(ctx, dims, palette, NUM) {
   }
 
   ctx.restore();
+  return { circles: rows * cols * 2, radius };
 }
 
 function drawVesica(ctx, cx, cy, radius, offset) {
@@ -183,15 +130,15 @@ function drawVesica(ctx, cx, cy, radius, offset) {
   ctx.stroke();
 }
 
-function drawTreeOfLife(ctx, dims, palette, NUM) {
-  const nodes = buildTreeNodes(dims, NUM);
+function drawTreeOfLife(ctx, dims, palette, numbers) {
+  const nodes = buildTreeNodes(dims, numbers);
   const paths = buildTreePaths();
-  const nodeRadius = Math.max(6, dims.width / NUM.NINETYNINE);
+  const nodeRadius = Math.max(6, dims.width / numbers.NINETYNINE);
 
   ctx.save();
   ctx.globalAlpha = 0.9;
-  ctx.strokeStyle = getLayerColor(palette, 1, "#89f7fe");
-  ctx.lineWidth = Math.max(1.2, dims.width / (NUM.ONEFORTYFOUR * 2.5));
+  ctx.strokeStyle = palette.layers[1];
+  ctx.lineWidth = Math.max(1.2, dims.width / (numbers.ONEFORTYFOUR * 2.5));
   ctx.lineJoin = "round";
 
   for (const [fromKey, toKey] of paths) {
@@ -203,7 +150,9 @@ function drawTreeOfLife(ctx, dims, palette, NUM) {
     ctx.stroke();
   }
 
-  ctx.fillStyle = getLayerColor(palette, 2, "#a0ffa1");
+  ctx.fillStyle = palette.layers[2];
+  ctx.strokeStyle = palette.ink;
+  ctx.lineWidth = 1;
   for (const key of Object.keys(nodes)) {
     const node = nodes[key];
     ctx.beginPath();
@@ -213,442 +162,187 @@ function drawTreeOfLife(ctx, dims, palette, NUM) {
   }
 
   ctx.restore();
+  return { nodes: Object.keys(nodes).length, paths: paths.length };
 }
 
-function buildTreeNodes(dims, NUM) {
-  const top = dims.height / NUM.NINE;
-  const span = dims.height * (NUM.SEVEN / NUM.NINE);
-  const verticalStep = span / NUM.NINE;
+function buildTreeNodes(dims, numbers) {
+  const marginY = dims.height / numbers.THIRTYTHREE;
   const centerX = dims.width / 2;
-  const columnOffset = dims.width * (NUM.ELEVEN / (NUM.TWENTYTWO * NUM.THREE));
-  const two = NUM.TWENTYTWO / NUM.ELEVEN;
-  const step = NUM.THREE / two; // 3/2 keeps Tree-of-Life tiers distinct without harsh jumps.
-  const three = NUM.THREE;
-  const six = two * NUM.THREE;
-  const nine = NUM.NINE;
-  const y = (multiplier) => top + multiplier * verticalStep;
+  const column = dims.width / numbers.THREE;
+  const stepY = (dims.height - marginY * 2) / (numbers.ELEVEN);
+
   return {
-    keter: { x: centerX, y: y(0) },
-    chokmah: { x: centerX + columnOffset, y: y(step) },
-    binah: { x: centerX - columnOffset, y: y(step) },
-    chesed: { x: centerX + columnOffset, y: y(three) },
-    geburah: { x: centerX - columnOffset, y: y(three) },
-    tiferet: { x: centerX, y: y(three + step) },
-    netzach: { x: centerX + columnOffset, y: y(six) },
-    hod: { x: centerX - columnOffset, y: y(six) },
-    yesod: { x: centerX, y: y(six + step) },
-    malkuth: { x: centerX, y: y(nine) }
+    kether: { x: centerX, y: marginY },
+    chokmah: { x: centerX + column / 2, y: marginY + stepY * 1.5 },
+    binah: { x: centerX - column / 2, y: marginY + stepY * 1.5 },
+    daath: { x: centerX, y: marginY + stepY * 2.6 },
+    chesed: { x: centerX + column / 2, y: marginY + stepY * 3.8 },
+    geburah: { x: centerX - column / 2, y: marginY + stepY * 3.8 },
+    tiphareth: { x: centerX, y: marginY + stepY * 5.1 },
+    netzach: { x: centerX + column / 2, y: marginY + stepY * 6.7 },
+    hod: { x: centerX - column / 2, y: marginY + stepY * 6.7 },
+    yesod: { x: centerX, y: marginY + stepY * 8.4 },
+    malkuth: { x: centerX, y: dims.height - marginY }
   };
 }
 
 function buildTreePaths() {
-  // 22 paths echo the Hebrew-letter correspondences in a simplified lattice.
   return [
-    ["keter", "chokmah"],
-    ["keter", "binah"],
-    ["keter", "tiferet"],
+    ["kether", "chokmah"],
+    ["kether", "binah"],
     ["chokmah", "binah"],
-    ["chokmah", "tiferet"],
     ["chokmah", "chesed"],
-    ["binah", "tiferet"],
     ["binah", "geburah"],
     ["chesed", "geburah"],
-    ["chesed", "tiferet"],
-    ["chesed", "netzach"],
-    ["geburah", "tiferet"],
-    ["geburah", "hod"],
-    ["tiferet", "netzach"],
-    ["tiferet", "hod"],
-    ["tiferet", "yesod"],
+    ["chesed", "tiphareth"],
+    ["geburah", "tiphareth"],
+    ["tiphareth", "netzach"],
+    ["tiphareth", "hod"],
     ["netzach", "hod"],
     ["netzach", "yesod"],
     ["hod", "yesod"],
+    ["yesod", "malkuth"],
+    ["kether", "daath"],
+    ["daath", "tiphareth"],
+    ["daath", "chesed"],
+    ["daath", "geburah"],
+    ["chesed", "netzach"],
+    ["geburah", "hod"],
     ["netzach", "malkuth"],
-    ["hod", "malkuth"],
-    ["yesod", "malkuth"]
+    ["hod", "malkuth"]
   ];
 }
 
-function drawFibonacciCurve(ctx, dims, palette, NUM) {
-  const fibNumbers = buildFibonacciSequence(NUM.ONEFORTYFOUR);
-  const centerX = dims.width * (NUM.ELEVEN / NUM.TWENTYTWO);
-  const centerY = dims.height * (NUM.SEVEN / NUM.ELEVEN);
-  const scale = Math.min(dims.width, dims.height) / (NUM.ONEFORTYFOUR * NUM.THREE);
-  const startAngle = -Math.PI / 2;
-
-  const points = fibNumbers.map((value, index) => {
-    const theta = startAngle + index * (Math.PI / NUM.ELEVEN);
-    const radius = value * scale;
-    return {
-      x: centerX + Math.cos(theta) * radius,
-      y: centerY + Math.sin(theta) * radius
-    };
-  });
+function drawFibonacciCurve(ctx, dims, palette, numbers) {
+  const sequence = buildFibonacciSequence(numbers.ONEFORTYFOUR);
+  const points = buildSpiralPoints(sequence, dims, numbers);
 
   ctx.save();
   ctx.globalAlpha = 0.85;
-  ctx.strokeStyle = getLayerColor(palette, 3, "#ffd27f");
-  ctx.lineWidth = Math.max(1.4, dims.width / (NUM.ONEFORTYFOUR * 2.2));
-  drawPolyline(ctx, points);
-  ctx.restore();
-}
-
-function buildFibonacciSequence(limit) {
-  const sequence = [1, 1];
-  while (sequence[sequence.length - 1] < limit) {
-    const next = sequence[sequence.length - 1] + sequence[sequence.length - 2];
-    if (next > limit) {
-      break;
-    }
-    sequence.push(next);
-  }
-  return sequence;
-}
-
-function drawHelixLattice(ctx, dims, palette, NUM) {
-  // 99 segments yield a smooth helix without requiring animation.
-  const segments = NUM.NINETYNINE;
-  const centerX = dims.width / 2;
-  const top = dims.height * (NUM.THREE / NUM.THIRTYTHREE);
-  const bottom = dims.height - top;
-  const height = bottom - top;
-  const amplitude = dims.width / NUM.SEVEN;
-  const phaseShift = Math.PI / NUM.THREE;
-  const leftStrand = [];
-  const rightStrand = [];
-
-  for (let i = 0; i <= segments; i += 1) {
-    const t = i / segments;
-    const y = top + t * height;
-    const angle = t * Math.PI * NUM.THREE;
-    const offsetPrimary = Math.sin(angle) * amplitude;
-    const offsetSecondary = Math.sin(angle + phaseShift) * amplitude * (NUM.NINE / NUM.ELEVEN);
-    leftStrand.push({ x: centerX - offsetPrimary, y });
-    rightStrand.push({ x: centerX + offsetSecondary, y });
-  }
-
-  ctx.save();
-  ctx.globalAlpha = 0.8;
-  ctx.strokeStyle = getLayerColor(palette, 4, "#f5a3ff");
-  ctx.lineWidth = Math.max(1.2, dims.width / (NUM.ONEFORTYFOUR * 2.8));
-  drawPolyline(ctx, leftStrand);
-
-  ctx.strokeStyle = getLayerColor(palette, 5, "#d0d0e6");
-  drawPolyline(ctx, rightStrand);
-
-  const rungInterval = Math.max(3, Math.floor(segments / NUM.ELEVEN));
-  ctx.strokeStyle = getLayerColor(palette, 2, "#a0ffa1");
-  ctx.lineWidth = Math.max(1, dims.width / (NUM.ONEFORTYFOUR * 3));
-  for (let i = 0; i <= segments; i += rungInterval) {
-    const left = leftStrand[i];
-    const right = rightStrand[i];
-    ctx.beginPath();
-    ctx.moveTo(left.x, left.y);
-    ctx.lineTo(right.x, right.y);
-    ctx.stroke();
-  }
-
-  ctx.restore();
-}
-
-function drawPolyline(ctx, points) {
-  if (points.length === 0) {
-    return;
-  }
+  ctx.strokeStyle = palette.layers[3];
+  ctx.lineWidth = Math.max(1.2, dims.width / numbers.NINETYNINE);
   ctx.beginPath();
-  ctx.moveTo(points[0].x, points[0].y);
-  for (let i = 1; i < points.length; i += 1) {
-    ctx.lineTo(points[i].x, points[i].y);
-  }
+  points.forEach((point, index) => {
+    if (index === 0) {
+      ctx.moveTo(point.x, point.y);
+    } else {
+      ctx.lineTo(point.x, point.y);
+    }
+  });
   ctx.stroke();
-}
-
-function getLayerColor(palette, index, fallback) {
-  const layers = palette.layers;
-  if (!layers || layers.length === 0) {
-    return fallback;
-  }
-  return layers[index % layers.length] || fallback;
-
-}
-
-function clearStage(ctx, dims, background) {
-  ctx.fillStyle = background;
-  ctx.fillRect(0, 0, dims.width, dims.height);
-}
-
-function drawVesicaField(ctx, dims, primary, accent, NUM) {
-  // Layer 1: vesica piscis grid with soft strokes to keep ND-safe focus.
-  const centerX = dims.width / 2;
-  const centerY = dims.height / 2;
-  const radius = Math.min(dims.width, dims.height) / NUM.THREE;
-  const offset = radius * 0.72;
-
-  withContext(ctx, (context) => {
-    context.lineWidth = 2.2;
-    context.strokeStyle = applyAlpha(primary, 0.65);
-    context.beginPath();
-    context.arc(centerX - offset, centerY, radius, 0, Math.PI * 2);
-    context.stroke();
-    context.beginPath();
-    context.arc(centerX + offset, centerY, radius, 0, Math.PI * 2);
-    context.stroke();
-  });
-
-  const rings = NUM.NINE;
-  for (let i = 1; i <= rings; i += 1) {
-    const scale = 1 - i / (rings + NUM.ELEVEN / NUM.THIRTYTHREE);
-    const ringRadius = radius * scale;
-    const alpha = 0.12 + (0.6 * (rings - i)) / rings;
-    withContext(ctx, (context) => {
-      context.lineWidth = 1.2;
-      context.strokeStyle = applyAlpha(accent, alpha);
-      context.beginPath();
-      context.arc(centerX, centerY, ringRadius, 0, Math.PI * 2);
-      context.stroke();
-    });
-  }
-
-  // Use 22 petals to echo the tarot paths while keeping geometry static.
-  const petals = NUM.TWENTYTWO;
-  for (let i = 0; i < petals; i += 1) {
-    const angle = (Math.PI * 2 * i) / petals;
-    const x = centerX + Math.cos(angle) * offset;
-    const y = centerY + Math.sin(angle) * (offset * 0.6);
-    withContext(ctx, (context) => {
-      context.fillStyle = applyAlpha(primary, 0.08);
-      context.beginPath();
-      context.ellipse(x, y, radius * 0.32, radius * 0.12, angle, 0, Math.PI * 2);
-      context.fill();
-    });
-  }
-
-  return { circles: rings + 2, petals };
-}
-
-function drawTreeOfLife(ctx, dims, nodeColor, pathColor, inkColor, NUM) {
-  // Layer 2: simplified Tree-of-Life using 10 nodes and 22 luminous paths.
-  const nodes = createTreeNodes(dims, NUM);
-  const paths = createTreePaths();
-
-  withContext(ctx, (context) => {
-    context.strokeStyle = applyAlpha(pathColor, 0.45);
-    context.lineWidth = 2;
-    context.lineCap = 'round';
-    paths.forEach(([from, to]) => {
-      const a = nodes[from];
-      const b = nodes[to];
-      context.beginPath();
-      context.moveTo(a.x, a.y);
-      context.lineTo(b.x, b.y);
-      context.stroke();
-    });
-  });
-
-  withContext(ctx, (context) => {
-    context.fillStyle = applyAlpha(nodeColor, 0.78);
-    context.strokeStyle = applyAlpha(inkColor, 0.6);
-    context.lineWidth = 1.5;
-    nodes.forEach((node) => {
-      context.beginPath();
-      context.arc(node.x, node.y, node.radius, 0, Math.PI * 2);
-      context.fill();
-      context.stroke();
-    });
-  });
-
-  return { nodes: nodes.length, paths: paths.length };
-}
-
-function createTreeNodes(dims, NUM) {
-  // Geometry uses numerology spacing to keep ratios gentle yet precise.
-  const marginTop = dims.height / NUM.NINE;
-  const marginBottom = dims.height / NUM.ELEVEN;
-  const usableHeight = dims.height - marginTop - marginBottom;
-  const stepY = usableHeight / NUM.NINE;
-  const xPositions = {
-    farLeft: dims.width * 0.32,
-    midLeft: dims.width * 0.42,
-    center: dims.width * 0.5,
-    midRight: dims.width * 0.58,
-    farRight: dims.width * 0.68
-  };
-  const radius = Math.min(dims.width, dims.height) / NUM.ONEFORTYFOUR * NUM.THREE;
-
-  return [
-    { name: 'Kether', x: xPositions.center, y: marginTop, radius },
-    { name: 'Chokhmah', x: xPositions.farRight, y: marginTop + stepY, radius },
-    { name: 'Binah', x: xPositions.farLeft, y: marginTop + stepY, radius },
-    { name: 'Chesed', x: xPositions.midRight, y: marginTop + stepY * 3, radius },
-    { name: 'Geburah', x: xPositions.midLeft, y: marginTop + stepY * 3, radius },
-    { name: 'Tiphareth', x: xPositions.center, y: marginTop + stepY * 4.5, radius },
-    { name: 'Netzach', x: xPositions.midRight, y: marginTop + stepY * 6, radius },
-    { name: 'Hod', x: xPositions.midLeft, y: marginTop + stepY * 6, radius },
-    { name: 'Yesod', x: xPositions.center, y: marginTop + stepY * 7.5, radius },
-    { name: 'Malkuth', x: xPositions.center, y: marginTop + stepY * 9, radius }
-  ];
-}
-
-function createTreePaths() {
-  return [
-    [0, 1], [0, 2], [1, 2], [1, 3], [2, 4],
-    [3, 5], [4, 5], [3, 6], [4, 7], [5, 6],
-    [5, 7], [6, 8], [7, 8], [8, 9], [3, 4],
-    [1, 4], [2, 3], [0, 5], [1, 5], [2, 5],
-    [6, 9], [7, 9]
-  ];
-}
-
-function drawFibonacciCurve(ctx, dims, color, NUM) {
-  // Layer 3: static Fibonacci-inspired curve following a log-spiral trace.
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const steps = NUM.TWENTYTWO;
-  const baseRadius = Math.min(dims.width, dims.height) / NUM.THIRTYTHREE;
-  const center = { x: dims.width * 0.24, y: dims.height * 0.6 };
-  const points = [];
-
-  for (let i = 0; i <= steps; i += 1) {
-    const t = i / steps;
-    const angle = -Math.PI / NUM.THREE + t * Math.PI * NUM.THREE;
-    const radius = Math.min(baseRadius * Math.pow(phi, t * NUM.SEVEN), dims.width / NUM.THREE);
-    points.push({
-      x: center.x + Math.cos(angle) * radius,
-      y: center.y + Math.sin(angle) * radius
-    });
-  }
-
-  withContext(ctx, (context) => {
-    context.strokeStyle = applyAlpha(color, 0.75);
-    context.lineWidth = 2.4;
-    context.lineCap = 'round';
-    context.beginPath();
-    points.forEach((point, index) => {
-      if (index === 0) {
-        context.moveTo(point.x, point.y);
-      } else {
-        context.lineTo(point.x, point.y);
-      }
-    });
-    context.stroke();
-  });
-
-  // Place three markers to honour the trinity without adding motion.
-  const markers = NUM.THREE;
-  for (let i = 0; i < markers; i += 1) {
-    const idx = Math.floor((points.length - 1) * ((i + 1) / (markers + 1)));
-    const point = points[idx];
-    withContext(ctx, (context) => {
-      context.fillStyle = applyAlpha(color, 0.35);
-      context.beginPath();
-      context.arc(point.x, point.y, Math.max(4, dims.width / NUM.ONEFORTYFOUR), 0, Math.PI * 2);
-      context.fill();
-    });
-  }
+  ctx.restore();
 
   return { points: points.length };
 }
 
-function drawHelixLattice(ctx, dims, colorA, colorB, inkColor, NUM) {
-  // Layer 4: double helix rendered as paired sinusoids with cross-braces.
-  const segments = NUM.ONEFORTYFOUR;
-  const amplitude = dims.height / NUM.THREE * 0.28;
-  const baseY = dims.height / 2;
-  const turns = NUM.THREE;
-
-  const railA = [];
-  const railB = [];
-  for (let i = 0; i <= segments; i += 1) {
-    const t = i / segments;
-    const angle = t * Math.PI * turns;
-    const x = t * dims.width;
-    railA.push({ x, y: baseY + Math.sin(angle) * amplitude });
-    railB.push({ x, y: baseY + Math.sin(angle + Math.PI) * amplitude });
+function buildFibonacciSequence(limit) {
+  const seq = [1, 1];
+  while (true) {
+    const next = seq[seq.length - 1] + seq[seq.length - 2];
+    if (next > limit) break;
+    seq.push(next);
   }
-
-  drawRail(ctx, railA, colorA);
-  drawRail(ctx, railB, colorB);
-
-  // Cross braces reference the 22 paths; lattice stays static for ND safety.
-  const braces = NUM.TWENTYTWO;
-  for (let i = 0; i <= braces; i += 1) {
-    const idx = Math.floor((railA.length - 1) * (i / braces));
-    const a = railA[idx];
-    const b = railB[idx];
-    withContext(ctx, (context) => {
-      context.strokeStyle = applyAlpha(inkColor, 0.25);
-      context.lineWidth = 1;
-      context.beginPath();
-      context.moveTo(a.x, a.y);
-      context.lineTo(b.x, b.y);
-      context.stroke();
-    });
-  }
-
-  return { rails: 2, braces: braces + 1 };
+  return seq;
 }
 
-function drawRail(ctx, points, color) {
-  withContext(ctx, (context) => {
-    context.strokeStyle = applyAlpha(color, 0.65);
-    context.lineWidth = 2;
-    context.lineCap = 'round';
-    context.beginPath();
-    points.forEach((point, index) => {
-      if (index === 0) {
-        context.moveTo(point.x, point.y);
-      } else {
-        context.lineTo(point.x, point.y);
-      }
-    });
-    context.stroke();
+function buildSpiralPoints(sequence, dims, numbers) {
+  const centerX = dims.width * 0.72;
+  const centerY = dims.height * 0.28;
+  const scale = Math.min(dims.width, dims.height) / (numbers.ONEFORTYFOUR * 0.9);
+  const goldenAngle = Math.PI * 2 / numbers.ELEVEN; // gentle rotation anchored to numerology
+
+  const points = sequence.map((value, index) => {
+    const angle = goldenAngle * index;
+    const radius = Math.sqrt(value) * scale;
+    return {
+      x: centerX + radius * Math.cos(angle),
+      y: centerY + radius * Math.sin(angle)
+    };
   });
+
+  // Always include centre to anchor the spiral visually
+  return [{ x: centerX, y: centerY }, ...points];
+}
+
+function drawHelixLattice(ctx, dims, palette, numbers) {
+  const rails = buildHelixRails(dims, numbers);
+
+  ctx.save();
+  ctx.strokeStyle = palette.layers[4];
+  ctx.lineWidth = Math.max(1.2, dims.width / numbers.ONEFORTYFOUR);
+
+  // Draw first rail
+  ctx.beginPath();
+  rails.a.forEach((point, index) => {
+    if (index === 0) ctx.moveTo(point.x, point.y); else ctx.lineTo(point.x, point.y);
+  });
+  ctx.stroke();
+
+  // Draw second rail
+  ctx.strokeStyle = palette.layers[5];
+  ctx.beginPath();
+  rails.b.forEach((point, index) => {
+    if (index === 0) ctx.moveTo(point.x, point.y); else ctx.lineTo(point.x, point.y);
+  });
+  ctx.stroke();
+
+  // Draw lattice rungs
+  ctx.strokeStyle = palette.ink;
+  ctx.lineWidth = Math.max(1, dims.width / numbers.ONEFORTYFOUR);
+  rails.rungs.forEach(rung => {
+    ctx.beginPath();
+    ctx.moveTo(rung.a.x, rung.a.y);
+    ctx.lineTo(rung.b.x, rung.b.y);
+    ctx.stroke();
+  });
+
+  ctx.restore();
+  return { rungs: rails.rungs.length };
+}
+
+function buildHelixRails(dims, numbers) {
+  const length = numbers.TWENTYTWO;
+  const startX = dims.width * 0.12;
+  const endX = dims.width * 0.88;
+  const amplitude = dims.height / numbers.ELEVEN;
+  const centreY = dims.height * 0.72;
+  const phaseShift = Math.PI / numbers.THREE;
+  const step = (endX - startX) / (length - 1);
+
+  const a = [];
+  const b = [];
+  const rungs = [];
+
+  for (let i = 0; i < length; i += 1) {
+    const x = startX + step * i;
+    const angle = (Math.PI * 2 * i) / numbers.ELEVEN;
+    const yA = centreY + Math.sin(angle) * amplitude;
+    const yB = centreY + Math.sin(angle + phaseShift) * amplitude;
+    const pointA = { x, y: yA };
+    const pointB = { x, y: yB };
+    a.push(pointA);
+    b.push(pointB);
+    if (i % 2 === 0) {
+      rungs.push({ a: pointA, b: pointB });
+    }
+  }
+
+  return { a, b, rungs };
 }
 
 function drawCanvasNotice(ctx, dims, color, message) {
-  withContext(ctx, (context) => {
-    context.fillStyle = applyAlpha(color, 0.75);
-    context.font = `${Math.max(12, dims.width / 90)}px/1.4 system-ui, sans-serif`;
-    context.textAlign = 'right';
-    context.textBaseline = 'bottom';
-    const padding = 24;
-    context.fillText(message, dims.width - padding, dims.height - padding);
-  });
+  ctx.save();
+  ctx.fillStyle = color;
+  ctx.font = `${Math.max(14, dims.width / 72)}px system-ui, -apple-system, Segoe UI, sans-serif`;
+  ctx.textAlign = "center";
+  ctx.fillText(message, dims.width / 2, dims.height - dims.height / 40);
+  ctx.restore();
 }
 
 function summariseLayers(stats) {
-  const parts = [
-    `Vesica field ${stats.vesicaStats.circles} rings`,
-    `Tree paths ${stats.treeStats.paths}`,
-    `Fibonacci points ${stats.fibonacciStats.points}`,
-    `Helix braces ${stats.helixStats.braces}`
-  ];
-  return `Layers rendered: ${parts.join(', ')}.`;
-}
-
-function withContext(ctx, fn) {
-  ctx.save();
-  try {
-    fn(ctx);
-  } finally {
-    ctx.restore();
-  }
-}
-
-function applyAlpha(hex, alpha) {
-  const { r, g, b } = hexToRgb(hex);
-  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
-}
-
-function hexToRgb(hex) {
-  const normalized = hex.replace('#', '');
-  const value = normalized.length === 3
-    ? normalized.split('').map((char) => char + char).join('')
-    : normalized;
-  const intValue = parseInt(value, 16);
-  return {
-    r: (intValue >> 16) & 255,
-    g: (intValue >> 8) & 255,
-    b: intValue & 255
-  };
-
+  const vesica = `${stats.vesicaStats.circles} vesica circles`;
+  const tree = `${stats.treeStats.paths} paths / ${stats.treeStats.nodes} nodes`;
+  const fibonacci = `${stats.fibonacciStats.points} spiral points`;
+  const helix = `${stats.helixStats.rungs} helix rungs`;
+  return `Layers rendered - ${vesica}; ${tree}; ${fibonacci}; ${helix}.`;
 }

--- a/site/index.html
+++ b/site/index.html
@@ -1,531 +1,560 @@
 <!doctype html>
 <html lang="en">
 <head>
-
-<meta charset="utf-8"/>
-<meta name="viewport" content="width=device-width, initial-scale=1"/>
-<title>Codex 144:99 · Cosmogenesis Learning Engine</title>
-<meta name="color-scheme" content="dark light"/>
-<style>
-/* --- RESET & TOKENS --- */
-*{margin:0;padding:0;box-sizing:border-box}
-:root{
-  --primary-gold:#FFD700;
-  --sacred-purple:#6B46C1;
-  --deep-indigo:#1a1a2e;
-  --astral-blue:#16213e;
-  --mystical-green:#0f3460;
-  --spirit-red:#e94560;
-  --moon-silver:#C0C0C0;
-  --ink:#ffffff;
-  --paper:#0a0a0a;
-  --paper2:#0f3460;
-  --focus: #80C7FF;
-}
-@media (prefers-color-scheme: light){
-  :root{ --ink:#111; --paper:#F5F0E6; --paper2:#E8E2D6 }
-}
-html,body{min-height:100%}
-body{
-  font-family: ui-serif, Georgia, serif;
-  background: linear-gradient(135deg,var(--paper) 0%, var(--deep-indigo) 50%, var(--paper2) 100%);
-  color: var(--ink);
-  overflow-x:hidden;
-}
-
-/* --- BACKDROP CANVAS (gated by motion pref) --- */
-#sacred-canvas{
-  position:fixed; inset:0; width:100%; height:100%;
-  z-index:-1; opacity:.28;
-}
-
-/* --- TREE NAV --- */
-.tree-nav{
-  position:fixed; top:16px; right:16px; z-index:1000;
-  display:flex; flex-direction:column; gap:10px;
-  background:rgba(0,0,0,.25); backdrop-filter:saturate(120%) blur(8px);
-  border:1px solid rgba(255,255,255,.12); padding:10px; border-radius:12px;
-}
-.sephirah-node{
-  width:44px;height:44px;border-radius:50%;
-  background: radial-gradient(circle, var(--primary-gold), var(--sacred-purple));
-  border:2px solid var(--moon-silver);
-  display:grid;place-items:center;font-size:20px;cursor:pointer;
-  transition:transform .2s ease, box-shadow .2s ease;
-  box-shadow:0 0 14px rgba(255,215,0,.25);
-}
-.sephirah-node:focus-visible{ outline:2px solid var(--focus); outline-offset:2px }
-.sephirah-node:hover{ transform:translateY(-2px); box-shadow:0 0 24px rgba(255,215,0,.45) }
-
-/* --- PAGE LAYOUT --- */
-main{ max-width:1400px; margin:0 auto; padding:40px 20px; position:relative; z-index:10 }
-.header{ text-align:center; margin-bottom:48px }
-.codex-title{
-  font-size:clamp(1.8rem,4.5vw,3.5rem);
-  background: linear-gradient(45deg,var(--primary-gold),var(--moon-silver),var(--sacred-purple));
-  -webkit-background-clip:text; background-clip:text; -webkit-text-fill-color:transparent;
-  text-shadow: 0 0 18px rgba(255,215,0,.35);
-  letter-spacing:.08em; font-weight:700; margin-bottom:8px
-}
-.codex-subtitle{ font-size:1.05rem; color:var(--moon-silver); font-style:italic }
-
-/* --- GRID --- */
-.node-grid{
-  display:grid; grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
-  gap:24px; margin:36px 0;
-}
-.module-node{
-  background: rgba(27,27,50,.78);
-  border:1.5px solid var(--primary-gold);
-  border-radius:12px; padding:22px; position:relative; overflow:hidden; cursor:pointer;
-  transition:transform .2s ease, box-shadow .2s ease, border-color .2s ease;
-}
-.module-node:focus-visible{ outline:2px solid var(--focus); outline-offset:2px }
-.module-node::before{
-  content:""; position:absolute; inset:-50% -50%;
-  width:200%; height:200%;
-  background: radial-gradient(circle, transparent, rgba(255,215,0,.08), transparent);
-  animation: slow-rotate 18s linear infinite;
-  pointer-events:none;
-}
-.module-node:hover{ transform:translateY(-6px); box-shadow:0 16px 34px rgba(255,215,0,.22); border-color:var(--moon-silver) }
-.module-title{ font-size:1.25rem; color:var(--primary-gold); display:flex; gap:10px; align-items:center; margin-bottom:10px }
-.module-symbol{ font-size:1.5rem }
-.module-description{ color:#cfd3e6; line-height:1.6; margin-bottom:14px }
-.module-tags{ display:flex; flex-wrap:wrap; gap:8px }
-.tag{ background: rgba(107,70,193,.28); color:var(--moon-silver); padding:4px 10px; border-radius:14px; font-size:.82rem; border:1px solid rgba(192,192,192,.28) }
-
-/* --- WORKSPACE --- */
-.workspace{
-  background: rgba(15,52,96,.22); border:1.5px solid var(--sacred-purple);
-  border-radius:16px; padding:28px; margin:48px 0;
-}
-.workspace-title{ font-size:1.6rem; color:var(--primary-gold); text-align:center; margin-bottom:18px }
-.geometry-container{
-  width:100%; height:380px; background:rgba(0,0,0,.46);
-  border:1px solid var(--primary-gold); border-radius:10px; display:flex; align-items:center; justify-content:center;
-}
-#geometry-canvas{ width:100%; height:100% }
-.control-panel{
-  display:grid; grid-template-columns:repeat(auto-fit,minmax(210px,1fr));
-  gap:16px; margin-top:18px; padding:14px; background:rgba(26,26,46,.55); border-radius:10px
-}
-.control-group{ display:flex; flex-direction:column; gap:8px }
-.control-label{ color:var(--primary-gold); font-size:.82rem; text-transform:uppercase; letter-spacing:.06em }
-.control-slider{ width:100%; height:6px; border-radius:3px; background:rgba(192,192,192,.28); outline:0; -webkit-appearance:none }
-.control-slider::-webkit-slider-thumb{
-  -webkit-appearance:none; width:18px; height:18px; border-radius:50%;
-  background:var(--primary-gold); box-shadow:0 0 10px rgba(255,215,0,.4); cursor:pointer
-}
-
-/* --- PATTERN CARDS --- */
-.pattern-display{ display:grid; grid-template-columns:repeat(3,1fr); gap:18px; margin:26px 0 }
-.pattern-card{
-  background:rgba(107,70,193,.22); border:1px solid var(--sacred-purple);
-  padding:18px; border-radius:10px; text-align:center; transition:transform .15s ease, box-shadow .15s ease
-}
-.pattern-card:hover{ transform:translateY(-4px); box-shadow:0 10px 26px rgba(107,70,193,.35) }
-.pattern-icon{ font-size:2.4rem; margin-bottom:8px }
-
-/* --- HEALING INTERFACE --- */
-.healing-interface{
-  background:rgba(0,0,0,.6); border:1.5px solid var(--mystical-green);
-  border-radius:14px; padding:22px; margin:28px 0;
-}
-.frequency-display{
-  font-size:1.8rem; color:var(--primary-gold); text-align:center; font-family:ui-monospace, SFMono-Regular, Menlo, monospace; margin:10px 0
-}
-.color-palette{ display:flex; justify-content:center; gap:12px; flex-wrap:wrap }
-.color-swatch{
-  width:48px; height:48px; border-radius:50%; cursor:pointer; transition:transform .15s ease, border-color .15s ease; border:2px solid transparent
-}
-.color-swatch:hover{ transform:scale(1.12); border-color:var(--primary-gold) }
-
-/* --- JOURNAL --- */
-.journal-entry{ background:rgba(26,26,46,.78); border-left:4px solid var(--spirit-red); padding:16px; margin:18px 0; border-radius:6px }
-.journal-date{ color:var(--moon-silver); font-size:.9rem; margin-bottom:8px }
-.journal-content{ color:#dfe3f3; line-height:1.72 }
-
-/* --- MODAL --- */
-.modal{ display:none; position:fixed; inset:0; z-index:2000; background:rgba(0,0,0,.92) }
-.modal-content{
-  position:relative; background:linear-gradient(135deg,#1a1a2e 0%, #0f3460 100%);
-  margin:5% auto; padding:28px; width:min(820px,90%); border:1.5px solid var(--primary-gold); border-radius:16px; max-height:80vh; overflow:auto
-}
-.close-modal{ color:var(--moon-silver); font-size:1.8rem; cursor:pointer; float:right }
-.close-modal:hover{ color:var(--primary-gold) }
-
-/* --- EXPERIMENTAL TOGGLE --- */
-.experimental-toggle{
-  position:fixed; bottom:20px; right:20px;
-  background:rgba(233,69,96,.9); color:#fff; padding:12px 18px; border-radius:28px; cursor:pointer;
-  font-weight:700; box-shadow:0 6px 18px rgba(233,69,96,.42)
-}
-
-/* --- FOOTER / PROVENANCE --- */
-footer{ margin:36px 0 20px; text-align:center; font-size:.85rem; color:var(--moon-silver) }
-footer small{ display:block; opacity:.9 }
-
-/* --- ANIMATIONS (soft; gated) --- */
-@keyframes slow-rotate{ from{transform:rotate(0)} to{transform:rotate(360deg)} }
-
-@media (prefers-reduced-motion: reduce){
-  .module-node::before{ animation:none }
-}
-@media (max-width:768px){
-  .node-grid{ grid-template-columns:1fr }
-  .pattern-display{ grid-template-columns:1fr }
-  .tree-nav{ flex-direction:row }
-  .sephirah-node{ width:40px;height:40px }
-}
-</style>
-</head>
-<body>
-<!-- Accessible landmarks -->
-<nav class="tree-nav" aria-label="Tree of Life Navigation">
-  <button class="sephirah-node" title="Kether – Crown" data-sephirah="kether" aria-label="Kether">👑</button>
-  <button class="sephirah-node" title="Chokmah – Wisdom" data-sephirah="chokmah" aria-label="Chokmah">🔮</button>
-  <button class="sephirah-node" title="Binah – Understanding" data-sephirah="binah" aria-label="Binah">🌙</button>
-  <button class="sephirah-node" title="Chesed – Mercy" data-sephirah="chesed" aria-label="Chesed">💙</button>
-  <button class="sephirah-node" title="Geburah – Severity" data-sephirah="geburah" aria-label="Geburah">🔥</button>
-  <button class="sephirah-node" title="Tiphareth – Beauty" data-sephirah="tiphareth" aria-label="Tiphareth">☀️</button>
-  <button class="sephirah-node" title="Netzach – Victory" data-sephirah="netzach" aria-label="Netzach">🌿</button>
-  <button class="sephirah-node" title="Hod – Glory" data-sephirah="hod" aria-label="Hod">📖</button>
-  <button class="sephirah-node" title="Yesod – Foundation" data-sephirah="yesod" aria-label="Yesod">🌛</button>
-  <button class="sephirah-node" title="Malkuth – Kingdom" data-sephirah="malkuth" aria-label="Malkuth">🌍</button>
-</nav>
-
-<canvas id="sacred-canvas" aria-hidden="true"></canvas>
-
-<main id="content" role="main">
-  <header class="header">
-    <h1 class="codex-title">CODEX 144:99</h1>
-    <p class="codex-subtitle">Circuitum99 · The Living Arcana Engine</p>
-  </header>
-
-  <section class="node-grid" aria-label="Modules">
-    <!-- Cards (same content you wrote, lightly trimmed) -->
-    <article class="module-node" data-module="cosmogenesis" tabindex="0">
-      <h3 class="module-title"><span class="module-symbol">🌌</span>Cosmogenesis Patterns</h3>
-      <p class="module-description">Explore creation myths through neurodivergent pattern recognition. Map sacred geometry of universe birthing across cultures.</p>
-      <div class="module-tags"><span class="tag">Sacred Geometry</span><span class="tag">Creation Myths</span><span class="tag">ND Cognition</span></div>
-    </article>
-
-    <article class="module-node" data-module="harmonic-research" tabindex="0">
-      <h3 class="module-title"><span class="module-symbol">🎵</span>Harmonic Resonance Lab</h3>
-      <p class="module-description">Investigate Schumann resonances, planetary frequencies, and solfeggio tones. Create custom frequency environments.</p>
-      <div class="module-tags"><span class="tag">Sound Healing</span><span class="tag">Frequency</span><span class="tag">Binaural</span></div>
-    </article>
-
-    <article class="module-node" data-module="symbolic-cognition" tabindex="0">
-      <h3 class="module-title"><span class="module-symbol">⚛️</span>Symbolic Cognition Archive</h3>
-      <p class="module-description">Art–science fusion. Study Red Book, temple geometry, synesthetic archives.</p>
-      <div class="module-tags"><span class="tag">Jung</span><span class="tag">Symbolism</span><span class="tag">ND Minds</span></div>
-    </article>
-
-    <article class="module-node" data-module="trauma-environments" tabindex="0">
-      <h3 class="module-title"><span class="module-symbol">🛡️</span>Trauma-Safe Spaces</h3>
-      <p class="module-description">Design healing environments with polyvagal theory, biophilic patterns, and RPG mechanics for regulation.</p>
-      <div class="module-tags"><span class="tag">PTSD</span><span class="tag">Healing</span><span class="tag">Safe Space</span></div>
-    </article>
-
-    <article class="module-node" data-module="alchemical-psychology" tabindex="0">
-      <h3 class="module-title"><span class="module-symbol">⚗️</span>Alchemical Psychology</h3>
-      <p class="module-description">In the line of Fortune, Case, Agrippa. Transform lead awareness into gold.</p>
-      <div class="module-tags"><span class="tag">Alchemy</span><span class="tag">Theosophy</span><span class="tag">Mysticism</span></div>
-    </article>
-
-    <article class="module-node" data-module="living-arcana" tabindex="0">
-      <h3 class="module-title"><span class="module-symbol">🃏</span>Living Arcana System</h3>
-      <p class="module-description">Dynamic Tarot ↔ Tree correspondences. Real-time archetypal pattern synthesis.</p>
-      <div class="module-tags"><span class="tag">Tarot</span><span class="tag">Qabalah</span><span class="tag">Hermetic</span></div>
-    </article>
-  </section>
-
-  <!-- Sacred Geometry Workspace -->
-  <section class="workspace" aria-label="Sacred Geometry Laboratory">
-    <h2 class="workspace-title">Sacred Geometry Laboratory</h2>
-    <div class="geometry-container"><canvas id="geometry-canvas" aria-label="Geometry Canvas"></canvas></div>
-    <div class="control-panel" role="group" aria-label="Geometry Controls">
-      <div class="control-group"><label class="control-label" for="recursion">Recursion Depth</label><input id="recursion" type="range" class="control-slider" min="1" max="12" value="6"/></div>
-      <div class="control-group"><label class="control-label" for="phi">Golden Ratio φ</label><input id="phi" type="range" class="control-slider" min="0" max="100" value="61"/></div>
-      <div class="control-group"><label class="control-label" for="rotation">Rotation Speed</label><input id="rotation" type="range" class="control-slider" min="0" max="100" value="30"/></div>
-      <div class="control-group"><label class="control-label" for="complexity">Fractal Complexity</label><input id="complexity" type="range" class="control-slider" min="3" max="24" value="12"/></div>
-    </div>
-  </section>
-
-  <!-- Healing interface (colors update from registry if present) -->
-  <section class="healing-interface" aria-label="Frequency & Color Healing">
-    <h3 style="text-align:center;color:var(--primary-gold);margin-bottom:12px">Frequency & Color Healing Chamber</h3>
-    <div class="frequency-display" id="freqReadout">432 Hz</div>
-    <div id="palette" class="color-palette" aria-live="polite">
-      <!-- Fallback swatches -->
-      <button class="color-swatch" style="background:#FF0000" data-freq="428" aria-label="Red 428 Hz"></button>
-      <button class="color-swatch" style="background:#FFA500" data-freq="480" aria-label="Orange 480 Hz"></button>
-      <button class="color-swatch" style="background:#FFFF00" data-freq="510" aria-label="Yellow 510 Hz"></button>
-      <button class="color-swatch" style="background:#00FF00" data-freq="528" aria-label="Green 528 Hz"></button>
-      <button class="color-swatch" style="background:#00FFFF" data-freq="600" aria-label="Cyan 600 Hz"></button>
-      <button class="color-swatch" style="background:#0000FF" data-freq="660" aria-label="Blue 660 Hz"></button>
-      <button class="color-swatch" style="background:#8B00FF" data-freq="720" aria-label="Violet 720 Hz"></button>
-    </div>
-  </section>
-
-  <!-- Journal -->
-  <article class="journal-entry" aria-label="Research Journal Entry">
-    <div class="journal-date">Entry 144 — Timestamp: Now</div>
-    <div class="journal-content">
-      The living engine awakens. Patterns emerge where ancient wisdom meets experimental research.
-      The Tree of Life navigates layers of consciousness; the Codex 144:99 frames completion (144) meeting the open spiral (99).
-    </div>
-  </article>
-
-  <footer>
-    © Rebecca Respawn · Codex 144:99 · CC-BY-SA-4.0 · <small>Provenance</small>
-  </footer>
-</main>
-
-<!-- Modal -->
-<div id="modal" class="modal" role="dialog" aria-modal="true" aria-label="Deep Dive">
-  <div class="modal-content">
-    <button class="close-modal" aria-label="Close">×</button>
-    <div id="modal-body"></div>
-  </div>
-</div>
-
-<button class="experimental-toggle" id="expToggle" aria-pressed="false" title="Experimental Mode">🧪 EXPERIMENTAL MODE</button>
-
-<script>
-/* ===== Motion Preference Gate ===== */
-const allowMotion = matchMedia('(prefers-reduced-motion: no-preference)').matches;
-
-/* ===== Backdrop Particles (ND-safe) ===== */
-const bg = document.getElementById('sacred-canvas');
-const g = bg.getContext('2d');
-function fitBG(){ bg.width = innerWidth; bg.height = innerHeight }
-fitBG(); addEventListener('resize', fitBG);
-
-const particles = Array.from({length: allowMotion ? 42 : 12}, () => ({
-  x: Math.random()*bg.width, y: Math.random()*bg.height,
-  vx: (Math.random()-.5)*.35, vy: (Math.random()-.5)*.35,
-  r: Math.random()*2+0.8, life: Math.random()*0.8+0.2
-}));
-
-function drawBG(){
-  g.clearRect(0,0,bg.width,bg.height);
-  for(const p of particles){
-    p.x+=p.vx; p.y+=p.vy; p.life-=0.0015;
-    if(p.x<0||p.x>bg.width) p.vx*=-1;
-    if(p.y<0||p.y>bg.height) p.vy*=-1;
-    if(p.life<=0){ p.x=Math.random()*bg.width; p.y=Math.random()*bg.height; p.life=Math.random()*0.8+0.2 }
-    g.globalAlpha = p.life*0.6;
-    g.fillStyle = '#FFD700';
-    g.beginPath(); g.arc(p.x,p.y,p.r,0,Math.PI*2); g.fill();
-  }
-  if(allowMotion) requestAnimationFrame(drawBG);
-}
-allowMotion && drawBG();
-
-/* ===== Geometry Lab ===== */
-const geo = document.getElementById('geometry-canvas');
-const ctx = geo.getContext('2d');
-function fitGeo(){ geo.width = geo.clientWidth; geo.height = geo.clientHeight }
-fitGeo(); addEventListener('resize', fitGeo);
-
-let t=0;
-let rotationSpeed=.3, recursionDepth=6, phi=1.618, complexity=12;
-document.getElementById('recursion').addEventListener('input',e=>recursionDepth=+e.target.value);
-document.getElementById('phi').addEventListener('input',e=>phi=1+ (+e.target.value)/100);
-document.getElementById('rotation').addEventListener('input',e=>rotationSpeed=(+e.target.value)/100);
-document.getElementById('complexity').addEventListener('input',e=>complexity=+e.target.value);
-
-function flower(x,y,r,depth){
-  if(depth<=0) return;
-  ctx.strokeStyle=`hsla(${(t*2)%360},70%,60%,${depth/recursionDepth})`;
-  ctx.lineWidth=.5; ctx.beginPath(); ctx.arc(x,y,r,0,Math.PI*2); ctx.stroke();
-  for(let i=0;i<6;i++){
-    const a = (Math.PI*2/6)*i + t*rotationSpeed;
-    const nx = x + Math.cos(a)*r, ny = y + Math.sin(a)*r;
-    ctx.beginPath(); ctx.arc(nx,ny,r,0,Math.PI*2); ctx.stroke();
-    if(depth>1) flower(nx,ny,r/phi,depth-1);
-  }
-}
-
-function loop(){
-  ctx.clearRect(0,0,geo.width,geo.height);
-  const r = Math.min(geo.width, geo.height)/ (2.6 + (12-complexity)/24);
-  flower(geo.width/2, geo.height/2, r, recursionDepth);
-  if(allowMotion){ t+=0.016; requestAnimationFrame(loop); }
-}
-allowMotion ? loop() : ( ()=>{ t=0; loop(); })();
-
-/* ===== Palette from Registry (graceful fallback) ===== */
-const freq = document.getElementById('freqReadout');
-function wirePalette(node){
-  if(!node) return;
-  node.addEventListener('click', e=>{
-    const btn = e.target.closest('.color-swatch');
-    if(!btn) return;
-    const hz = btn.getAttribute('data-freq')||'432';
-    freq.textContent = hz + ' Hz';
-  });
-}
-wirePalette(document.getElementById('palette'));
-
-// Try to fetch /dist/projection.json and hydrate colors if present
-fetch('/dist/projection.json').then(r=>r.ok?r.json():null).then(data=>{
-  if(!data) return;
-  const items = Array.isArray(data.items)?data.items:[];
-  // Example: look for solfeggio/crystals records
-  const tones = items.filter(x=>x.kind==='numerology' && /hz|tone|frequency/i.test(x.name||'')).slice(0,7);
-  if(tones.length){
-    const palette = document.getElementById('palette');
-    palette.innerHTML='';
-    tones.forEach((t,i)=>{
-      const sw=document.createElement('button');
-      const hz = (t.value||432);
-      const color = t.color || ['#FF0000','#FFA500','#FFFF00','#00FF00','#00FFFF','#0000FF','#8B00FF'][i%7];
-      sw.className='color-swatch'; sw.style.background=color; sw.setAttribute('data-freq', hz);
-      sw.setAttribute('aria-label', `${t.name||'Tone'} ${hz} Hz`); palette.appendChild(sw);
-    });
-    wirePalette(palette);
-  }
-}).catch(()=>{ /* silent: stay with fallback */ });
-
-/* ===== Modal (for deep dive cards) ===== */
-const modal = document.getElementById('modal');
-const modalBody = document.getElementById('modal-body');
-document.querySelector('.close-modal').addEventListener('click', ()=> modal.style.display='none');
-document.addEventListener('click', e=>{
-  const card = e.target.closest('.module-node');
-  if(!card) return;
-  modalBody.innerHTML = `
-    <h2 style="color:var(--primary-gold);margin-bottom:10px">${card.querySelector('.module-title').innerText}</h2>
-    <p style="color:#dfe3f3;line-height:1.7">${card.querySelector('.module-description').innerText}</p>
-  `;
-  modal.style.display='block';
-});
-
-/* ===== Experimental mode (state only; no autoplay) ===== */
-const exp = document.getElementById('expToggle');
-exp.addEventListener('click', ()=>{
-  const pressed = exp.getAttribute('aria-pressed')==='true';
-  exp.setAttribute('aria-pressed', String(!pressed));
-  exp.textContent = !pressed ? '🧪 EXPERIMENTAL MODE · ON' : '🧪 EXPERIMENTAL MODE';
-});
-</script>
-
   <meta charset="utf-8">
   <title>Cosmogenesis Learning Engine</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <meta name="description" content="ND-safe world-building generator for Codex 144:99.">
+  <meta name="description" content="ND-safe atelier index for the Cosmogenesis Learning Engine.">
   <style>
     :root {
-      --bg:#0b0b12;
-      --ink:#f2f2f7;
-      --muted:#9ca3c7;
-      --card:#141424;
-      --accent:#8ecae6;
+      --noir-absolu:#05050c;
+      --encre:#f5f4ff;
+      --encre-dim:#a5a8c6;
+      --violet-ray:#8f7bff;
+      --violet-deep:#4f3ea0;
+      --dorure:#d6b87c;
+      --verre:#131321;
+      --ombre:#0b0b16;
+      --focus:#8cc7ff;
     }
-    body {
+
+    /* unified body rule */
+    body{
+      font-family:'Bodoni Moda','Didot',Georgia,serif;
+      background:radial-gradient(circle at 20% 20%,rgba(143,123,255,0.08),transparent 60%),linear-gradient(135deg,var(--noir-absolu) 0%,var(--ombre) 50%,#111228 100%);
+      color:var(--encre);
+      overflow-x:hidden;
       margin:0;
-      font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
-      background:var(--bg);
-      color:var(--ink);
-      line-height:1.6;
+      min-height:100vh;
+
+      /* custom cursor */
+      cursor:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><circle cx="16" cy="16" r="2" fill="white"/><circle cx="16" cy="16" r="8" fill="none" stroke="white" stroke-width="0.5" opacity="0.5"/></svg>'),auto;
     }
-    header {
-      padding:32px 24px 16px;
-      max-width:960px;
-      margin:0 auto;
+
+    /* accessibility helpers */
+    .skip-link{position:absolute;left:-9999px;top:auto}
+    .skip-link:focus{left:1rem;top:1rem;background:#000;color:#fff;padding:.5rem 1rem;z-index:10001;border-radius:999px}
+
+    #sacred-canvas{position:fixed;inset:0;z-index:-2;opacity:.32}
+
+    .atelier-nav{
+      position:sticky;top:0;display:flex;align-items:center;justify-content:space-between;gap:2rem;padding:1.2rem clamp(1.5rem,4vw,4rem);background:rgba(8,7,18,0.72);backdrop-filter:saturate(140%) blur(16px);border-bottom:1px solid rgba(214,184,124,0.25);z-index:1000;
     }
-    h1 {
-      margin:0 0 8px;
-      font-size:2.8rem;
-      letter-spacing:0.02em;
+    .marque-logo{font-size:1.2rem;font-weight:600;letter-spacing:.28em;text-transform:uppercase;color:var(--encre);text-decoration:none}
+    .nav-collection{list-style:none;display:flex;gap:1.5rem;margin:0;padding:0}
+    .nav-collection a{color:var(--encre-dim);text-decoration:none;font-size:.95rem;letter-spacing:.08em;text-transform:uppercase}
+    .nav-collection a:focus-visible,.nav-collection a:hover{color:var(--dorure)}
+    .btn-couture{background:transparent;border:1px solid var(--dorure);color:var(--dorure);padding:.6rem 1.4rem;border-radius:999px;font-size:.9rem;letter-spacing:.12em;text-transform:uppercase;cursor:pointer}
+    .btn-couture:focus-visible{outline:3px solid var(--focus);outline-offset:2px}
+
+    main{padding:clamp(3rem,6vw,5rem) clamp(1.5rem,6vw,6rem);display:grid;gap:clamp(4rem,6vw,6rem)}
+
+    .hero{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));align-items:center;gap:clamp(2rem,5vw,6rem)}
+    .hero-copy{display:grid;gap:1rem}
+    .hero-title{margin:0;font-size:clamp(2.8rem,6vw,4.6rem);letter-spacing:.32em}
+    .hero-subtitle{margin:0;font-size:1.1rem;color:var(--encre-dim);max-width:40ch;line-height:1.6}
+    .hero-actions{display:flex;gap:1rem;flex-wrap:wrap;margin-top:1rem}
+    .btn-outline{display:inline-flex;align-items:center;justify-content:center;padding:.7rem 1.5rem;border:1px solid var(--encre-dim);border-radius:999px;color:var(--encre);text-decoration:none;letter-spacing:.1em;text-transform:uppercase;font-size:.9rem}
+    .btn-outline:hover,.btn-outline:focus-visible{border-color:var(--dorure);color:var(--dorure)}
+
+    .loading-sigil{width:140px;height:140px;border-radius:50%;margin-inline:auto;border:1px solid rgba(214,184,124,0.4);display:grid;place-items:center;position:relative;box-shadow:0 0 40px rgba(79,62,160,0.25);animation:sigil-spin 24s linear infinite}
+    .loading-sigil::before,.loading-sigil::after{content:"";position:absolute;border-radius:50%;border:1px solid rgba(143,123,255,0.35)}
+    .loading-sigil::before{inset:12%;box-shadow:0 0 20px rgba(143,123,255,0.2)}
+    .loading-sigil::after{inset:24%;border-color:rgba(214,184,124,0.35)}
+    .loading-sigil span{width:4px;height:40%;background:linear-gradient(180deg,var(--violet-ray),transparent);transform-origin:50% 100%;animation:sigil-rays 18s linear infinite}
+
+    @keyframes sigil-spin{from{transform:rotate(0deg)}to{transform:rotate(360deg)}}
+    @keyframes sigil-rays{from{transform:rotate(0deg)}to{transform:rotate(360deg)}}
+
+    .section{display:grid;gap:1.5rem}
+    .section-titre{font-size:clamp(1.6rem,3vw,2.4rem);letter-spacing:.22em;margin:0;text-transform:uppercase}
+    .section-sous-titre{margin:0;color:var(--encre-dim);font-size:1.05rem;max-width:60ch}
+
+    .module-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:1.6rem}
+    .module-card{background:rgba(17,17,32,0.8);border:1px solid rgba(214,184,124,0.2);border-radius:18px;padding:1.6rem;display:grid;gap:1rem;position:relative;overflow:hidden;box-shadow:0 18px 50px rgba(11,11,22,0.6);transition:transform .35s ease, box-shadow .35s ease, border-color .35s ease}
+    .module-card::before{content:"";position:absolute;inset:-60% -20%;background:radial-gradient(circle,rgba(143,123,255,0.22),transparent 65%);animation:slow-rotate 28s linear infinite;mix-blend-mode:screen}
+    .module-card:hover,.module-card:focus-within{transform:translateY(-6px);border-color:var(--dorure);box-shadow:0 26px 60px rgba(79,62,160,0.45)}
+    .module-title{margin:0;font-size:1.35rem;letter-spacing:.1em;display:flex;align-items:center;gap:.6rem}
+    .module-description{margin:0;color:var(--encre-dim);line-height:1.7;font-size:.95rem}
+    .module-tags{display:flex;flex-wrap:wrap;gap:.5rem}
+    .tag{padding:.3rem .8rem;border-radius:999px;background:rgba(79,62,160,0.28);border:1px solid rgba(143,123,255,0.25);font-size:.75rem;letter-spacing:.08em;color:var(--encre-dim)}
+
+    @keyframes slow-rotate{from{transform:rotate(0deg)}to{transform:rotate(360deg)}}
+
+    .geometry-lab{background:rgba(17,17,36,0.74);border:1px solid rgba(143,123,255,0.25);border-radius:20px;padding:1.5rem;display:grid;gap:1.4rem;box-shadow:0 18px 50px rgba(8,8,20,0.65)}
+    .geometry-frame{position:relative;border:1px solid rgba(214,184,124,0.28);border-radius:16px;overflow:hidden;background:rgba(7,7,16,0.65)}
+    .geometric-canvas{display:block;width:100%;height:360px}
+    .control-panel{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:1rem}
+    .control-group{display:grid;gap:.4rem}
+    .control-label{text-transform:uppercase;letter-spacing:.08em;font-size:.75rem;color:var(--dorure)}
+    .control-slider{-webkit-appearance:none;height:6px;border-radius:3px;background:rgba(143,123,255,0.35);outline:0}
+    .control-slider::-webkit-slider-thumb{-webkit-appearance:none;width:18px;height:18px;border-radius:50%;background:var(--dorure);box-shadow:0 0 12px rgba(214,184,124,0.5);cursor:pointer}
+
+    .research-list{list-style:none;margin:0;padding:0;display:grid;gap:.8rem}
+    .research-list a{color:var(--dorure);text-decoration:none;letter-spacing:.08em}
+    .research-list a:focus-visible,.research-list a:hover{color:var(--violet-ray)}
+
+    .healing-interface{background:rgba(13,13,26,0.7);border:1px solid rgba(143,123,255,0.25);border-radius:18px;padding:1.6rem;display:grid;gap:1.2rem}
+    .frequency-display{font-family:"Roboto Mono",ui-monospace,monospace;text-align:center;font-size:1.6rem;color:var(--dorure)}
+    .color-palette{display:flex;flex-wrap:wrap;gap:.6rem;justify-content:center}
+    .color-swatch{width:48px;height:48px;border-radius:50%;border:2px solid transparent;cursor:pointer}
+    .color-swatch:focus-visible,.color-swatch:hover{border-color:var(--dorure)}
+
+    .journal-entry{background:rgba(18,18,32,0.82);border-left:3px solid var(--violet-ray);padding:1.2rem;border-radius:12px;color:var(--encre-dim);line-height:1.7}
+    .journal-date{font-size:.85rem;letter-spacing:.1em;text-transform:uppercase;color:var(--dorure);margin-bottom:.5rem}
+
+    .modal{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;background:rgba(5,5,12,0.86);backdrop-filter:blur(10px);z-index:2000}
+    .modal[hidden]{display:none}
+    .modal-content{background:linear-gradient(160deg,rgba(17,17,36,0.95),rgba(56,42,120,0.95));border:1px solid rgba(214,184,124,0.35);border-radius:18px;padding:2rem;max-width:520px;width:min(90vw,520px);box-shadow:0 30px 90px rgba(0,0,0,0.6)}
+    .close-modal{background:none;border:none;color:var(--encre-dim);font-size:1.4rem;cursor:pointer;position:absolute;top:1.2rem;right:1.2rem}
+    .close-modal:hover,.close-modal:focus-visible{color:var(--dorure)}
+    .modal-title{margin-top:0;letter-spacing:.12em;text-transform:uppercase}
+    .modal-body{color:var(--encre-dim);line-height:1.7}
+
+    .maison-footer{margin:4rem 0 2.5rem;text-align:center;color:var(--encre-dim);font-size:.85rem;letter-spacing:.08em;display:grid;gap:.8rem}
+    .footer-links{display:flex;flex-wrap:wrap;justify-content:center;gap:1.2rem}
+    .footer-links a{color:var(--encre-dim);text-decoration:none}
+    .footer-links a:hover,.footer-links a:focus-visible{color:var(--dorure)}
+
+    /* ND-safe: freeze ALL animations when reduced motion is set */
+    .reduced-motion *{animation:none!important;transition:none!important}
+    .reduced-motion .geometric-canvas::before,
+    .reduced-motion .geometric-canvas::after{animation:none!important}
+    .reduced-motion .loading-sigil{animation:none!important}
+    .reduced-motion .module-card::before{animation:none!important}
+
+    @media (prefers-reduced-motion: reduce){
+      .loading-sigil{animation:none}
+      .module-card::before{animation:none}
     }
-    p.lede {
-      margin:0;
-      max-width:720px;
-      color:var(--muted);
-      font-size:1.1rem;
-    }
-    .cards {
-      display:grid;
-      gap:16px;
-      grid-template-columns:repeat(auto-fit,minmax(220px,1fr));
-      padding:24px;
-      max-width:960px;
-      margin:0 auto 40px;
-    }
-    .card {
-      background:var(--card);
-      border:1px solid rgba(142,202,230,0.2);
-      border-radius:12px;
-      padding:20px;
-      display:flex;
-      flex-direction:column;
-      gap:12px;
-    }
-    .card h2 {
-      margin:0;
-      font-size:1.5rem;
-    }
-    .card p {
-      margin:0;
-      color:var(--muted);
-    }
-    .card a {
-      align-self:flex-start;
-      color:var(--accent);
-      text-decoration:none;
-      font-weight:600;
-    }
-    .card a:focus,
-    .card a:hover {
-      text-decoration:underline;
-    }
-    .provenance-chip {
-      border-top:1px solid rgba(142,202,230,0.25);
-      padding:16px 24px 32px;
-      font-size:0.85rem;
-      color:var(--muted);
-      text-align:center;
-    }
-    @media (max-width:600px) {
-      header {
-        padding:24px 16px 12px;
-      }
-      h1 {
-        font-size:2.1rem;
-      }
+
+    @media (max-width:900px){
+      .nav-collection{gap:1rem}
+      .btn-couture{display:none}
     }
   </style>
 </head>
 <body>
-  <header>
-    <h1>Cosmogenesis Learning Engine</h1>
-    <p class="lede">A world-building generator for Codex 144:99. Layered geometry, trauma-informed learning, and provenance-first storytelling that links Art, Learn, and Play without forcing motion.</p>
-  </header>
-  <main>
-    <section class="cards" aria-label="Primary modes">
-      <article class="card">
-        <h2>Art</h2>
-        <p>Palette laboratories, geometry renderers, and ND-safe exports. Launch the Grimoire web app Art mode to sculpt plates from registry data.</p>
-        <a href="../apps/grimoire-web/#/art">Open Art Mode</a>
-      </article>
-      <article class="card">
-        <h2>Learn</h2>
-        <p>Cross-cosmology exercises that move from recognition to integration to transmission. Guided by the numerology and angelic registries.</p>
-        <a href="../apps/grimoire-web/#/learn">Open Learn Mode</a>
-      </article>
-      <article class="card">
-        <h2>Play</h2>
-        <p>Story labyrinths powered by Circuitum99. Step into text-first adventures that respect pacing and embed provenance cues throughout.</p>
-        <a href="../apps/grimoire-web/#/play">Open Play Mode</a>
+  <a class="skip-link" href="#main">Skip to content</a>
+
+  <nav class="atelier-nav">
+    <a href="#collections" class="marque-logo">COSMOGENESIS</a>
+    <ul class="nav-collection">
+      <li><a href="#collections">Collections</a></li>
+      <li><a href="#arcana">Living Arcana</a></li>
+      <li><a href="#node-system">Node System</a></li>
+      <li><a href="#research">Research</a></li>
+      <li><a href="#atelier">Atelier</a></li>
+    </ul>
+    <button id="calmToggle" class="btn-couture" aria-pressed="false">Calm Mode</button>
+  </nav>
+
+  <canvas id="sacred-canvas" aria-hidden="true"></canvas>
+
+  <main id="main">
+    <section id="collections" class="hero" aria-labelledby="hero-title">
+      <div class="hero-copy">
+        <h1 id="hero-title" class="hero-title">COSMOGENESIS</h1>
+        <p class="hero-subtitle">A couture codex weaving sacred geometry, trauma-informed pedagogy, and living arcana registries. Every layer breathes slowly and honours ND-safe pacing.</p>
+        <div class="hero-actions">
+          <a class="btn-outline" href="#arcana">Explore Collections</a>
+          <a class="btn-outline" href="#atelier">Enter Atelier</a>
+        </div>
+      </div>
+      <div class="loading-sigil" aria-hidden="true"><span></span></div>
+    </section>
+
+    <section id="arcana" class="section" aria-labelledby="arcana-title">
+      <h2 id="arcana-title" class="section-titre">Living Arcana</h2>
+      <p class="section-sous-titre">Key codex collections bridging art, learn, and play. Hover or focus to open the modal chapel&mdash;no autoplay, only annotated pathways.</p>
+      <div class="module-grid">
+        <article class="module-card" tabindex="0" data-title="Cosmogenesis Patterns" data-description="Explore creation myths through neurodivergent pattern recognition. Map sacred geometry of universe birthing across cultures.">
+          <h3 class="module-title">Cosmogenesis Patterns</h3>
+          <p class="module-description">Explore creation myths through neurodivergent pattern recognition. Map sacred geometry of universe birthing across cultures.</p>
+          <div class="module-tags">
+            <span class="tag">Sacred Geometry</span>
+            <span class="tag">Creation Myths</span>
+            <span class="tag">ND Cognition</span>
+          </div>
+        </article>
+        <article class="module-card" tabindex="0" data-title="Harmonic Resonance Lab" data-description="Investigate Schumann resonances, planetary frequencies, and solfeggio tones. Create custom frequency environments.">
+          <h3 class="module-title">Harmonic Resonance Lab</h3>
+          <p class="module-description">Investigate Schumann resonances, planetary frequencies, and solfeggio tones. Create custom frequency environments.</p>
+          <div class="module-tags">
+            <span class="tag">Sound Healing</span>
+            <span class="tag">Frequency</span>
+            <span class="tag">Binaural</span>
+          </div>
+        </article>
+        <article class="module-card" tabindex="0" data-title="Symbolic Cognition Archive" data-description="Art-science fusion: Red Book, temple geometry, synesthetic archives--curated for nonlinear minds.">
+          <h3 class="module-title">Symbolic Cognition Archive</h3>
+          <p class="module-description">Art-science fusion. Study Red Book, temple geometry, synesthetic archives.</p>
+          <div class="module-tags">
+            <span class="tag">Jung</span>
+            <span class="tag">Symbolism</span>
+            <span class="tag">ND Minds</span>
+          </div>
+        </article>
+        <article class="module-card" tabindex="0" data-title="Trauma-Safe Spaces" data-description="Design healing environments with polyvagal theory, biophilic patterns, and RPG mechanics for regulation.">
+          <h3 class="module-title">Trauma-Safe Spaces</h3>
+          <p class="module-description">Design healing environments with polyvagal theory, biophilic patterns, and RPG mechanics for regulation.</p>
+          <div class="module-tags">
+            <span class="tag">PTSD</span>
+            <span class="tag">Healing</span>
+            <span class="tag">Safe Space</span>
+          </div>
+        </article>
+        <article class="module-card" tabindex="0" data-title="Alchemical Psychology" data-description="In the line of Fortune, Case, Agrippa. Transform lead awareness into gold through layered praxis.">
+          <h3 class="module-title">Alchemical Psychology</h3>
+          <p class="module-description">In the line of Fortune, Case, Agrippa. Transform lead awareness into gold.</p>
+          <div class="module-tags">
+            <span class="tag">Alchemy</span>
+            <span class="tag">Theosophy</span>
+            <span class="tag">Mysticism</span>
+          </div>
+        </article>
+        <article class="module-card" tabindex="0" data-title="Living Arcana System" data-description="Dynamic Tarot <-> Tree correspondences. Real-time archetypal pattern synthesis.">
+          <h3 class="module-title">Living Arcana System</h3>
+          <p class="module-description">Dynamic Tarot <-> Tree correspondences. Real-time archetypal pattern synthesis.</p>
+          <div class="module-tags">
+            <span class="tag">Tarot</span>
+            <span class="tag">Qabalah</span>
+            <span class="tag">Hermetic</span>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section id="node-system" class="section" aria-labelledby="node-title">
+      <h2 id="node-title" class="section-titre">Node System Laboratory</h2>
+      <p class="section-sous-titre">Layered geometry studio&mdash;calibrated to numerology constants {3, 7, 9, 11, 22, 33, 99, 144}. Motion pauses when Calm Mode is active.</p>
+      <div class="geometry-lab">
+        <div class="geometry-frame">
+          <canvas id="geometry-canvas" class="geometric-canvas" aria-label="Geometry canvas"></canvas>
+        </div>
+        <div class="control-panel" role="group" aria-label="Geometry controls">
+          <div class="control-group">
+            <label class="control-label" for="recursion">Recursion Depth</label>
+            <input id="recursion" type="range" class="control-slider" min="1" max="12" value="6">
+          </div>
+          <div class="control-group">
+            <label class="control-label" for="phi">Golden Ratio (phi)</label>
+            <input id="phi" type="range" class="control-slider" min="0" max="100" value="61">
+          </div>
+          <div class="control-group">
+            <label class="control-label" for="rotation">Rotation Speed</label>
+            <input id="rotation" type="range" class="control-slider" min="0" max="100" value="30">
+          </div>
+          <div class="control-group">
+            <label class="control-label" for="complexity">Fractal Complexity</label>
+            <input id="complexity" type="range" class="control-slider" min="3" max="24" value="12">
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="research" class="section" aria-label="Research Index">
+      <h2 class="section-titre">Research Index</h2>
+      <p class="section-sous-titre">Primary scrolls and datasets for provenance-first study.</p>
+      <ul class="research-list">
+        <li><a href="scrolls/index.html">Scrolls - Provenance excerpts</a></li>
+        <li><a href="about/index.html">About the Cosmogenesis Learning Engine</a></li>
+        <li><a href="../docs/aurora_gate_node_00.html">Aurora Gate node dossier (docs)</a></li>
+      </ul>
+    </section>
+
+    <section id="atelier" class="section" aria-labelledby="atelier-title">
+      <h2 id="atelier-title" class="section-titre">Atelier Harmonics</h2>
+      <p class="section-sous-titre">Colour-frequency chamber and field notes. Everything remains static until you interact.</p>
+      <div class="healing-interface">
+        <div class="frequency-display" id="freqReadout">432 Hz</div>
+        <div id="palette" class="color-palette" aria-live="polite">
+          <button class="color-swatch" style="background:#FF0000" data-freq="428" aria-label="Red 428 Hz"></button>
+          <button class="color-swatch" style="background:#FFA500" data-freq="480" aria-label="Orange 480 Hz"></button>
+          <button class="color-swatch" style="background:#FFFF00" data-freq="510" aria-label="Yellow 510 Hz"></button>
+          <button class="color-swatch" style="background:#00FF00" data-freq="528" aria-label="Green 528 Hz"></button>
+          <button class="color-swatch" style="background:#00FFFF" data-freq="600" aria-label="Cyan 600 Hz"></button>
+          <button class="color-swatch" style="background:#0000FF" data-freq="660" aria-label="Blue 660 Hz"></button>
+          <button class="color-swatch" style="background:#8B00FF" data-freq="720" aria-label="Violet 720 Hz"></button>
+        </div>
+      </div>
+      <article class="journal-entry" aria-label="Research Journal Entry">
+        <div class="journal-date">Entry 144 - Timestamp: Now</div>
+        <div>The engine awakens. Patterns emerge where ancient wisdom meets experimental research. The Tree of Life navigates layers of consciousness; the Codex 144:99 frames completion (144) meeting the open spiral (99).</div>
       </article>
     </section>
   </main>
-  <footer class="provenance-chip">© Rebecca Respawn · Codex 144:99 · CC-BY-SA-4.0 · Provenance</footer>
 
+  <div id="modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title" hidden>
+    <div class="modal-content">
+      <button type="button" class="close-modal" aria-label="Close modal">Close</button>
+      <h3 id="modal-title" class="modal-title"></h3>
+      <p id="modal-body" class="modal-body"></p>
+    </div>
+  </div>
+
+  <footer class="maison-footer">
+    <div class="footer-links">
+      <a href="#collections">Harmonic Research</a>
+      <a href="#node-system">Node System Docs</a>
+      <a href="https://github.com/Rebecca-Respawn/cosmogenesis-learning-engine" rel="noopener noreferrer">Open Source</a>
+      <a href="#atelier">Commissions</a>
+    </div>
+    <p class="copyright">&copy; MMXXV &mdash; Atelier of Sacred Geometry &amp; Consciousness Research</p>
+  </footer>
+
+  <script>
+    const root = document.documentElement;
+    const calmBtn = document.getElementById('calmToggle');
+    const prefersReducedMotion = typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+      ? window.matchMedia('(prefers-reduced-motion: reduce)')
+      : null;
+
+    function setCalmButtonState() {
+      if (calmBtn) {
+        calmBtn.setAttribute('aria-pressed', String(root.classList.contains('reduced-motion')));
+      }
+    }
+
+    if (prefersReducedMotion && prefersReducedMotion.matches) {
+      root.classList.add('reduced-motion');
+    }
+    setCalmButtonState();
+
+    const handlePreferenceChange = (event) => {
+      root.classList.toggle('reduced-motion', event.matches);
+      refreshMotionState();
+    };
+
+    if (prefersReducedMotion) {
+      if (typeof prefersReducedMotion.addEventListener === 'function') {
+        prefersReducedMotion.addEventListener('change', handlePreferenceChange);
+      } else if (typeof prefersReducedMotion.addListener === 'function') {
+        prefersReducedMotion.addListener(handlePreferenceChange);
+      }
+    }
+
+    calmBtn?.addEventListener('click', () => {
+      root.classList.toggle('reduced-motion');
+      refreshMotionState();
+    });
+
+    const bgCanvas = document.getElementById('sacred-canvas');
+    const bgCtx = bgCanvas ? bgCanvas.getContext('2d') : null;
+    const particles = [];
+    let bgAnimationId = null;
+
+    function resizeBg() {
+      if (!bgCanvas) return;
+      bgCanvas.width = window.innerWidth;
+      bgCanvas.height = window.innerHeight;
+    }
+
+    function seedParticles() {
+      if (!bgCanvas) return;
+      particles.length = 0;
+      const count = root.classList.contains('reduced-motion') ? 12 : 48;
+      for (let i = 0; i < count; i += 1) {
+        particles.push({
+          x: Math.random() * bgCanvas.width,
+          y: Math.random() * bgCanvas.height,
+          vx: (Math.random() - 0.5) * 0.28,
+          vy: (Math.random() - 0.5) * 0.28,
+          r: Math.random() * 2 + 0.6,
+          life: Math.random() * 0.8 + 0.2
+        });
+      }
+    }
+
+    function drawBackdrop() {
+      if (!bgCanvas || !bgCtx) return;
+      bgCtx.clearRect(0, 0, bgCanvas.width, bgCanvas.height);
+      particles.forEach((p) => {
+        p.x += p.vx;
+        p.y += p.vy;
+        p.life -= 0.0012;
+        if (p.x < 0 || p.x > bgCanvas.width) p.vx *= -1;
+        if (p.y < 0 || p.y > bgCanvas.height) p.vy *= -1;
+        if (p.life <= 0) {
+          p.x = Math.random() * bgCanvas.width;
+          p.y = Math.random() * bgCanvas.height;
+          p.life = Math.random() * 0.8 + 0.2;
+        }
+        bgCtx.globalAlpha = p.life * 0.6;
+        bgCtx.fillStyle = '#d6b87c';
+        bgCtx.beginPath();
+        bgCtx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
+        bgCtx.fill();
+      });
+      bgCtx.globalAlpha = 1;
+      if (!root.classList.contains('reduced-motion')) {
+        bgAnimationId = requestAnimationFrame(drawBackdrop);
+      }
+    }
+
+    function startBackdrop() {
+      if (!bgCanvas || !bgCtx) return;
+      cancelAnimationFrame(bgAnimationId);
+      if (root.classList.contains('reduced-motion')) {
+        drawBackdrop();
+        return;
+      }
+      bgAnimationId = requestAnimationFrame(drawBackdrop);
+    }
+
+    const geometryCanvas = document.getElementById('geometry-canvas');
+    const geoCtx = geometryCanvas ? geometryCanvas.getContext('2d') : null;
+    let geoAnimationId = null;
+    let geoTime = 0;
+    let recursionDepth = 6;
+    let phiRatio = 1.61;
+    let rotationSpeed = 0.3;
+    let complexity = 12;
+
+    function resizeGeometry() {
+      if (!geometryCanvas) return;
+      geometryCanvas.width = geometryCanvas.clientWidth;
+      geometryCanvas.height = geometryCanvas.clientHeight;
+    }
+
+    function drawFlower(x, y, r, depth) {
+      if (!geoCtx || depth <= 0) return;
+      geoCtx.strokeStyle = `hsla(${(geoTime * 45) % 360},70%,68%,${depth / recursionDepth})`;
+      geoCtx.lineWidth = 0.6;
+      geoCtx.beginPath();
+      geoCtx.arc(x, y, r, 0, Math.PI * 2);
+      geoCtx.stroke();
+      for (let i = 0; i < complexity; i += 6) {
+        const angle = (Math.PI * 2 / complexity) * (i + 1) + geoTime * rotationSpeed;
+        const nx = x + Math.cos(angle) * r;
+        const ny = y + Math.sin(angle) * r;
+        geoCtx.beginPath();
+        geoCtx.arc(nx, ny, r / phiRatio, 0, Math.PI * 2);
+        geoCtx.stroke();
+        if (depth > 1) {
+          drawFlower(nx, ny, r / phiRatio, depth - 1);
+        }
+      }
+    }
+
+    function renderGeometry() {
+      if (!geometryCanvas || !geoCtx) return;
+      geoCtx.clearRect(0, 0, geometryCanvas.width, geometryCanvas.height);
+      const radius = Math.min(geometryCanvas.width, geometryCanvas.height) / 3.2;
+      drawFlower(geometryCanvas.width / 2, geometryCanvas.height / 2, radius, recursionDepth);
+      if (!root.classList.contains('reduced-motion')) {
+        geoTime += 0.015;
+        geoAnimationId = requestAnimationFrame(renderGeometry);
+      }
+    }
+
+    function startGeometry() {
+      if (!geometryCanvas || !geoCtx) return;
+      cancelAnimationFrame(geoAnimationId);
+      renderGeometry();
+    }
+
+    document.getElementById('recursion')?.addEventListener('input', (event) => {
+      recursionDepth = Number(event.target.value);
+      startGeometry();
+    });
+    document.getElementById('phi')?.addEventListener('input', (event) => {
+      phiRatio = 1 + Number(event.target.value) / 100;
+      startGeometry();
+    });
+    document.getElementById('rotation')?.addEventListener('input', (event) => {
+      rotationSpeed = Number(event.target.value) / 120;
+      startGeometry();
+    });
+    document.getElementById('complexity')?.addEventListener('input', (event) => {
+      complexity = Number(event.target.value);
+      startGeometry();
+    });
+
+    const freqReadout = document.getElementById('freqReadout');
+    document.getElementById('palette')?.addEventListener('click', (event) => {
+      const swatch = event.target.closest('.color-swatch');
+      if (!swatch || !freqReadout) return;
+      const hz = swatch.getAttribute('data-freq') || '432';
+      freqReadout.textContent = `${hz} Hz`;
+    });
+
+    const modal = document.getElementById('modal');
+    const modalTitle = document.getElementById('modal-title');
+    const modalBody = document.getElementById('modal-body');
+    const closeModalBtn = modal?.querySelector('.close-modal');
+
+    function openModal(title, description) {
+      if (!modal || !modalTitle || !modalBody || !closeModalBtn) return;
+      modalTitle.textContent = title;
+      modalBody.textContent = description;
+      modal.removeAttribute('hidden');
+      closeModalBtn.focus();
+    }
+
+    function closeModal() {
+      if (!modal) return;
+      modal.setAttribute('hidden', '');
+    }
+
+    closeModalBtn?.addEventListener('click', closeModal);
+    modal?.addEventListener('click', (event) => {
+      if (event.target === modal) {
+        closeModal();
+      }
+    });
+    window.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && modal && !modal.hasAttribute('hidden')) {
+        closeModal();
+      }
+    });
+
+    document.querySelectorAll('.module-card').forEach((card) => {
+      card.addEventListener('click', () => {
+        openModal(card.dataset.title || 'Module', card.dataset.description || 'Details forthcoming.');
+      });
+      card.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          openModal(card.dataset.title || 'Module', card.dataset.description || 'Details forthcoming.');
+        }
+      });
+    });
+
+    function refreshMotionState() {
+      setCalmButtonState();
+      seedParticles();
+      startBackdrop();
+      startGeometry();
+    }
+
+    window.addEventListener('resize', () => {
+      resizeBg();
+      resizeGeometry();
+      refreshMotionState();
+    });
+
+    resizeBg();
+    resizeGeometry();
+    refreshMotionState();
+
+    (function(){
+      const canvas = document.querySelector('.geometric-canvas');
+      if (!canvas) return;
+      let ticking = false;
+      function updateParallax(){
+        if (root.classList.contains('reduced-motion')) {
+          canvas.style.transform = '';
+          ticking = false; return;
+        }
+        const y = window.scrollY * 0.5;
+        canvas.style.transform = `translateY(${y}px)`;
+        ticking = false;
+      }
+      window.addEventListener('scroll', function(){
+        if (!ticking){ requestAnimationFrame(updateParallax); ticking = true; }
+      }, { passive:true });
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- rebuild the offline Cosmic Helix entry point to load an optional palette JSON, fall back safely, and call the new pure rendering helper
- implement a pure ES module for the helix renderer with palette/number normalisation and detailed geometry routines for each layer
- refresh the renderer README and palette data to document usage and keep a concise ND-safe colour set
- recreate `site/index.html` with unified body styling, skip link, accessible navigation, Calm Mode toggle, research section, ND-safe animations, and reduced-motion aware scripting

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68cb756060008328ab6f55c868969e73