### PR TITLE
Improve offline palette loading for helix renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -30,3 +30,4 @@ All routines stay parameterised by `{3, 7, 9, 11, 22, 33, 99, 144}` to honour th
 - Adjust colours by editing `data/palette.json`. Provide `bg`, `ink`, and a six colour `layers` array.
 - Override numerology constants in `index.html` before calling `renderHelix` if alternate ratios are desired.
 - Compose new layers by duplicating the helper pattern in `js/helix-renderer.mjs`. Keep additions static and well-commented to preserve ND safety.
+- The loader prefers JSON module imports when opened via `file://` to avoid network access. Browsers without JSON module support fall back to the bundled palette safely.

--- a/index.html
+++ b/index.html
@@ -18,8 +18,8 @@
 </head>
 <body>
   <header>
-    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Loading palette...</div>
+    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette…</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
@@ -34,6 +34,15 @@
 
     async function loadJSON(path) {
       try {
+        if (window.location && window.location.protocol === "file:") {
+          try {
+            // Offline-first: JSON module import avoids blocked fetch calls under file:// origins.
+            const module = await import(path, { assert: { type: "json" } });
+            return module.default;
+          } catch (importError) {
+            // Silent fallback: some browsers reject JSON assertions, so we retry with fetch below.
+          }
+        }
         const res = await fetch(path, { cache: "no-store" });
         if (!res.ok) throw new Error(String(res.status));
         return await res.json();
@@ -59,7 +68,16 @@
     const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
 
     // ND-safe rationale: no motion, high readability, soft colors, layered order
-    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM, notice: usingFallback ? "Palette fallback active" : null });
+    renderHelix(
+      ctx,
+      {
+        width: canvas.width,
+        height: canvas.height,
+        palette: active,
+        NUM,
+        notice: usingFallback ? "Palette fallback active" : null
+      }
+    );
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure index.html matches the ND-safe copy while improving offline palette loading by preferring JSON module imports with fetch fallback
- expand the renderHelix invocation for readability and maintain the fallback notice messaging
- document the loader behaviour update in README_RENDERER

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cc6e927a448328b751ab3ead62173d