### PR TITLE
Consolidate atelier site navigation and app shells

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,19 +1,32 @@
-# /netlify.toml
 [build]
   publish = "site"
   command = ""
 
-# keep your older app under /engine if needed
-[[redirects]]
-  from = "/engine/*"
-  to = "/app/index.html"
-  status = 200 # /netlify.toml
-[build]
-  publish = "site"
-  command = ""
+  [build.environment]
+    GIT_LFS_ENABLED = "true"
 
-# keep your older app under /engine if needed
+# spokes under one roof
 [[redirects]]
-  from = "/engine/*"
-  to = "/app/index.html"
+  from = "/liber/*"
+  to   = "/apps/liber-arcanae/index.html"
   status = 200
+
+[[redirects]]
+  from = "/circuitum/*"
+  to   = "/apps/circuitum99/index.html"
+  status = 200
+
+# SPA catch-all for plain folders like /research, /gallery, /contact (static works too)
+[[redirects]]
+  from = "/*"
+  to   = "/index.html"
+  status = 200
+
+# minimal headers
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Content-Type-Options = "nosniff"
+    X-Frame-Options        = "SAMEORIGIN"
+    Referrer-Policy        = "no-referrer"
+    Permissions-Policy     = "accelerometer=(), camera=(), geolocation=()"

--- a/site/apps/circuitum99/index.html
+++ b/site/apps/circuitum99/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Circuitum99 · Sacred Geometry</title>
+<link rel="stylesheet" href="../../assets/css/atelier.css">
+<header class="atelier-nav"><a href="../../index.html" class="marque-logo">COSMOGENESIS</a></header>
+<main id="main" class="collections">
+  <h1 class="section-titre">Circuitum99</h1>
+  <p class="section-sous-titre">Tesseracts, vesicas, harmonic engines</p>
+  <div id="node-list" class="collection-grid" aria-live="polite"></div>
+  <script type="application/json" id="brain-config">
+  {"origin":location.origin,"path":"/data/v1/nodes.min.json"}
+  </script>
+  <script type="application/json" id="nodes-fallback">
+  [{"id":"01-magician","name":"Magician","type":"Arcana","numerology":1,"lore":"The will to pattern reality."}]
+  </script>
+</main>
+<footer class="maison-footer"><a href="../../index.html">← Atelier</a></footer>
+<script src="../../js/boot.js" defer></script>

--- a/site/apps/liber-arcanae/index.html
+++ b/site/apps/liber-arcanae/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Liber Arcanae · Living Tarot</title>
+<link rel="stylesheet" href="../../assets/css/atelier.css">
+<header class="atelier-nav"><a href="../../index.html" class="marque-logo">COSMOGENESIS</a></header>
+<main id="main" class="collections">
+  <h1 class="section-titre">Liber Arcanae</h1>
+  <p class="section-sous-titre">Interactive tarot & lineage scrolls</p>
+  <div id="node-list" class="collection-grid" aria-live="polite"></div>
+  <script type="application/json" id="brain-config">
+  {"origin":location.origin,"path":"/data/v1/nodes.min.json"}
+  </script>
+  <script type="application/json" id="nodes-fallback">
+  [{"id":"00-void","name":"Void","type":"Axiom","numerology":0,"lore":"The silent ground of being."}]
+  </script>
+</main>
+<footer class="maison-footer"><a href="../../index.html">← Atelier</a></footer>
+<script src="../../js/boot.js" defer></script>

