### PR TITLE
feat: install atelier shell on site homepage

### DIFF
--- a/site/assets/css/atelier.css
+++ b/site/assets/css/atelier.css
@@ -1,0 +1,606 @@
+:root {
+  color-scheme: dark;
+  --noir-absolu:#05050c;
+  --encre:#f5f4ff;
+  --encre-dim:#a5a8c6;
+  --violet-ray:#8f7bff;
+  --violet-deep:#4f3ea0;
+  --dorure:#d6b87c;
+  --verre:#131321;
+  --ombre:#0b0b16;
+  --focus:#8cc7ff;
+  --panel:rgba(17,17,32,0.82);
+  --line-soft:rgba(214,184,124,0.25);
+  --scale-xs:clamp(0.82rem,0.16vw+0.78rem,0.9rem);
+  --scale-sm:clamp(0.9rem,0.22vw+0.84rem,1rem);
+  --scale-md:clamp(1.05rem,0.35vw+0.96rem,1.2rem);
+  --scale-lg:clamp(1.35rem,0.48vw+1.18rem,1.6rem);
+  --scale-xl:clamp(1.6rem,0.6vw+1.32rem,2.4rem);
+  --scale-xxl:clamp(2.8rem,6vw,4.6rem);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: 'Bodoni Moda','Didot',Georgia,serif;
+  background:
+    radial-gradient(circle at 20% 20%,rgba(143,123,255,0.08),transparent 60%),
+    linear-gradient(135deg,var(--noir-absolu) 0%,var(--ombre) 50%,#111228 100%);
+  color: var(--encre);
+  overflow-x: hidden;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  cursor: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><circle cx="16" cy="16" r="2" fill="white"/><circle cx="16" cy="16" r="8" fill="none" stroke="white" stroke-width="0.5" opacity="0.5"/></svg>'), auto;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 2px;
+}
+
+img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+button {
+  font: inherit;
+  color: inherit;
+}
+
+.atelier-header {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  background: rgba(8,7,18,0.72);
+  backdrop-filter: saturate(140%) blur(16px);
+  border-bottom: 1px solid rgba(214,184,124,0.25);
+}
+
+.atelier-nav {
+  margin: 0 auto;
+  max-width: 1200px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: 1.2rem clamp(1.5rem,4vw,4rem);
+}
+
+.marque-logo {
+  font-size: 1.2rem;
+  font-weight: 600;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--encre);
+}
+
+.nav-collection {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-collection a {
+  color: var(--encre-dim);
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.nav-collection a:hover,
+.nav-collection a:focus-visible {
+  color: var(--dorure);
+}
+
+.btn-couture {
+  background: transparent;
+  border: 1px solid var(--dorure);
+  color: var(--dorure);
+  padding: 0.6rem 1.4rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.btn-couture:hover,
+.btn-couture:focus-visible {
+  border-color: var(--encre);
+}
+
+main {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: clamp(3rem,6vw,5rem) clamp(1.5rem,6vw,6rem) 4rem;
+  display: grid;
+  gap: clamp(4rem,6vw,6rem);
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit,minmax(280px,1fr));
+  align-items: center;
+  gap: clamp(2rem,5vw,6rem);
+}
+
+.hero-copy {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.hero-title {
+  margin: 0;
+  font-size: var(--scale-xxl);
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  background: linear-gradient(120deg,var(--dorure) 0%,rgba(143,123,255,0.9) 60%,var(--encre) 100%);
+  background-clip: text;
+  -webkit-background-clip: text;
+  color: transparent;
+  text-shadow: 0 0 45px rgba(143,123,255,0.35);
+}
+
+.hero-subtitle {
+  margin: 0;
+  font-size: 1.1rem;
+  max-width: 40ch;
+  line-height: 1.6;
+  color: var(--encre-dim);
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 0.5rem;
+}
+
+.btn-outline {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.7rem 1.5rem;
+  border: 1px solid var(--encre-dim);
+  border-radius: 999px;
+  color: var(--encre);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.9rem;
+}
+
+.btn-outline:hover,
+.btn-outline:focus-visible {
+  border-color: var(--dorure);
+  color: var(--dorure);
+}
+
+.hero-visual {
+  position: relative;
+  display: grid;
+  place-items: center;
+  gap: 1.5rem;
+}
+
+.hero-image {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  border-radius: 20px;
+  border: 1px solid rgba(143,123,255,0.24);
+  box-shadow: 0 30px 60px rgba(9,8,18,0.6);
+}
+
+.atelier-loading {
+  width: 140px;
+  height: 140px;
+  border-radius: 50%;
+  border: 1px solid rgba(214,184,124,0.4);
+  display: grid;
+  place-items: center;
+  position: relative;
+  box-shadow: 0 0 40px rgba(79,62,160,0.25);
+  animation: sigil-spin 24s linear infinite;
+}
+
+.atelier-loading::before,
+.atelier-loading::after {
+  content: '';
+  position: absolute;
+  border-radius: 50%;
+  border: 1px solid rgba(143,123,255,0.35);
+}
+
+.atelier-loading::before {
+  inset: 12%;
+  box-shadow: 0 0 20px rgba(143,123,255,0.2);
+}
+
+.atelier-loading::after {
+  inset: 24%;
+  border-color: rgba(214,184,124,0.35);
+}
+
+.atelier-loading .loader-ray {
+  width: 4px;
+  height: 40%;
+  background: linear-gradient(180deg,var(--violet-ray),transparent);
+  transform-origin: 50% 100%;
+  animation: sigil-rays 18s linear infinite;
+}
+
+.atelier-loading[hidden] {
+  display: none;
+}
+
+@keyframes sigil-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+@keyframes sigil-rays {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.section {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.section-titre {
+  margin: 0;
+  font-size: clamp(1.6rem,3vw,2.4rem);
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+}
+
+.section-sous-titre {
+  margin: 0;
+  color: var(--encre-dim);
+  font-size: 1.05rem;
+  max-width: 60ch;
+  line-height: 1.7;
+}
+
+.module-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit,minmax(240px,1fr));
+  gap: 1.6rem;
+}
+
+.module-card {
+  background: rgba(17,17,32,0.82);
+  border: 1px solid var(--line-soft);
+  border-radius: 18px;
+  padding: 1.6rem;
+  display: grid;
+  gap: 1rem;
+  position: relative;
+  overflow: hidden;
+  box-shadow: 0 18px 50px rgba(11,11,22,0.6);
+  transition: transform 0.35s ease, box-shadow 0.35s ease, border-color 0.35s ease;
+}
+
+.module-card::before {
+  content: '';
+  position: absolute;
+  inset: -60% -20%;
+  background: radial-gradient(circle,rgba(143,123,255,0.22),transparent 65%);
+  animation: slow-rotate 28s linear infinite;
+  mix-blend-mode: screen;
+}
+
+.module-card:hover,
+.module-card:focus-within {
+  transform: translateY(-6px);
+  border-color: var(--dorure);
+  box-shadow: 0 26px 60px rgba(79,62,160,0.45);
+}
+
+.module-title {
+  margin: 0;
+  font-size: 1.35rem;
+  letter-spacing: 0.1em;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.module-description {
+  margin: 0;
+  color: var(--encre-dim);
+  line-height: 1.7;
+  font-size: 0.95rem;
+}
+
+.module-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.tag {
+  padding: 0.3rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(79,62,160,0.28);
+  border: 1px solid rgba(143,123,255,0.25);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  color: var(--encre-dim);
+}
+
+@keyframes slow-rotate {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.node-grid-wrapper {
+  background: rgba(13,12,26,0.72);
+  border: 1px solid rgba(143,123,255,0.25);
+  border-radius: 20px;
+  padding: 1.8rem;
+  display: grid;
+  gap: 1.4rem;
+  box-shadow: 0 18px 50px rgba(8,8,20,0.65);
+}
+
+.node-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit,minmax(240px,1fr));
+  gap: 1.2rem;
+}
+
+.node-card {
+  border: 1px solid rgba(214,184,124,0.25);
+  border-radius: 16px;
+  padding: 1.2rem;
+  background: rgba(17,17,32,0.78);
+  display: grid;
+  gap: 0.75rem;
+  box-shadow: 0 14px 30px rgba(9,8,20,0.55);
+}
+
+.node-card-title {
+  margin: 0;
+  font-size: 1.2rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.node-card-meta {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--dorure);
+  letter-spacing: 0.06em;
+}
+
+.node-card-lore {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--encre-dim);
+  line-height: 1.6;
+}
+
+.node-card-actions {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.node-card-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--dorure);
+}
+
+.node-card-link:hover,
+.node-card-link:focus-visible {
+  color: var(--encre);
+}
+
+.node-empty {
+  font-size: 0.95rem;
+  color: var(--encre-dim);
+}
+
+.research-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.8rem;
+}
+
+.research-list a {
+  color: var(--dorure);
+  letter-spacing: 0.08em;
+}
+
+.research-list a:hover,
+.research-list a:focus-visible {
+  color: var(--violet-ray);
+}
+
+.healing-interface {
+  background: rgba(13,13,26,0.72);
+  border: 1px solid rgba(143,123,255,0.25);
+  border-radius: 18px;
+  padding: 1.6rem;
+  display: grid;
+  gap: 1.2rem;
+}
+
+.frequency-display {
+  font-family: 'Roboto Mono',ui-monospace,monospace;
+  text-align: center;
+  font-size: 1.6rem;
+  color: var(--dorure);
+}
+
+.color-palette {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  justify-content: center;
+}
+
+.color-swatch {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  cursor: pointer;
+}
+
+.color-swatch:hover,
+.color-swatch:focus-visible {
+  border-color: var(--dorure);
+}
+
+.journal-entry {
+  background: rgba(18,18,32,0.82);
+  border-left: 3px solid var(--violet-ray);
+  padding: 1.2rem;
+  border-radius: 12px;
+  color: var(--encre-dim);
+  line-height: 1.7;
+}
+
+.journal-date {
+  font-size: 0.85rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--dorure);
+  margin-bottom: 0.5rem;
+}
+
+.maison-footer {
+  margin: 4rem 0 2.5rem;
+  text-align: center;
+  color: var(--encre-dim);
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  display: grid;
+  gap: 0.8rem;
+}
+
+.footer-marque {
+  font-size: 1rem;
+  letter-spacing: 0.4rem;
+  text-transform: uppercase;
+  display: inline-flex;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.75rem 1.25rem;
+  border: 1px solid rgba(199,168,103,0.4);
+  border-radius: 999px;
+  background: rgba(12,8,22,0.65);
+}
+
+.footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1.2rem;
+}
+
+.footer-links a {
+  color: var(--encre-dim);
+}
+
+.footer-links a:hover,
+.footer-links a:focus-visible {
+  color: var(--dorure);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.geometric-canvas {
+  position: fixed;
+  inset: 0;
+  z-index: -2;
+  pointer-events: none;
+}
+
+.geometric-canvas::before,
+.geometric-canvas::after {
+  content: '';
+  position: absolute;
+  border-radius: 50%;
+  border: 1px solid rgba(199,168,103,0.28);
+  inset: 10% 20%;
+  background: radial-gradient(circle,rgba(107,58,214,0.18),transparent 70%);
+  animation: pulse 18s ease-in-out infinite;
+  mix-blend-mode: screen;
+}
+
+.geometric-canvas::after {
+  inset: 18% 26%;
+  animation: pulse-alt 24s ease-in-out infinite;
+  opacity: 0.6;
+}
+
+@keyframes pulse {
+  0%,100% { transform: scale(1); opacity: 0.7; }
+  50% { transform: scale(1.08); opacity: 0.4; }
+}
+
+@keyframes pulse-alt {
+  0%,100% { transform: scale(0.95); opacity: 0.5; }
+  50% { transform: scale(1.1); opacity: 0.35; }
+}
+
+@media (max-width: 900px) {
+  .nav-collection {
+    gap: 1rem;
+  }
+
+  .btn-couture {
+    display: none;
+  }
+
+  main {
+    padding: 3rem 1.5rem 4rem;
+  }
+}
+
+/* a11y helpers */
+.skip-link{position:absolute;left:-9999px;top:auto}
+.skip-link:focus{left:1rem;top:1rem;background:#000;color:#fff;padding:.5rem 1rem;z-index:10001}
+
+/* ND-safe motion controls */
+.reduced-motion *{animation:none!important;transition:none!important}
+.reduced-motion .geometric-canvas::before,
+.reduced-motion .geometric-canvas::after{animation:none!important}
+.reduced-motion .atelier-loading{animation:none!important}

--- a/site/assets/img/tesseract-chamber-1024.webp
+++ b/site/assets/img/tesseract-chamber-1024.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:347e65eef2a79164b386ff9c6d95f73d2e0c3a094ca615867381d8010bf7c621
+size 7694

--- a/site/assets/js/boot.js
+++ b/site/assets/js/boot.js
@@ -1,0 +1,239 @@
+const docEl = document.documentElement;
+
+async function loadNodes() {
+  try {
+    const res = await fetch('/data/nodes.json', { cache: 'no-store' });
+    if (!res.ok) {
+      throw new Error('netfail');
+    }
+    const nodes = await res.json();
+    if (Array.isArray(nodes)) {
+      return nodes;
+    }
+    throw new Error('shape');
+  } catch (error) {
+    const fallback = document.getElementById('nodes-fallback');
+    if (!fallback) {
+      return [];
+    }
+    try {
+      return JSON.parse(fallback.textContent || '[]');
+    } catch (parseError) {
+      return [];
+    }
+  }
+}
+
+function clearChildren(el) {
+  if (!el) {
+    return;
+  }
+  while (el.firstChild) {
+    el.removeChild(el.firstChild);
+  }
+}
+
+function createNodeCard(node) {
+  const item = document.createElement('li');
+  item.className = 'node-card';
+
+  const title = document.createElement('h3');
+  title.className = 'node-card-title';
+  title.textContent = node && node.name ? String(node.name) : 'Unnamed Node';
+  item.appendChild(title);
+
+  const meta = document.createElement('p');
+  meta.className = 'node-card-meta';
+  const metaParts = [];
+  if (node && node.id) {
+    metaParts.push(`#${String(node.id)}`);
+  }
+  if (node && node.type) {
+    metaParts.push(String(node.type));
+  }
+  if (node && typeof node.numerology !== 'undefined') {
+    metaParts.push(`No.${node.numerology}`);
+  }
+  meta.textContent = metaParts.join(' • ');
+  item.appendChild(meta);
+
+  if (node && node.lore) {
+    const lore = document.createElement('p');
+    lore.className = 'node-card-lore';
+    lore.textContent = String(node.lore);
+    item.appendChild(lore);
+  }
+
+  if (node && node.lab) {
+    const actions = document.createElement('div');
+    actions.className = 'node-card-actions';
+    const link = document.createElement('a');
+    link.className = 'node-card-link';
+    link.textContent = 'Open Lab';
+    try {
+      const labUrl = new URL(String(node.lab), window.location.origin);
+      link.href = labUrl.href;
+      if (labUrl.origin !== window.location.origin) {
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+      }
+    } catch (urlError) {
+      link.href = String(node.lab);
+      link.target = '_blank';
+      link.rel = 'noopener noreferrer';
+    }
+    actions.appendChild(link);
+    item.appendChild(actions);
+  }
+
+  return item;
+}
+
+function renderNodes(nodes, listEl, loaderEl) {
+  if (!listEl) {
+    return;
+  }
+  clearChildren(listEl);
+
+  if (!Array.isArray(nodes) || nodes.length === 0) {
+    const empty = document.createElement('li');
+    empty.className = 'node-empty';
+    empty.textContent = 'Node atlas offline. Using safe fallback.';
+    listEl.appendChild(empty);
+    if (loaderEl) {
+      loaderEl.setAttribute('hidden', '');
+    }
+    return;
+  }
+
+  nodes.forEach((node) => {
+    listEl.appendChild(createNodeCard(node));
+  });
+
+  if (loaderEl) {
+    loaderEl.setAttribute('hidden', '');
+  }
+}
+
+function initCalmMode(calmBtn) {
+  const prefersReduced = typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+    ? window.matchMedia('(prefers-reduced-motion: reduce)')
+    : null;
+
+  const setState = (active) => {
+    docEl.classList.toggle('reduced-motion', active);
+    if (calmBtn) {
+      calmBtn.setAttribute('aria-pressed', String(active));
+    }
+    try {
+      const detail = { active };
+      document.dispatchEvent(new CustomEvent('calm-mode-change', { detail }));
+    } catch (eventError) {
+      // CustomEvent may not exist in very old browsers; ignore gracefully.
+    }
+  };
+
+  if (prefersReduced && prefersReduced.matches) {
+    setState(true);
+  } else {
+    setState(docEl.classList.contains('reduced-motion'));
+  }
+
+  const handlePreferenceChange = (event) => {
+    setState(event.matches);
+  };
+
+  if (prefersReduced) {
+    if (typeof prefersReduced.addEventListener === 'function') {
+      prefersReduced.addEventListener('change', handlePreferenceChange);
+    } else if (typeof prefersReduced.addListener === 'function') {
+      prefersReduced.addListener(handlePreferenceChange);
+    }
+  }
+
+  calmBtn?.addEventListener('click', () => {
+    const next = !docEl.classList.contains('reduced-motion');
+    setState(next);
+  });
+}
+
+function initRouting() {
+  const links = document.querySelectorAll('a[data-route]');
+  links.forEach((link) => {
+    link.addEventListener('click', (event) => {
+      const href = link.getAttribute('href');
+      if (!href || href.charAt(0) !== '#') {
+        return;
+      }
+      const target = document.querySelector(href);
+      if (!target) {
+        return;
+      }
+      event.preventDefault();
+      target.scrollIntoView({
+        behavior: docEl.classList.contains('reduced-motion') ? 'auto' : 'smooth',
+        block: 'start'
+      });
+    });
+  });
+}
+
+function initParallax() {
+  const canvas = document.querySelector('.geometric-canvas');
+  if (!canvas) {
+    return;
+  }
+  let ticking = false;
+  const update = () => {
+    if (docEl.classList.contains('reduced-motion')) {
+      canvas.style.transform = '';
+      ticking = false;
+      return;
+    }
+    const offset = window.scrollY * 0.5;
+    canvas.style.transform = `translateY(${offset}px)`;
+    ticking = false;
+  };
+  window.addEventListener('scroll', () => {
+    if (!ticking) {
+      window.requestAnimationFrame(update);
+      ticking = true;
+    }
+  }, { passive: true });
+  document.addEventListener('calm-mode-change', update);
+  update();
+}
+
+function initPalette() {
+  const palette = document.getElementById('palette');
+  const readout = document.getElementById('freqReadout');
+  if (!palette || !readout) {
+    return;
+  }
+  palette.addEventListener('click', (event) => {
+    const swatch = event.target.closest('.color-swatch');
+    if (!swatch) {
+      return;
+    }
+    const hz = swatch.getAttribute('data-freq') || '432';
+    readout.textContent = `${hz} Hz`;
+  });
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const calmBtn = document.getElementById('calmToggle');
+  const nodeList = document.getElementById('node-list');
+  const loader = document.getElementById('node-loader');
+
+  initCalmMode(calmBtn);
+  initRouting();
+  initParallax();
+  initPalette();
+
+  try {
+    const nodes = await loadNodes();
+    renderNodes(nodes, nodeList, loader);
+  } catch (error) {
+    renderNodes([], nodeList, loader);
+  }
+});

--- a/site/data/nodes.json
+++ b/site/data/nodes.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "00-void",
+    "name": "Void",
+    "type": "Origin",
+    "numerology": 0,
+    "lore": "The silent lumen holds the womb of all potential.",
+    "lab": "/nodes/atelier/void.html"
+  },
+  {
+    "id": "01-magician",
+    "name": "Magician",
+    "type": "Initiate",
+    "numerology": 1,
+    "lore": "The first spark weaves intention through the lattice.",
+    "lab": "https://cosmogenesis-learning-engine.net/labs/magician"
+  },
+  {
+    "id": "02-priestess",
+    "name": "High Priestess",
+    "type": "Oracle",
+    "numerology": 2,
+    "lore": "Moonlit veils translate subconscious patterns into safe rituals."
+  },
+  {
+    "id": "03-empress",
+    "name": "Empress",
+    "type": "Matrix",
+    "numerology": 3,
+    "lore": "Living gardens harmonize numerology constants with sensory grounding."
+  },
+  {
+    "id": "04-emperor",
+    "name": "Emperor",
+    "type": "Architect",
+    "numerology": 4,
+    "lore": "Framework steward aligning trauma-informed pacing with layered geometry."
+  },
+  {
+    "id": "05-hierophant",
+    "name": "Hierophant",
+    "type": "Bridge",
+    "numerology": 5,
+    "lore": "Choral lineages map canonical wisdom into the Cosmogenesis atelier."
+  }
+]

