### PR TITLE
Fix void lab dataset link

### DIFF
--- a/site/data/nodes.json
+++ b/site/data/nodes.json
@@ -1,12 +1,11 @@
 [
-
   {
     "id": "00-void",
     "name": "Void",
     "type": "Origin",
     "numerology": 0,
     "lore": "The silent lumen holds the womb of all potential.",
-    "lab": "/nodes/atelier/void.html"
+    "lab": "/labs/void-lab.html"
   },
   {
     "id": "01-magician",
@@ -44,8 +43,4 @@
     "numerology": 5,
     "lore": "Choral lineages map canonical wisdom into the Cosmogenesis atelier."
   }
-
-  { "id":"00-void","name":"Void","type":"Axiom","numerology":0,"lore":"The silent ground of being.","lab":"./labs/void-lab.html" },
-  { "id":"01-magician","name":"Magician","type":"Arcana","numerology":1,"lore":"The will to pattern reality.","lab":"./labs/void-lab.html" }
-
 ]


### PR DESCRIPTION
## Summary
- point the Void node lab reference at the existing /labs/void-lab.html page
- prune duplicate inline objects so the nodes dataset stays valid JSON with unique ids

## Testing
- node - <<'NODE' ...

------
https://chatgpt.com/codex/tasks/task_e_68cc358858148328bad56d6dc8843ca6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Void node’s lab link to point to the updated /labs/void-lab.html path.

* **Chores**
  * Removed two obsolete nodes (Void Axiom and Magician Arcana) from the node list to reduce clutter and avoid confusion in navigation and search.
  * Ensured remaining node entries reference current lab pages, improving consistency across the site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->