--- a/site/assets/css/atelier.css
+++ b/site/assets/css/atelier.css
@@ -1,0 +1,412 @@
+/*
+  Atelier styles shared across the consolidated site.
+  ND-safe guidance: calm contrast palette, optional Calm Mode reduces motion.
+*/
+:root {
+  --noir: #000000;
+  --blanc: #ffffff;
+  --or: #d4af37;
+  --argent: #c0c0c0;
+  --pourpre: #6b3aa0;
+  --xs: 0.618rem;
+  --sm: 1rem;
+  --md: 1.618rem;
+  --lg: 2.618rem;
+  --xl: 4.236rem;
+  --xxl: 6.854rem;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html, body {
+  min-height: 100%;
+}
+
+body {
+  font-family: 'Bodoni Moda', 'Didot', Georgia, serif;
+  background: var(--noir);
+  color: var(--blanc);
+  overflow-x: hidden;
+}
+
+body a {
+  color: inherit;
+}
+
+.skip-link {
+  position: absolute;
+  left: -9999px;
+}
+
+.skip-link:focus {
+  left: 1rem;
+  top: 1rem;
+  background: #000000;
+  color: #ffffff;
+  padding: 0.5rem 1rem;
+  z-index: 10001;
+  border: 1px solid var(--or);
+}
+
+.reduced-motion * {
+  animation: none !important;
+  transition: none !important;
+}
+
+.atelier-nav {
+  position: fixed;
+  inset: 0 0 auto 0;
+  padding: 1rem 2rem;
+  z-index: 1000;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  align-items: center;
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.9), transparent);
+}
+
+.marque-logo {
+  font-size: var(--md);
+  letter-spacing: 0.3em;
+  font-weight: 300;
+  color: var(--blanc);
+  text-decoration: none;
+  transition: letter-spacing 0.5s cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.marque-logo:hover,
+.marque-logo:focus-visible {
+  letter-spacing: 0.5em;
+  color: var(--or);
+}
+
+.nav-collection {
+  display: flex;
+  gap: 2rem;
+  list-style: none;
+}
+
+.nav-collection a {
+  color: var(--argent);
+  text-decoration: none;
+  font-size: var(--xs);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  position: relative;
+}
+
+.nav-collection a::after {
+  content: '';
+  position: absolute;
+  bottom: -5px;
+  left: 0;
+  width: 0;
+  height: 1px;
+  background: var(--or);
+  transition: width 0.3s ease;
+}
+
+.nav-collection a:hover::after,
+.nav-collection a:focus-visible::after {
+  width: 100%;
+}
+
+.btn {
+  border: 1px solid var(--or);
+  background: transparent;
+  color: var(--blanc);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 0.5rem 0.8rem;
+  font-size: var(--xs);
+  cursor: pointer;
+}
+
+.entrance {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  overflow: hidden;
+  padding-top: 5rem;
+}
+
+.field {
+  position: absolute;
+  inset: 0;
+  opacity: 0.18;
+  background:
+    radial-gradient(600px 400px at 50% 60%, rgba(212, 175, 55, 0.06), transparent 60%),
+    url('../img/hero.webp') center/cover no-repeat;
+}
+
+.field::before,
+.field::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 500px;
+  height: 500px;
+  border: 1px solid var(--or);
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  animation: expand 8s ease-in-out infinite;
+}
+
+.field::after {
+  border-color: var(--pourpre);
+  transform: translate(-50%, -50%) rotate(45deg);
+  animation-direction: reverse;
+}
+
+@keyframes expand {
+  0%,
+  100% {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 0.3;
+  }
+  50% {
+    transform: translate(-50%, -50%) scale(1.5);
+    opacity: 0.08;
+  }
+}
+
+.hero {
+  z-index: 1;
+  max-width: 1000px;
+  padding: 0 2rem;
+  text-align: center;
+}
+
+.grand {
+  font-size: var(--xxl);
+  font-weight: 300;
+  letter-spacing: 0.1em;
+  line-height: 0.9;
+  margin-bottom: 1rem;
+  background: linear-gradient(180deg, var(--blanc) 0%, var(--or) 55%, var(--blanc) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: shimmer 3s ease-in-out infinite;
+}
+
+@keyframes shimmer {
+  0%,
+  100% {
+    filter: brightness(1);
+  }
+  50% {
+    filter: brightness(1.15);
+  }
+}
+
+.sous {
+  font-size: var(--sm);
+  font-weight: 300;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--argent);
+  margin-bottom: 1.4rem;
+}
+
+.manif {
+  font-size: var(--md);
+  line-height: 1.8;
+  font-style: italic;
+  opacity: 0.9;
+  max-width: 800px;
+  margin: 0 auto 1.4rem;
+}
+
+.actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.actions a,
+.actions button {
+  padding: 1rem 1.8rem;
+}
+
+.section {
+  padding: 6rem 2rem;
+}
+
+.title {
+  font-size: var(--xl);
+  font-weight: 300;
+  letter-spacing: 0.15em;
+  margin-bottom: 0.5rem;
+  color: var(--or);
+  text-align: center;
+}
+
+.sub {
+  font-size: var(--sm);
+  font-style: italic;
+  color: var(--argent);
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+.grid,
+.collection-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.collection-grid {
+  list-style: none;
+  padding: 0;
+}
+
+.card,
+.collection-piece {
+  border: 1px solid rgba(212, 175, 55, 0.3);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.02), transparent);
+  padding: 2rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.card:hover,
+.collection-piece:hover {
+  border-color: var(--or);
+  transform: translateY(-6px);
+  transition: 0.3s ease;
+}
+
+.collection-piece h3 {
+  font-size: 1.4rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.collection-description,
+.collection-piece p {
+  color: var(--argent);
+  line-height: 1.6;
+}
+
+.collection-piece button,
+.collection-piece a {
+  justify-self: start;
+  border: 1px solid var(--or);
+  background: transparent;
+  color: var(--blanc);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 0.5rem 0.8rem;
+  font-size: var(--xs);
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.collections {
+  padding: 6rem 2rem 4rem;
+  display: grid;
+  gap: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.collections > h1 {
+  text-align: center;
+}
+
+.section-titre {
+  font-size: var(--xl);
+  font-weight: 300;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--or);
+  text-align: center;
+}
+
+.section-sous-titre {
+  font-size: var(--sm);
+  font-style: italic;
+  color: var(--argent);
+  text-align: center;
+}
+
+.maison-footer {
+  padding: 3rem 2rem;
+  text-align: center;
+  border-top: 1px solid rgba(212, 175, 55, 0.2);
+}
+
+.maison-footer a {
+  color: var(--argent);
+  text-decoration: none;
+}
+
+.footer {
+  padding: 3rem 2rem;
+  border-top: 1px solid rgba(212, 175, 55, 0.2);
+  text-align: center;
+}
+
+.footer .brand {
+  font-size: var(--lg);
+  letter-spacing: 0.3em;
+  margin-bottom: 1rem;
+  color: var(--or);
+}
+
+.atelier-statement {
+  padding: 6rem 2rem 4rem;
+  display: grid;
+  gap: 1.5rem;
+  max-width: 800px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.statement-text {
+  font-size: 1.2rem;
+  letter-spacing: 0.05em;
+}
+
+.footer-links {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.footer-links a {
+  color: var(--argent);
+  letter-spacing: 0.1em;
+  text-decoration: none;
+  text-transform: uppercase;
+  font-size: var(--xs);
+}
+
+@media (max-width: 768px) {
+  .grand {
+    font-size: var(--xl);
+  }
+
+  .nav-collection {
+    display: none;
+  }
+
+  .collections,
+  .section {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+}

--- a/site/contact/index.html
+++ b/site/contact/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Contact & Provenance · Cosmogenesis</title>
+<link rel="stylesheet" href="../assets/css/atelier.css">
+<header class="atelier-nav"><a href="../index.html" class="marque-logo">COSMOGENESIS</a></header>
+<main id="main" class="atelier-statement">
+  <h1 class="section-titre">Provenance</h1>
+  <p class="statement-text">© 2025 Rebecca Respawn (Bekalah). License & lineage honored.</p>
+  <p><a href="/LICENSE" rel="noopener noreferrer">License</a> · <a href="/open_source_art_index.md" rel="noopener noreferrer">Open-source art index</a></p>
+</main>
+<footer class="maison-footer"><a href="../index.html">← Atelier</a></footer>

--- a/site/data/v1/nodes.min.json
+++ b/site/data/v1/nodes.min.json
@@ -1,0 +1,4 @@
+[
+  {"id":"00-void","name":"Void","type":"Axiom","numerology":0,"lore":"The silent ground of being.","lab":"/apps/liber-arcanae/index.html"},
+  {"id":"01-magician","name":"Magician","type":"Arcana","numerology":1,"lore":"The will to pattern reality.","lab":"/apps/circuitum99/index.html"}
+]

--- a/site/gallery/index.html
+++ b/site/gallery/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Gallery · Cosmogenesis</title>
+<link rel="stylesheet" href="../assets/css/atelier.css">
+<header class="atelier-nav"><a href="../index.html" class="marque-logo">COSMOGENESIS</a></header>
+<main id="main" class="collections">
+  <h1 class="section-titre">Gallery</h1>
+  <div class="collection-grid">
+    <!-- add <figure class="collection-piece"><img src="/assets/img/plate01.webp" alt="…" loading="lazy" decoding="async"><figcaption>…</figcaption></figure> -->
+  </div>
+</main>
+<footer class="maison-footer"><a href="../index.html">← Atelier</a></footer>

--- a/site/index.html
+++ b/site/index.html
@@ -6,73 +6,20 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="description" content="A couture atelier for harmonic matrices, living arcana, and the bridge between science and art." />
   <link href="https://fonts.googleapis.com/css2?family=Bodoni+Moda:wght@300;400;700&display=swap" rel="stylesheet" />
-  <style>
-    :root{
-      --noir:#000; --blanc:#fff; --or:#D4AF37; --argent:#C0C0C0; --pourpre:#6B3AA0;
-      --xs:.618rem; --sm:1rem; --md:1.618rem; --lg:2.618rem; --xl:4.236rem; --xxl:6.854rem;
-    }
-    *{margin:0;padding:0;box-sizing:border-box}
-    body{
-      font-family:'Bodoni Moda','Didot',Georgia,serif; background:var(--noir); color:var(--blanc); overflow-x:hidden;
-      cursor:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32"><circle cx="16" cy="16" r="2" fill="white"/><circle cx="16" cy="16" r="8" fill="none" stroke="white" stroke-width="0.5" opacity="0.5"/></svg>'),auto;
-    }
-    .skip-link{position:absolute;left:-9999px}
-    .skip-link:focus{left:1rem;top:1rem;background:#000;color:#fff;padding:.5rem 1rem;z-index:10001;border:1px solid var(--or)}
-    .reduced-motion *{animation:none!important;transition:none!important}
-
-    /* Nav */
-    .atelier-nav{position:fixed;inset:0 0 auto 0;padding:1rem 2rem;z-index:1000;display:flex;gap:1rem;justify-content:space-between;align-items:center;background:linear-gradient(180deg,rgba(0,0,0,.9),transparent)}
-    .marque-logo{font-size:var(--md);letter-spacing:.3em;font-weight:300;color:var(--blanc);text-decoration:none;transition:letter-spacing .5s cubic-bezier(.23,1,.32,1)}
-    .marque-logo:hover{letter-spacing:.5em;color:var(--or)}
-    .nav-collection{display:flex;gap:2rem;list-style:none}
-    .nav-collection a{color:var(--argent);text-decoration:none;font-size:var(--xs);letter-spacing:.1em;text-transform:uppercase;position:relative}
-    .nav-collection a::after{content:'';position:absolute;bottom:-5px;left:0;width:0;height:1px;background:var(--or);transition:width .3s}
-    .nav-collection a:hover::after{width:100%}
-    .btn{border:1px solid var(--or);background:transparent;color:var(--blanc);letter-spacing:.12em;text-transform:uppercase;padding:.5rem .8rem;font-size:var(--xs);cursor:pointer}
-
-    /* Hero */
-    .entrance{min-height:100vh;display:flex;align-items:center;justify-content:center;position:relative;overflow:hidden;padding-top:5rem}
-    .field{position:absolute;inset:0;opacity:.18;background:
-      radial-gradient(600px 400px at 50% 60%, rgba(212,175,55,.06), transparent 60%),
-      url('./assets/img/hero.webp') center/cover no-repeat}
-    .field::before,.field::after{content:'';position:absolute;top:50%;left:50%;width:500px;height:500px;border:1px solid var(--or);border-radius:50%;
-      transform:translate(-50%,-50%);animation:expand 8s ease-in-out infinite}
-    .field::after{border-color:var(--pourpre);transform:translate(-50%,-50%) rotate(45deg);animation-direction:reverse}
-    @keyframes expand{0%,100%{transform:translate(-50%,-50%) scale(1);opacity:.3}50%{transform:translate(-50%,-50%) scale(1.5);opacity:.08}}
-
-    .hero{z-index:1;max-width:1000px;padding:0 2rem;text-align:center}
-    .grand{font-size:var(--xxl);font-weight:300;letter-spacing:.1em;line-height:.9;margin-bottom:1rem;
-      background:linear-gradient(180deg,var(--blanc) 0%,var(--or) 55%,var(--blanc) 100%);-webkit-background-clip:text;-webkit-text-fill-color:transparent;animation:shimmer 3s ease-in-out infinite}
-    @keyframes shimmer{0%,100%{filter:brightness(1)}50%{filter:brightness(1.15)}}
-    .sous{font-size:var(--sm);font-weight:300;letter-spacing:.2em;text-transform:uppercase;color:var(--argent);margin-bottom:1.4rem}
-    .manif{font-size:var(--md);line-height:1.8;font-style:italic;opacity:.9;max-width:800px;margin:0 auto 1.4rem}
-    .actions{display:flex;gap:1rem;flex-wrap:wrap;justify-content:center}
-    .actions a,.actions button{padding:1rem 1.8rem}
-
-    /* Sections */
-    .section{padding:6rem 2rem}
-    .title{font-size:var(--xl);font-weight:300;letter-spacing:.15em;margin-bottom:.5rem;color:var(--or);text-align:center}
-    .sub{font-size:var(--sm);font-style:italic;color:var(--argent);text-align:center;margin-bottom:2.5rem}
-    .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:2rem;max-width:1200px;margin:0 auto}
-    .card{border:1px solid rgba(212,175,55,.3);background:linear-gradient(135deg,rgba(255,255,255,.02),transparent);padding:2rem}
-    .card:hover{border-color:var(--or);transform:translateY(-6px);transition:.3s}
-
-    .footer{padding:3rem 2rem;border-top:1px solid rgba(212,175,55,.2);text-align:center}
-    .footer .brand{font-size:var(--lg);letter-spacing:.3em;margin-bottom:1rem;color:var(--or)}
-
-    @media (max-width:768px){.grand{font-size:var(--xl)} .nav-collection{display:none}}
-  </style>
+  <link rel="stylesheet" href="./assets/css/atelier.css" />
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
 
   <nav class="atelier-nav" role="navigation" aria-label="Primary">
-    <a href="#collections" class="marque-logo">COSMOGENESIS</a>
+    <a href="./" class="marque-logo">COSMOGENESIS</a>
     <ul class="nav-collection">
       <li><a href="#collections">Collections</a></li>
-      <li><a href="#arcana">Living Arcana</a></li>
-      <li><a href="#node-system">Node System</a></li>
-      <li><a href="#atelier">Atelier</a></li>
+      <li><a href="/liber/">Liber Arcanae</a></li>
+      <li><a href="/circuitum/">Circuitum99</a></li>
+      <li><a href="/research/">Research</a></li>
+      <li><a href="/gallery/">Gallery</a></li>
+      <li><a href="/contact/">Contact</a></li>
     </ul>
     <button id="calmToggle" class="btn" aria-pressed="false">Calm Mode</button>
   </nav>
@@ -106,11 +53,13 @@
     <section class="section" id="node-system" aria-label="Node Catalog">
       <h2 class="title">Modular Node System</h2>
       <p class="sub">Programmable art via sacred mathematics</p>
-      <div id="node-list" class="grid" aria-live="polite"></div>
-      <!-- Inline dataset enables offline viewing; HTTP(S) will fetch /data/nodes.json instead -->
-      <script type="application/json" id="nodes-data">
-        [{"id":"00-void","name":"Void","type":"Axiom","numerology":0,"lore":"The silent ground of being.","lab":"./labs/void-lab.html"},
-         {"id":"01-magician","name":"Magician","type":"Arcana","numerology":1,"lore":"The will to pattern reality.","lab":"./labs/void-lab.html"}]
+      <div id="node-list" class="collection-grid" aria-live="polite"></div>
+      <script type="application/json" id="brain-config">
+        {"origin":location.origin,"path":"/data/v1/nodes.min.json"}
+      </script>
+      <script type="application/json" id="nodes-fallback">
+        [{"id":"00-void","name":"Void","type":"Axiom","numerology":0,"lore":"The silent ground of being.","lab":"/apps/liber-arcanae/index.html"},
+         {"id":"01-magician","name":"Magician","type":"Arcana","numerology":1,"lore":"The will to pattern reality.","lab":"/apps/circuitum99/index.html"}]
       </script>
     </section>
 
@@ -130,19 +79,24 @@
       <div class="grid">
         <article class="card"><h3>Studio</h3><p>Commissions & collaboration.</p></article>
         <article class="card"><h3>Scrolls</h3><p>Essays, diagrams, datasets.</p></article>
-        <article class="card"><h3>Provenance</h3><p>Licenses & lineage.</p></article> This keeps your atelier look while fixing the duplicates, the broken anchor, and adds Calm Mode per your accessibility goals and the progressive enhancement strategy.    
-
-
+        <article class="card"><h3>Provenance</h3><p>Licenses & lineage.</p></article>
       </div>
     </section>
   </main>
 
   <footer class="footer" role="contentinfo">
+    <nav class="footer-links" aria-label="Footer">
+      <a href="#collections">Collections</a>
+      <a href="/liber/">Liber Arcanae</a>
+      <a href="/circuitum/">Circuitum99</a>
+      <a href="/research/">Research</a>
+      <a href="/gallery/">Gallery</a>
+      <a href="/contact/">Contact</a>
+    </nav>
     <div class="brand">COSMOGENESIS</div>
     <p>© MMXXV — Atelier of Sacred Geometry & Consciousness Research</p>
   </footer>
 
-  <script src="./js/calm.js" defer></script>
-  <script src="./js/nodes.js" defer></script>
+  <script src="./js/boot.js" defer></script>
 </body>
 </html>

--- a/site/js/boot.js
+++ b/site/js/boot.js
@@ -1,0 +1,198 @@
+(function () {
+  'use strict';
+
+  const doc = document;
+  const root = doc.documentElement;
+  let updateParallax = null;
+
+  initCalmMode();
+  setupParallax();
+  hydrateNodes();
+
+  function initCalmMode() {
+    const toggle = doc.getElementById('calmToggle');
+    const prefersReduced = typeof window.matchMedia === 'function' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (prefersReduced) {
+      root.classList.add('reduced-motion');
+      if (toggle) toggle.setAttribute('aria-pressed', 'true');
+    }
+
+    if (toggle) {
+      toggle.addEventListener('click', () => {
+        const active = root.classList.toggle('reduced-motion');
+        toggle.setAttribute('aria-pressed', String(active));
+        if (typeof updateParallax === 'function') {
+          updateParallax();
+        }
+      });
+    }
+  }
+
+  function setupParallax() {
+    const field = doc.querySelector('.field');
+    if (!field || typeof window.requestAnimationFrame !== 'function') return;
+
+    updateParallax = () => {
+      if (root.classList.contains('reduced-motion')) {
+        field.style.transform = '';
+        return;
+      }
+      field.style.transform = `translateY(${window.scrollY * 0.5}px)`;
+    };
+
+    let ticking = false;
+    window.addEventListener('scroll', () => {
+      if (ticking) return;
+      ticking = true;
+      window.requestAnimationFrame(() => {
+        updateParallax();
+        ticking = false;
+      });
+    }, { passive: true });
+
+    updateParallax();
+  }
+
+  function hydrateNodes() {
+    const list = doc.getElementById('node-list');
+    if (!list) return;
+
+    const configBlock = doc.getElementById('brain-config');
+    const fallbackBlock = doc.getElementById('nodes-fallback');
+    const fallbackData = parseJson(fallbackBlock);
+    const config = parseConfig(configBlock);
+
+    const useNetwork = location.protocol === 'http:' || location.protocol === 'https:';
+    const sourceUrl = resolveSource(config);
+
+    if (useNetwork && sourceUrl) {
+      fetch(sourceUrl, { cache: 'no-store' })
+        .then((response) => response.ok ? response.json() : Promise.reject(new Error('bad status')))
+        .then((nodes) => Array.isArray(nodes) ? populate(nodes) : Promise.reject(new Error('nodes must be array')))
+        .catch(() => {
+          if (Array.isArray(fallbackData)) {
+            populate(fallbackData);
+          } else {
+            showMessage();
+          }
+        });
+      return;
+    }
+
+    if (Array.isArray(fallbackData)) {
+      populate(fallbackData);
+    } else {
+      showMessage();
+    }
+
+    function populate(nodes) {
+      list.textContent = '';
+      nodes.forEach((node) => {
+        list.appendChild(createNodeCard(node));
+      });
+      if (!nodes.length) {
+        showMessage();
+      }
+    }
+
+    function showMessage() {
+      list.textContent = '';
+      const fallback = doc.createElement('article');
+      fallback.className = 'collection-piece';
+      fallback.textContent = 'Unable to load nodes right now.';
+      list.appendChild(fallback);
+    }
+  }
+
+  function parseJson(block) {
+    if (!block) return null;
+    try {
+      const raw = block.textContent.trim();
+      if (!raw) return null;
+      return JSON.parse(raw);
+    } catch (error) {
+      console.warn('nodes-fallback parse error', error);
+      return null;
+    }
+  }
+
+  function parseConfig(block) {
+    if (!block) return null;
+    const raw = block.textContent.trim();
+    if (!raw) return null;
+    const substituted = raw.replace(/location\.origin/g, JSON.stringify(location.origin));
+    try {
+      return JSON.parse(substituted);
+    } catch (error) {
+      console.warn('brain-config parse error', error);
+      return null;
+    }
+  }
+
+  function resolveSource(config) {
+    if (!config || !config.path) return null;
+    const base = typeof config.origin === 'string' && config.origin !== 'null' && config.origin !== ''
+      ? config.origin
+      : (location.origin && location.origin !== 'null' ? location.origin : location.href);
+    try {
+      return new URL(config.path, base).href;
+    } catch (error) {
+      console.warn('Unable to resolve node source', error);
+      return null;
+    }
+  }
+
+  function createNodeCard(node) {
+    const card = doc.createElement('article');
+    card.className = 'collection-piece';
+
+    const title = doc.createElement('h3');
+    title.textContent = String(node && (node.name || node.id || 'Node'));
+    card.appendChild(title);
+
+    const metaPieces = [];
+    if (node && node.type) metaPieces.push(String(node.type));
+    if (node && (typeof node.numerology === 'number' || node.numerology === 0)) {
+      metaPieces.push(`Numerology: ${node.numerology}`);
+    }
+    if (metaPieces.length) {
+      const meta = doc.createElement('p');
+      meta.className = 'collection-description';
+      meta.textContent = metaPieces.join(' • ');
+      card.appendChild(meta);
+    }
+
+    if (node && node.lore) {
+      const lore = doc.createElement('p');
+      lore.className = 'collection-description';
+      lore.textContent = String(node.lore);
+      card.appendChild(lore);
+    }
+
+    if (node && node.lab) {
+      const button = doc.createElement('button');
+      button.type = 'button';
+      button.textContent = 'Open Lab';
+      button.addEventListener('click', () => {
+        openLab(node.lab);
+      });
+      card.appendChild(button);
+    }
+
+    return card;
+  }
+
+  function openLab(href) {
+    const baseOrigin = location.origin && location.origin !== 'null' ? location.origin : null;
+    const base = baseOrigin || location.href;
+    try {
+      const target = new URL(String(href), base);
+      const sameOrigin = baseOrigin ? target.origin === baseOrigin : target.protocol === location.protocol;
+      if (!sameOrigin) return;
+      const win = window.open(target.href, '_blank', 'noopener,noreferrer');
+      if (win) win.opener = null;
+    } catch (error) {
+      console.warn('Invalid lab URL', href, error);
+    }
+  }
+})();

--- a/site/research/index.html
+++ b/site/research/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Research · Cosmogenesis</title>
+<link rel="stylesheet" href="../assets/css/atelier.css">
+<header class="atelier-nav"><a href="../index.html" class="marque-logo">COSMOGENESIS</a></header>
+<main id="main" class="collections">
+  <h1 class="section-titre">Research Index</h1>
+  <ul class="collection-grid">
+    <li class="collection-piece"><h3>Codex 144:99</h3><p class="collection-description">Meta-codex & pedagogy spiral.</p></li>
+    <li class="collection-piece"><h3>Tarot Engine</h3><p class="collection-description">Datasets & correspondences.</p></li>
+    <li class="collection-piece"><h3>Tesseract Notes</h3><p class="collection-description">Octagram, projections, bridges.</p></li>
+  </ul>
+</main>
+<footer class="maison-footer"><a href="../index.html">← Atelier</a></footer>


### PR DESCRIPTION
## Summary
- replace the Netlify configuration with a single-site setup, LFS env, and SPA redirects for the atelier and new app routes
- add Liber Arcanae and Circuitum99 app shells plus research, gallery, and contact sections that share a new atelier stylesheet
- update the home page navigation, shared node loader, and data JSON with a consolidated boot script

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cba04d9fec83288122771d704e68f2