--- a/site/index.html
+++ b/site/index.html
@@ -3,165 +3,44 @@
 <head>
   <meta charset="utf-8">
   <title>Cosmogenesis Learning Engine</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
   <meta name="description" content="ND-safe atelier index for the Cosmogenesis Learning Engine.">
-  <style>
-    :root {
-      --noir-absolu:#05050c;
-      --encre:#f5f4ff;
-      --encre-dim:#a5a8c6;
-      --violet-ray:#8f7bff;
-      --violet-deep:#4f3ea0;
-      --dorure:#d6b87c;
-      --verre:#131321;
-      --ombre:#0b0b16;
-      --focus:#8cc7ff;
-    }
-
-    /* unified body rule */
-    body{
-      font-family:'Bodoni Moda','Didot',Georgia,serif;
-      background:radial-gradient(circle at 20% 20%,rgba(143,123,255,0.08),transparent 60%),linear-gradient(135deg,var(--noir-absolu) 0%,var(--ombre) 50%,#111228 100%);
-      color:var(--encre);
-      overflow-x:hidden;
-      margin:0;
-      min-height:100vh;
-
-      /* custom cursor */
-      cursor:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><circle cx="16" cy="16" r="2" fill="white"/><circle cx="16" cy="16" r="8" fill="none" stroke="white" stroke-width="0.5" opacity="0.5"/></svg>'),auto;
-    }
-
-    /* accessibility helpers */
-    .skip-link{position:absolute;left:-9999px;top:auto}
-    .skip-link:focus{left:1rem;top:1rem;background:#000;color:#fff;padding:.5rem 1rem;z-index:10001;border-radius:999px}
-
-    #sacred-canvas{position:fixed;inset:0;z-index:-2;opacity:.32}
-
-    .atelier-nav{
-      position:sticky;top:0;display:flex;align-items:center;justify-content:space-between;gap:2rem;padding:1.2rem clamp(1.5rem,4vw,4rem);background:rgba(8,7,18,0.72);backdrop-filter:saturate(140%) blur(16px);border-bottom:1px solid rgba(214,184,124,0.25);z-index:1000;
-    }
-    .marque-logo{font-size:1.2rem;font-weight:600;letter-spacing:.28em;text-transform:uppercase;color:var(--encre);text-decoration:none}
-    .nav-collection{list-style:none;display:flex;gap:1.5rem;margin:0;padding:0}
-    .nav-collection a{color:var(--encre-dim);text-decoration:none;font-size:.95rem;letter-spacing:.08em;text-transform:uppercase}
-    .nav-collection a:focus-visible,.nav-collection a:hover{color:var(--dorure)}
-    .btn-couture{background:transparent;border:1px solid var(--dorure);color:var(--dorure);padding:.6rem 1.4rem;border-radius:999px;font-size:.9rem;letter-spacing:.12em;text-transform:uppercase;cursor:pointer}
-    .btn-couture:focus-visible{outline:3px solid var(--focus);outline-offset:2px}
-
-    main{padding:clamp(3rem,6vw,5rem) clamp(1.5rem,6vw,6rem);display:grid;gap:clamp(4rem,6vw,6rem)}
-
-    .hero{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));align-items:center;gap:clamp(2rem,5vw,6rem)}
-    .hero-copy{display:grid;gap:1rem}
-    .hero-title{margin:0;font-size:clamp(2.8rem,6vw,4.6rem);letter-spacing:.32em}
-    .hero-subtitle{margin:0;font-size:1.1rem;color:var(--encre-dim);max-width:40ch;line-height:1.6}
-    .hero-actions{display:flex;gap:1rem;flex-wrap:wrap;margin-top:1rem}
-    .btn-outline{display:inline-flex;align-items:center;justify-content:center;padding:.7rem 1.5rem;border:1px solid var(--encre-dim);border-radius:999px;color:var(--encre);text-decoration:none;letter-spacing:.1em;text-transform:uppercase;font-size:.9rem}
-    .btn-outline:hover,.btn-outline:focus-visible{border-color:var(--dorure);color:var(--dorure)}
-
-    .loading-sigil{width:140px;height:140px;border-radius:50%;margin-inline:auto;border:1px solid rgba(214,184,124,0.4);display:grid;place-items:center;position:relative;box-shadow:0 0 40px rgba(79,62,160,0.25);animation:sigil-spin 24s linear infinite}
-    .loading-sigil::before,.loading-sigil::after{content:"";position:absolute;border-radius:50%;border:1px solid rgba(143,123,255,0.35)}
-    .loading-sigil::before{inset:12%;box-shadow:0 0 20px rgba(143,123,255,0.2)}
-    .loading-sigil::after{inset:24%;border-color:rgba(214,184,124,0.35)}
-    .loading-sigil span{width:4px;height:40%;background:linear-gradient(180deg,var(--violet-ray),transparent);transform-origin:50% 100%;animation:sigil-rays 18s linear infinite}
-
-    @keyframes sigil-spin{from{transform:rotate(0deg)}to{transform:rotate(360deg)}}
-    @keyframes sigil-rays{from{transform:rotate(0deg)}to{transform:rotate(360deg)}}
-
-    .section{display:grid;gap:1.5rem}
-    .section-titre{font-size:clamp(1.6rem,3vw,2.4rem);letter-spacing:.22em;margin:0;text-transform:uppercase}
-    .section-sous-titre{margin:0;color:var(--encre-dim);font-size:1.05rem;max-width:60ch}
-
-    .module-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:1.6rem}
-    .module-card{background:rgba(17,17,32,0.8);border:1px solid rgba(214,184,124,0.2);border-radius:18px;padding:1.6rem;display:grid;gap:1rem;position:relative;overflow:hidden;box-shadow:0 18px 50px rgba(11,11,22,0.6);transition:transform .35s ease, box-shadow .35s ease, border-color .35s ease}
-    .module-card::before{content:"";position:absolute;inset:-60% -20%;background:radial-gradient(circle,rgba(143,123,255,0.22),transparent 65%);animation:slow-rotate 28s linear infinite;mix-blend-mode:screen}
-    .module-card:hover,.module-card:focus-within{transform:translateY(-6px);border-color:var(--dorure);box-shadow:0 26px 60px rgba(79,62,160,0.45)}
-    .module-title{margin:0;font-size:1.35rem;letter-spacing:.1em;display:flex;align-items:center;gap:.6rem}
-    .module-description{margin:0;color:var(--encre-dim);line-height:1.7;font-size:.95rem}
-    .module-tags{display:flex;flex-wrap:wrap;gap:.5rem}
-    .tag{padding:.3rem .8rem;border-radius:999px;background:rgba(79,62,160,0.28);border:1px solid rgba(143,123,255,0.25);font-size:.75rem;letter-spacing:.08em;color:var(--encre-dim)}
-
-    @keyframes slow-rotate{from{transform:rotate(0deg)}to{transform:rotate(360deg)}}
-
-    .geometry-lab{background:rgba(17,17,36,0.74);border:1px solid rgba(143,123,255,0.25);border-radius:20px;padding:1.5rem;display:grid;gap:1.4rem;box-shadow:0 18px 50px rgba(8,8,20,0.65)}
-    .geometry-frame{position:relative;border:1px solid rgba(214,184,124,0.28);border-radius:16px;overflow:hidden;background:rgba(7,7,16,0.65)}
-    .geometric-canvas{display:block;width:100%;height:360px}
-    .control-panel{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:1rem}
-    .control-group{display:grid;gap:.4rem}
-    .control-label{text-transform:uppercase;letter-spacing:.08em;font-size:.75rem;color:var(--dorure)}
-    .control-slider{-webkit-appearance:none;height:6px;border-radius:3px;background:rgba(143,123,255,0.35);outline:0}
-    .control-slider::-webkit-slider-thumb{-webkit-appearance:none;width:18px;height:18px;border-radius:50%;background:var(--dorure);box-shadow:0 0 12px rgba(214,184,124,0.5);cursor:pointer}
-
-    .research-list{list-style:none;margin:0;padding:0;display:grid;gap:.8rem}
-    .research-list a{color:var(--dorure);text-decoration:none;letter-spacing:.08em}
-    .research-list a:focus-visible,.research-list a:hover{color:var(--violet-ray)}
-
-    .healing-interface{background:rgba(13,13,26,0.7);border:1px solid rgba(143,123,255,0.25);border-radius:18px;padding:1.6rem;display:grid;gap:1.2rem}
-    .frequency-display{font-family:"Roboto Mono",ui-monospace,monospace;text-align:center;font-size:1.6rem;color:var(--dorure)}
-    .color-palette{display:flex;flex-wrap:wrap;gap:.6rem;justify-content:center}
-    .color-swatch{width:48px;height:48px;border-radius:50%;border:2px solid transparent;cursor:pointer}
-    .color-swatch:focus-visible,.color-swatch:hover{border-color:var(--dorure)}
-
-    .journal-entry{background:rgba(18,18,32,0.82);border-left:3px solid var(--violet-ray);padding:1.2rem;border-radius:12px;color:var(--encre-dim);line-height:1.7}
-    .journal-date{font-size:.85rem;letter-spacing:.1em;text-transform:uppercase;color:var(--dorure);margin-bottom:.5rem}
-
-    .modal{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;background:rgba(5,5,12,0.86);backdrop-filter:blur(10px);z-index:2000}
-    .modal[hidden]{display:none}
-    .modal-content{background:linear-gradient(160deg,rgba(17,17,36,0.95),rgba(56,42,120,0.95));border:1px solid rgba(214,184,124,0.35);border-radius:18px;padding:2rem;max-width:520px;width:min(90vw,520px);box-shadow:0 30px 90px rgba(0,0,0,0.6)}
-    .close-modal{background:none;border:none;color:var(--encre-dim);font-size:1.4rem;cursor:pointer;position:absolute;top:1.2rem;right:1.2rem}
-    .close-modal:hover,.close-modal:focus-visible{color:var(--dorure)}
-    .modal-title{margin-top:0;letter-spacing:.12em;text-transform:uppercase}
-    .modal-body{color:var(--encre-dim);line-height:1.7}
-
-    .maison-footer{margin:4rem 0 2.5rem;text-align:center;color:var(--encre-dim);font-size:.85rem;letter-spacing:.08em;display:grid;gap:.8rem}
-    .footer-links{display:flex;flex-wrap:wrap;justify-content:center;gap:1.2rem}
-    .footer-links a{color:var(--encre-dim);text-decoration:none}
-    .footer-links a:hover,.footer-links a:focus-visible{color:var(--dorure)}
-
-    /* ND-safe: freeze ALL animations when reduced motion is set */
-    .reduced-motion *{animation:none!important;transition:none!important}
-    .reduced-motion .geometric-canvas::before,
-    .reduced-motion .geometric-canvas::after{animation:none!important}
-    .reduced-motion .loading-sigil{animation:none!important}
-    .reduced-motion .module-card::before{animation:none!important}
-
-    @media (prefers-reduced-motion: reduce){
-      .loading-sigil{animation:none}
-      .module-card::before{animation:none}
-    }
-
-    @media (max-width:900px){
-      .nav-collection{gap:1rem}
-      .btn-couture{display:none}
-    }
-  </style>
+  <link rel="preload" as="image" href="./assets/img/tesseract-chamber-1024.webp">
+  <link rel="stylesheet" href="./assets/css/atelier.css">
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
+  <div class="geometric-canvas" aria-hidden="true"></div>
+  <header class="atelier-header" id="top">
+    <nav class="atelier-nav" aria-label="Primary">
+      <a href="#collections" class="marque-logo">COSMOGENESIS</a>
+      <ul class="nav-collection">
+        <li><a data-route="true" href="#collections">Collections</a></li>
+        <li><a data-route="true" href="#arcana">Living Arcana</a></li>
+        <li><a data-route="true" href="#node-system">Node System</a></li>
+        <li><a data-route="true" href="#research">Research</a></li>
+        <li><a data-route="true" href="#atelier">Atelier</a></li>
+      </ul>
+      <button id="calmToggle" type="button" class="btn-couture" aria-pressed="false">Calm Mode</button>
+    </nav>
+  </header>
 
-  <nav class="atelier-nav">
-    <a href="#collections" class="marque-logo">COSMOGENESIS</a>
-    <ul class="nav-collection">
-      <li><a href="#collections">Collections</a></li>
-      <li><a href="#arcana">Living Arcana</a></li>
-      <li><a href="#node-system">Node System</a></li>
-      <li><a href="#research">Research</a></li>
-      <li><a href="#atelier">Atelier</a></li>
-    </ul>
-    <button id="calmToggle" class="btn-couture" aria-pressed="false">Calm Mode</button>
-  </nav>
-
-  <canvas id="sacred-canvas" aria-hidden="true"></canvas>
-
-  <main id="main">
+  <main id="main" tabindex="-1">
     <section id="collections" class="hero" aria-labelledby="hero-title">
       <div class="hero-copy">
         <h1 id="hero-title" class="hero-title">COSMOGENESIS</h1>
         <p class="hero-subtitle">A couture codex weaving sacred geometry, trauma-informed pedagogy, and living arcana registries. Every layer breathes slowly and honours ND-safe pacing.</p>
         <div class="hero-actions">
-          <a class="btn-outline" href="#arcana">Explore Collections</a>
-          <a class="btn-outline" href="#atelier">Enter Atelier</a>
+          <a class="btn-outline" data-route="true" href="#arcana">Explore Collections</a>
+          <a class="btn-outline" data-route="true" href="#atelier">Enter Atelier</a>
         </div>
       </div>
-      <div class="loading-sigil" aria-hidden="true"><span></span></div>
+      <div class="hero-visual">
+        <img class="hero-image" src="./assets/img/tesseract-chamber-1024.webp" width="720" height="480" alt="Celestial chamber with layered sacred geometry." decoding="async">
+        <div class="atelier-loading" aria-hidden="true">
+          <span class="loader-ray" aria-hidden="true"></span>
+        </div>
+      </div>
     </section>
 
     <section id="arcana" class="section" aria-labelledby="arcana-title">
@@ -215,7 +94,7 @@
         </article>
         <article class="module-card" tabindex="0" data-title="Living Arcana System" data-description="Dynamic Tarot <-> Tree correspondences. Real-time archetypal pattern synthesis.">
           <h3 class="module-title">Living Arcana System</h3>
-          <p class="module-description">Dynamic Tarot <-> Tree correspondences. Real-time archetypal pattern synthesis.</p>
+          <p class="module-description">Dynamic Tarot &lt;-&gt; Tree correspondences. Real-time archetypal pattern synthesis.</p>
           <div class="module-tags">
             <span class="tag">Tarot</span>
             <span class="tag">Qabalah</span>
@@ -228,28 +107,12 @@
     <section id="node-system" class="section" aria-labelledby="node-title">
       <h2 id="node-title" class="section-titre">Node System Laboratory</h2>
       <p class="section-sous-titre">Layered geometry studio&mdash;calibrated to numerology constants {3, 7, 9, 11, 22, 33, 99, 144}. Motion pauses when Calm Mode is active.</p>
-      <div class="geometry-lab">
-        <div class="geometry-frame">
-          <canvas id="geometry-canvas" class="geometric-canvas" aria-label="Geometry canvas"></canvas>
+      <div class="node-grid-wrapper" role="region" aria-labelledby="node-title" aria-live="polite">
+        <div id="node-loader" class="atelier-loading" role="status" aria-live="polite">
+          <span class="sr-only">Calibrating node registry...</span>
+          <span class="loader-ray" aria-hidden="true"></span>
         </div>
-        <div class="control-panel" role="group" aria-label="Geometry controls">
-          <div class="control-group">
-            <label class="control-label" for="recursion">Recursion Depth</label>
-            <input id="recursion" type="range" class="control-slider" min="1" max="12" value="6">
-          </div>
-          <div class="control-group">
-            <label class="control-label" for="phi">Golden Ratio (phi)</label>
-            <input id="phi" type="range" class="control-slider" min="0" max="100" value="61">
-          </div>
-          <div class="control-group">
-            <label class="control-label" for="rotation">Rotation Speed</label>
-            <input id="rotation" type="range" class="control-slider" min="0" max="100" value="30">
-          </div>
-          <div class="control-group">
-            <label class="control-label" for="complexity">Fractal Complexity</label>
-            <input id="complexity" type="range" class="control-slider" min="3" max="24" value="12">
-          </div>
-        </div>
+        <ul id="node-list" class="node-grid" aria-live="polite"></ul>
       </div>
     </section>
 
@@ -285,276 +148,23 @@
     </section>
   </main>
 
-  <div id="modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title" hidden>
-    <div class="modal-content">
-      <button type="button" class="close-modal" aria-label="Close modal">Close</button>
-      <h3 id="modal-title" class="modal-title"></h3>
-      <p id="modal-body" class="modal-body"></p>
-    </div>
-  </div>
-
   <footer class="maison-footer">
+    <div class="footer-marque">COSMOGENESIS</div>
     <div class="footer-links">
       <a href="#collections">Harmonic Research</a>
       <a href="#node-system">Node System Docs</a>
       <a href="https://github.com/Rebecca-Respawn/cosmogenesis-learning-engine" rel="noopener noreferrer">Open Source</a>
       <a href="#atelier">Commissions</a>
     </div>
-    <p class="copyright">&copy; MMXXV &mdash; Atelier of Sacred Geometry &amp; Consciousness Research</p>
+    <p class="copyright">© MMXXV — Atelier of Sacred Geometry &amp; Consciousness Research</p>
   </footer>
 
-  <script>
-    const root = document.documentElement;
-    const calmBtn = document.getElementById('calmToggle');
-    const prefersReducedMotion = typeof window !== 'undefined' && typeof window.matchMedia === 'function'
-      ? window.matchMedia('(prefers-reduced-motion: reduce)')
-      : null;
-
-    function setCalmButtonState() {
-      if (calmBtn) {
-        calmBtn.setAttribute('aria-pressed', String(root.classList.contains('reduced-motion')));
-      }
-    }
-
-    if (prefersReducedMotion && prefersReducedMotion.matches) {
-      root.classList.add('reduced-motion');
-    }
-    setCalmButtonState();
-
-    const handlePreferenceChange = (event) => {
-      root.classList.toggle('reduced-motion', event.matches);
-      refreshMotionState();
-    };
-
-    if (prefersReducedMotion) {
-      if (typeof prefersReducedMotion.addEventListener === 'function') {
-        prefersReducedMotion.addEventListener('change', handlePreferenceChange);
-      } else if (typeof prefersReducedMotion.addListener === 'function') {
-        prefersReducedMotion.addListener(handlePreferenceChange);
-      }
-    }
-
-    calmBtn?.addEventListener('click', () => {
-      root.classList.toggle('reduced-motion');
-      refreshMotionState();
-    });
-
-    const bgCanvas = document.getElementById('sacred-canvas');
-    const bgCtx = bgCanvas ? bgCanvas.getContext('2d') : null;
-    const particles = [];
-    let bgAnimationId = null;
-
-    function resizeBg() {
-      if (!bgCanvas) return;
-      bgCanvas.width = window.innerWidth;
-      bgCanvas.height = window.innerHeight;
-    }
-
-    function seedParticles() {
-      if (!bgCanvas) return;
-      particles.length = 0;
-      const count = root.classList.contains('reduced-motion') ? 12 : 48;
-      for (let i = 0; i < count; i += 1) {
-        particles.push({
-          x: Math.random() * bgCanvas.width,
-          y: Math.random() * bgCanvas.height,
-          vx: (Math.random() - 0.5) * 0.28,
-          vy: (Math.random() - 0.5) * 0.28,
-          r: Math.random() * 2 + 0.6,
-          life: Math.random() * 0.8 + 0.2
-        });
-      }
-    }
-
-    function drawBackdrop() {
-      if (!bgCanvas || !bgCtx) return;
-      bgCtx.clearRect(0, 0, bgCanvas.width, bgCanvas.height);
-      particles.forEach((p) => {
-        p.x += p.vx;
-        p.y += p.vy;
-        p.life -= 0.0012;
-        if (p.x < 0 || p.x > bgCanvas.width) p.vx *= -1;
-        if (p.y < 0 || p.y > bgCanvas.height) p.vy *= -1;
-        if (p.life <= 0) {
-          p.x = Math.random() * bgCanvas.width;
-          p.y = Math.random() * bgCanvas.height;
-          p.life = Math.random() * 0.8 + 0.2;
-        }
-        bgCtx.globalAlpha = p.life * 0.6;
-        bgCtx.fillStyle = '#d6b87c';
-        bgCtx.beginPath();
-        bgCtx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
-        bgCtx.fill();
-      });
-      bgCtx.globalAlpha = 1;
-      if (!root.classList.contains('reduced-motion')) {
-        bgAnimationId = requestAnimationFrame(drawBackdrop);
-      }
-    }
-
-    function startBackdrop() {
-      if (!bgCanvas || !bgCtx) return;
-      cancelAnimationFrame(bgAnimationId);
-      if (root.classList.contains('reduced-motion')) {
-        drawBackdrop();
-        return;
-      }
-      bgAnimationId = requestAnimationFrame(drawBackdrop);
-    }
-
-    const geometryCanvas = document.getElementById('geometry-canvas');
-    const geoCtx = geometryCanvas ? geometryCanvas.getContext('2d') : null;
-    let geoAnimationId = null;
-    let geoTime = 0;
-    let recursionDepth = 6;
-    let phiRatio = 1.61;
-    let rotationSpeed = 0.3;
-    let complexity = 12;
-
-    function resizeGeometry() {
-      if (!geometryCanvas) return;
-      geometryCanvas.width = geometryCanvas.clientWidth;
-      geometryCanvas.height = geometryCanvas.clientHeight;
-    }
-
-    function drawFlower(x, y, r, depth) {
-      if (!geoCtx || depth <= 0) return;
-      geoCtx.strokeStyle = `hsla(${(geoTime * 45) % 360},70%,68%,${depth / recursionDepth})`;
-      geoCtx.lineWidth = 0.6;
-      geoCtx.beginPath();
-      geoCtx.arc(x, y, r, 0, Math.PI * 2);
-      geoCtx.stroke();
-      for (let i = 0; i < complexity; i += 6) {
-        const angle = (Math.PI * 2 / complexity) * (i + 1) + geoTime * rotationSpeed;
-        const nx = x + Math.cos(angle) * r;
-        const ny = y + Math.sin(angle) * r;
-        geoCtx.beginPath();
-        geoCtx.arc(nx, ny, r / phiRatio, 0, Math.PI * 2);
-        geoCtx.stroke();
-        if (depth > 1) {
-          drawFlower(nx, ny, r / phiRatio, depth - 1);
-        }
-      }
-    }
-
-    function renderGeometry() {
-      if (!geometryCanvas || !geoCtx) return;
-      geoCtx.clearRect(0, 0, geometryCanvas.width, geometryCanvas.height);
-      const radius = Math.min(geometryCanvas.width, geometryCanvas.height) / 3.2;
-      drawFlower(geometryCanvas.width / 2, geometryCanvas.height / 2, radius, recursionDepth);
-      if (!root.classList.contains('reduced-motion')) {
-        geoTime += 0.015;
-        geoAnimationId = requestAnimationFrame(renderGeometry);
-      }
-    }
-
-    function startGeometry() {
-      if (!geometryCanvas || !geoCtx) return;
-      cancelAnimationFrame(geoAnimationId);
-      renderGeometry();
-    }
-
-    document.getElementById('recursion')?.addEventListener('input', (event) => {
-      recursionDepth = Number(event.target.value);
-      startGeometry();
-    });
-    document.getElementById('phi')?.addEventListener('input', (event) => {
-      phiRatio = 1 + Number(event.target.value) / 100;
-      startGeometry();
-    });
-    document.getElementById('rotation')?.addEventListener('input', (event) => {
-      rotationSpeed = Number(event.target.value) / 120;
-      startGeometry();
-    });
-    document.getElementById('complexity')?.addEventListener('input', (event) => {
-      complexity = Number(event.target.value);
-      startGeometry();
-    });
-
-    const freqReadout = document.getElementById('freqReadout');
-    document.getElementById('palette')?.addEventListener('click', (event) => {
-      const swatch = event.target.closest('.color-swatch');
-      if (!swatch || !freqReadout) return;
-      const hz = swatch.getAttribute('data-freq') || '432';
-      freqReadout.textContent = `${hz} Hz`;
-    });
-
-    const modal = document.getElementById('modal');
-    const modalTitle = document.getElementById('modal-title');
-    const modalBody = document.getElementById('modal-body');
-    const closeModalBtn = modal?.querySelector('.close-modal');
-
-    function openModal(title, description) {
-      if (!modal || !modalTitle || !modalBody || !closeModalBtn) return;
-      modalTitle.textContent = title;
-      modalBody.textContent = description;
-      modal.removeAttribute('hidden');
-      closeModalBtn.focus();
-    }
-
-    function closeModal() {
-      if (!modal) return;
-      modal.setAttribute('hidden', '');
-    }
-
-    closeModalBtn?.addEventListener('click', closeModal);
-    modal?.addEventListener('click', (event) => {
-      if (event.target === modal) {
-        closeModal();
-      }
-    });
-    window.addEventListener('keydown', (event) => {
-      if (event.key === 'Escape' && modal && !modal.hasAttribute('hidden')) {
-        closeModal();
-      }
-    });
-
-    document.querySelectorAll('.module-card').forEach((card) => {
-      card.addEventListener('click', () => {
-        openModal(card.dataset.title || 'Module', card.dataset.description || 'Details forthcoming.');
-      });
-      card.addEventListener('keydown', (event) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault();
-          openModal(card.dataset.title || 'Module', card.dataset.description || 'Details forthcoming.');
-        }
-      });
-    });
-
-    function refreshMotionState() {
-      setCalmButtonState();
-      seedParticles();
-      startBackdrop();
-      startGeometry();
-    }
-
-    window.addEventListener('resize', () => {
-      resizeBg();
-      resizeGeometry();
-      refreshMotionState();
-    });
-
-    resizeBg();
-    resizeGeometry();
-    refreshMotionState();
-
-    (function(){
-      const canvas = document.querySelector('.geometric-canvas');
-      if (!canvas) return;
-      let ticking = false;
-      function updateParallax(){
-        if (root.classList.contains('reduced-motion')) {
-          canvas.style.transform = '';
-          ticking = false; return;
-        }
-        const y = window.scrollY * 0.5;
-        canvas.style.transform = `translateY(${y}px)`;
-        ticking = false;
-      }
-      window.addEventListener('scroll', function(){
-        if (!ticking){ requestAnimationFrame(updateParallax); ticking = true; }
-      }, { passive:true });
-    })();
+  <script type="module" src="./assets/js/boot.js"></script>
+  <script type="application/json" id="nodes-fallback">
+  [
+    {"id":"00-void","name":"Void","type":"Origin","numerology":0,"lore":"The silent lumen holds the womb of all potential."},
+    {"id":"01-magician","name":"Magician","type":"Initiate","numerology":1,"lore":"The first spark weaves intention through the lattice."}
+  ]
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add dedicated atelier stylesheet with haute-couture palette, golden-ratio scale, and motion safety helpers
- replace the site landing page with the atelier shell, inline JSON fallback, and ND-safe section layout
- add a boot script and node dataset to drive calm mode, parallax guard, and safe node card rendering

## Testing
- not run (static content changes)

------
https://chatgpt.com/codex/tasks/task_e_68cb8cc4d8508328959bfba41a438bf4