### PR TITLE
Refine cosmic helix offline renderer

### DIFF
--- a/cosmic-helix/README_RENDERER.md
+++ b/cosmic-helix/README_RENDERER.md
@@ -1,68 +1,35 @@
 # Cosmic Helix Renderer (Offline, ND-safe)
 
-
-Static HTML + Canvas capsule that renders the layered cosmology without motion. Double-clicking `index.html` paints a 1440x900
-canvas with four calm layers: vesica grid, Tree-of-Life scaffold, Fibonacci curve, and a double-helix lattice. Everything runs
-offline with no build tools or external libraries.
-
-## Files
-- `index.html` - offline entry point that loads the palette (with fallback), seeds numerology constants, and invokes the
-  renderer.
-- `js/helix-renderer.mjs` - ES module of small pure drawing helpers. Each helper documents why the ND-safe order matters.
-- `data/palette.json` - optional palette override. If missing, the renderer keeps a safe fallback and paints a notice on the
-  canvas.
-
-## Usage (offline)
-1. Open `cosmic-helix/index.html` directly in any modern browser. No server or network connection is required.
-2. The header status reports whether the palette loaded. Missing data keeps the fallback colours and adds a gentle notice to the
-   canvas corner.
-3. The canvas renders the four layers once using the numerology constants (3, 7, 9, 11, 22, 33, 99, 144) baked into the helper
-   functions.
-
-## Layer order (back to front)
-1. **Vesica field** - intersecting circle lattice spaced with 9x11 divisions to honour womb-of-forms geometry.
-2. **Tree-of-Life scaffold** - ten sephirot nodes joined by twenty-two steady paths, scaled by the numerology denominators for
-   clarity.
-3. **Fibonacci curve** - static logarithmic spiral sampled over 144 points with golden ratio pacing.
-4. **Double-helix lattice** - two phase-shifted strands with thirty-three cross ties and no motion.
-
-## ND-safe and trauma-informed choices
-- No animation or timers; everything draws once per load to avoid sensory spikes.
-- Calm palette defaults with status messaging explain fallbacks so nothing fails silently.
-- Comments explain why each layer order and spacing choice preserves depth without flattening geometry.
-- ASCII quotes, UTF-8, and LF newlines keep the module portable across offline environments.
-
-## Customising safely
-- Adjust `data/palette.json` to change colours. Keys remain `bg`, `ink`, `muted`, and `layers` (array of six hex strings).
-- Pass a custom geometry object when calling `renderHelix` if deeper tuning is required; the function validates numbers and
-  keeps the ND-safe structure intact.
-=======
-Static HTML + Canvas renderer that draws the requested four-layer cosmology on a fixed 1440x900 stage. It lives in `cosmic-helix/` so the wider site keeps its lore-first entry point.
+Static HTML + Canvas capsule that renders the layered cosmology with no motion. Double-clicking `index.html` paints a
+1440x900 canvas in four calm passes: vesica field, Tree-of-Life scaffold, Fibonacci curve, and the static double helix.
+Everything runs offline with zero dependencies so the lore remains portable.
 
 ## Files
-- `index.html` - offline entry point that loads the optional palette, seeds numerology constants, and invokes the renderer.
-- `js/helix-renderer.mjs` - ES module of small pure drawing helpers (one layer per function plus shared utilities).
-- `data/palette.json` - optional colour overrides. Missing data triggers a calm fallback and a gentle notice.
+- `index.html` - offline entry point. Loads the optional palette, seeds numerology constants, and invokes the renderer.
+- `js/helix-renderer.mjs` - ES module of pure drawing helpers. Comments explain why each layer order stays ND-safe.
+- `data/palette.json` - optional palette override. Missing or invalid data keeps the sealed fallback and shows a gentle
+  notice in the canvas corner.
 
 ## Usage (offline)
 1. Open `cosmic-helix/index.html` directly in any modern browser (no server required).
-2. The header status reports whether `data/palette.json` loaded successfully.
-3. The canvas renders the four layers once. If the palette file is missing under `file://` rules, the renderer prints a small notice while using the sealed fallback palette.
+2. The header status reports whether `data/palette.json` loaded. If file:// security blocks the fetch, the fallback palette
+   activates and the canvas prints a calm notice.
+3. Rendering happens once per load using the numerology constants (3, 7, 9, 11, 22, 33, 99, 144) baked into the geometry.
 
 ## Layer order (back to front)
-1. **Vesica field** - intersecting circle lattice spaced with 3/7/9/11 ratios to set the womb-of-forms foundation.
-2. **Tree-of-Life scaffold** - ten sephirot nodes linked by twenty-two paths, scaled by 33/99/144 denominators for clarity.
-3. **Fibonacci curve** - logarithmic spiral polyline sampled over 144 points with golden-ratio pacing.
-4. **Double-helix lattice** - two static sine strands with cross ties drawn across 33 anchor points.
+1. **Vesica field** - intersecting circle lattice spaced with 9x11 divisions (why: honours womb-of-forms geometry).
+2. **Tree-of-Life scaffold** - ten sephirot joined by twenty-two paths, scaled by 33/99 ratios so lines stay readable.
+3. **Fibonacci curve** - logarithmic spiral sampled over 144 points with golden ratio pacing.
+4. **Double-helix lattice** - two phase-shifted strands with thirty-three cross ties and no animation.
 
 ## ND-safe and trauma-informed choices
-- **No motion:** the renderer draws once per load with no timers or autoplay hooks.
-- **Calm palette:** palette validation keeps contrast comfortable and applies sealed fallbacks when JSON is absent.
-- **Layered depth:** geometry is rendered as separate layers instead of flattening sacred forms into one outline.
-- **Commented intent:** inline comments explain why safety choices exist for future stewards.
+- No timers or autoplay; the canvas draws once to avoid sensory spikes.
+- Calm palette defaults with clear status messaging so fallbacks never surprise the viewer.
+- Layered depth is preserved by drawing in ordered passes rather than flattening forms.
+- All code sticks to ASCII quotes, UTF-8, LF newlines, and small pure helpers for ease of stewardship.
 
 ## Customising safely
-Update `data/palette.json` to supply custom colours:
+Update `data/palette.json` to supply new colours:
 
 ```json
 {
@@ -73,7 +40,6 @@ Update `data/palette.json` to supply custom colours:
 }
 ```
 
-If the file is missing or malformed the renderer keeps the sealed palette, updates the status line, and posts the gentle notice on the canvas so nothing fails silently.
-
-
-Add new geometry by composing additional pure helpers inside `js/helix-renderer.mjs`. Maintain the covenant: ASCII quotes, UTF-8 with LF newlines, static rendering, and inline comments describing lore or safety rationale.
+If the file is absent or malformed, the renderer keeps the sealed palette, updates the header status, and prints the gentle
+notice in the canvas so nothing fails silently. Geometry overrides can be passed to `renderHelix` when embedding the module,
+but keep the covenant: static rendering, ND-safe palettes, and comments explaining every change.

--- a/cosmic-helix/index.html
+++ b/cosmic-helix/index.html
@@ -6,7 +6,6 @@
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
   <meta name="color-scheme" content="light dark">
   <style>
-
     /* ND-safe chrome: calm contrast, no motion, layered depth preserved (why: reduces sensory load). */
     :root {
       --bg: #0b0b12;
@@ -15,7 +14,8 @@
       --outline: #1d1d2a;
     }
 
-    html, body {
+    html,
+    body {
       margin: 0;
       padding: 0;
       background: var(--bg);
@@ -31,6 +31,7 @@
 
     header strong {
       font-weight: 600;
+      letter-spacing: 0.06em;
     }
 
     .status {
@@ -41,17 +42,25 @@
 
     #stage {
       display: block;
+      width: 1440px;
+      height: 900px;
       margin: 16px auto;
-      width: 100%;
-      max-width: 1440px;
       box-shadow: 0 0 0 1px var(--outline);
       background: var(--bg);
+      max-width: calc(100vw - 32px);
+      max-height: calc(100vh - 160px);
+    }
+
+    canvas {
+      width: 100%;
+      height: 100%;
+      display: block;
     }
 
     .note {
       max-width: 900px;
-      margin: 0 auto 16px;
-      padding: 0 16px 24px;
+      margin: 0 auto 24px;
+      padding: 0 16px;
       color: var(--muted);
     }
 
@@ -60,71 +69,26 @@
       padding: 2px 4px;
       border-radius: 3px;
     }
-
-    /* ND-safe: calm contrast, no motion, generous spacing */
-    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
-    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
-    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; background:linear-gradient(180deg, rgba(255,255,255,0.05), transparent); }
-    header strong { font-weight:600; letter-spacing:0.06em; }
-    .status { margin-top:4px; color:var(--muted); font-size:12px; }
-    #stage { display:block; margin:16px auto; width:1440px; height:900px; box-shadow:0 0 0 1px #1d1d2a; background:var(--bg); max-width:calc(100vw - 32px); max-height:calc(100vh - 160px); }
-    canvas { width:100%; height:100%; display:block; }
-    .note { max-width:900px; margin:0 auto 24px; padding:0 16px; color:var(--muted); }
-    code { background:#11111a; padding:2px 4px; border-radius:3px; }
-
   </style>
 </head>
 <body>
   <header>
     <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
-
     <div class="status" id="status">Loading palette...</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">Static renderer for vesica grid, Tree-of-Life nodes, Fibonacci curve, and a double-helix lattice. Open this file directly (no server, no animation, ND-safe palette).</p>
-
-    <div class="status" id="status">Preparing palette...</div>
-  </header>
-
-  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">Static renderer encoding Vesica field, Tree-of-Life scaffold, Fibonacci curve, and a double-helix lattice. No animation, no autoplay, no external libraries. Open this file directly.</p>
-
+  <p class="note">This static renderer encodes the vesica field, Tree-of-Life scaffold, Fibonacci curve, and static double helix. Open
+    this file directly - no build tools, no animation, ND-safe palette.</p>
 
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
 
-
-    const elStatus = document.getElementById("status");
-
     const statusEl = document.getElementById("status");
-
     const canvas = document.getElementById("stage");
-    const ctx = canvas.getContext("2d");
+    const context = canvas.getContext("2d");
 
-    async function loadPalette(path) {
-      try {
-        const response = await fetch(path, { cache: "no-store" });
-        if (!response.ok) {
-          throw new Error(String(response.status));
-        }
-        return await response.json();
-      } catch (error) {
-        return null;
-
-      }
-    }
-
-    const defaults = {
-      palette: {
-        bg: "#0b0b12",
-        ink: "#e8e8f0",
-        muted: "#a6a6c1",
-        layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-      }
-    };
-
-    const NUM = {
+    const NUM = Object.freeze({
       THREE: 3,
       SEVEN: 7,
       NINE: 9,
@@ -133,61 +97,55 @@
       THIRTYTHREE: 33,
       NINETYNINE: 99,
       ONEFORTYFOUR: 144
-    };
+    });
 
-    (async () => {
-      const palette = await loadPalette("./data/palette.json");
-      const activePalette = palette || defaults.palette;
-      const notice = palette ? "" : "Palette missing; using ND-safe fallback.";
-      elStatus.textContent = palette ? "Palette loaded." : "Palette missing; fallback active.";
-
-      if (!ctx) {
-        elStatus.textContent = "Canvas unavailable in this browser.";
-        return;
-      }
-
-      // ND-safe order: draw once, preserve calm layering, flag fallbacks visually.
-      renderHelix(ctx, {
-        width: canvas.width,
-        height: canvas.height,
-        palette: activePalette,
-        NUM,
-        notice
-      });
-    })();
-
-      }
-    }
-
-    const FALLBACK = {
+    const FALLBACK = Object.freeze({
       palette: {
         bg: "#0b0b12",
         ink: "#e8e8f0",
         muted: "#a6a6c1",
         layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
       }
-    };
-
-    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
-
-    const palette = await loadPalette("./data/palette.json");
-    const usingFallback = !palette;
-
-    const notice = usingFallback ? "Palette file missing - sealed fallback engaged." : "";
-    const result = renderHelix(ctx, {
-      width: canvas.width,
-      height: canvas.height,
-      palette: palette || FALLBACK.palette,
-      NUM,
-      notice
     });
 
-    if (result.ok) {
-      statusEl.textContent = usingFallback ? "Palette missing; using sealed fallback palette." : "Palette loaded from data/palette.json.";
-    } else {
-      statusEl.textContent = "Renderer error: " + (result.reason || "unknown");
+    function updateStatus(message) {
+      statusEl.textContent = message;
     }
 
+    async function loadJSON(path) {
+      try {
+        const response = await fetch(path, { cache: "no-store" });
+        if (!response.ok) {
+          throw new Error(String(response.status));
+        }
+        return await response.json();
+      } catch (error) {
+        return null;
+      }
+    }
+
+    if (!context) {
+      updateStatus("Canvas context unavailable in this browser.");
+    } else {
+      const palette = await loadJSON("./data/palette.json");
+      const activePalette = palette || FALLBACK.palette;
+      const notice = palette ? "" : "Palette missing; using sealed fallback.";
+
+      // Draw once: calm sequencing keeps ND-safe pacing.
+      const result = renderHelix(context, {
+        width: canvas.width,
+        height: canvas.height,
+        palette: activePalette,
+        NUM,
+        notice
+      });
+
+      if (result.ok) {
+        updateStatus(palette ? "Palette loaded." : "Palette missing; fallback active.");
+      } else {
+        updateStatus(`Render failed: ${result.reason}`);
+      }
+    }
   </script>
 </body>
 </html>

--- a/cosmic-helix/js/helix-renderer.mjs
+++ b/cosmic-helix/js/helix-renderer.mjs
@@ -1,41 +1,19 @@
 /*
   helix-renderer.mjs
 
-  Static renderer for the Cosmic Helix canvas. All helpers are pure functions so the
-  module stays predictable and ND-safe (why: keeps rendering single-pass and calm).
-
+  ND-safe static renderer for the four-layer cosmic helix.
+  The helpers are pure and sequenced so the canvas paints once without motion.
   Layer order (back to front):
-    1) Vesica field - intersecting circles establishing the womb-of-forms grid.
-    2) Tree-of-Life scaffold - ten sephirot linked by twenty-two steady paths.
-    3) Fibonacci curve - logarithmic spiral encoded with golden ratio pacing.
-    4) Double-helix lattice - two static strands with gentle cross ties.
+    1) Vesica field - intersecting circles establish the womb-of-forms grid.
+    2) Tree-of-Life scaffold - ten sephirot and twenty-two paths anchor lineage.
+    3) Fibonacci curve - logarithmic spiral sampling the golden ratio for growth.
+    4) Double-helix lattice - static sine strands with calm cross ties.
 
-  Numerology constants (3, 7, 9, 11, 22, 33, 99, 144) shape spacing, sampling,
-  and proportions throughout the helpers to honour the requested symbolism.
-
-  ND-safe static renderer for layered sacred geometry.
-
-  Layers (rendered back to front):
-    1) Vesica field - intersecting circle lattice for the womb-of-forms motif.
-    2) Tree-of-Life scaffold - ten sephirot joined by twenty-two calm paths.
-    3) Fibonacci curve - logarithmic spiral polyline with golden-ratio pacing.
-    4) Double-helix lattice - two still strands with gentle cross ties.
-
-  Rationale:
-    - No animation: everything draws once on load to respect ND-safe pacing.
-    - Calm palette: soft contrast keeps lines readable without sensory spikes.
-    - Numerology constants (3, 7, 9, 11, 22, 33, 99, 144) guide proportions.
-
+  Numerology constants (3, 7, 9, 11, 22, 33, 99, 144) parameterise spacing so
+  sacred ratios remain readable without animation (why: respects covenant).
 */
 
-const FALLBACK_PALETTE = {
-  bg: "#0b0b12",
-  ink: "#e8e8f0",
-  muted: "#a6a6c1",
-  layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-};
-
-const DEFAULT_NUM = {
+const DEFAULT_NUM = Object.freeze({
   THREE: 3,
   SEVEN: 7,
   NINE: 9,
@@ -44,33 +22,39 @@ const DEFAULT_NUM = {
   THIRTYTHREE: 33,
   NINETYNINE: 99,
   ONEFORTYFOUR: 144
-};
+});
+
+const FALLBACK_PALETTE = Object.freeze({
+  bg: "#0b0b12",
+  ink: "#e8e8f0",
+  muted: "#a6a6c1",
+  layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
+});
 
 const FALLBACK_GEOMETRY = {
-  // Vesica lattice references 9x11 grid divisions (why: ties to 9/11 numerology).
   vesica: {
-    rows: 9,
-    columns: 11,
-    paddingDivisor: 11,
-    radiusFactor: 1.5,
-    strokeDivisor: 99,
+    rows: DEFAULT_NUM.NINE,
+    columns: DEFAULT_NUM.ELEVEN,
+    paddingDivisor: DEFAULT_NUM.ELEVEN,
+    radiusFactor: DEFAULT_NUM.SEVEN / DEFAULT_NUM.THREE,
+    strokeDivisor: DEFAULT_NUM.NINETYNINE,
     alpha: 0.55
   },
-  // Tree-of-Life scaffold uses ten nodes with 22 connective paths.
   treeOfLife: {
-    marginDivisor: 11,
-    radiusDivisor: 22,
-    labelOffset: -24,
-    labelFont: "13px system-ui, -apple-system, Segoe UI, sans-serif",
+    marginDivisor: DEFAULT_NUM.ELEVEN,
+    radiusDivisor: DEFAULT_NUM.THIRTYTHREE,
+    labelOffset: -DEFAULT_NUM.TWENTYTWO,
+    labelLineHeight: 14,
+    labelFont: "12px system-ui, -apple-system, Segoe UI, sans-serif",
     nodes: [
       { id: "kether", title: "Kether", meaning: "Crown", level: 0, xFactor: 0.5 },
-      { id: "chokmah", title: "Chokmah", meaning: "Wisdom", level: 1, xFactor: 0.7 },
-      { id: "binah", title: "Binah", meaning: "Understanding", level: 1, xFactor: 0.3 },
+      { id: "chokmah", title: "Chokmah", meaning: "Wisdom", level: 1, xFactor: 0.72 },
+      { id: "binah", title: "Binah", meaning: "Understanding", level: 1, xFactor: 0.28 },
       { id: "chesed", title: "Chesed", meaning: "Mercy", level: 2, xFactor: 0.68 },
       { id: "geburah", title: "Geburah", meaning: "Severity", level: 2, xFactor: 0.32 },
       { id: "tiphareth", title: "Tiphareth", meaning: "Beauty", level: 3, xFactor: 0.5 },
-      { id: "netzach", title: "Netzach", meaning: "Victory", level: 4, xFactor: 0.66 },
-      { id: "hod", title: "Hod", meaning: "Glory", level: 4, xFactor: 0.34 },
+      { id: "netzach", title: "Netzach", meaning: "Victory", level: 4, xFactor: 0.7 },
+      { id: "hod", title: "Hod", meaning: "Glory", level: 4, xFactor: 0.3 },
       { id: "yesod", title: "Yesod", meaning: "Foundation", level: 5, xFactor: 0.5 },
       { id: "malkuth", title: "Malkuth", meaning: "Kingdom", level: 6, xFactor: 0.5 }
     ],
@@ -100,20 +84,20 @@ const FALLBACK_GEOMETRY = {
     ]
   },
   fibonacci: {
-    sampleCount: 144,
-    turns: 3,
-    baseRadiusDivisor: 3,
+    sampleCount: DEFAULT_NUM.ONEFORTYFOUR,
+    turns: DEFAULT_NUM.THREE,
+    baseRadiusDivisor: DEFAULT_NUM.THREE,
     phi: 1.618033988749895,
-    alpha: 0.85
+    alpha: 0.88
   },
   helix: {
-    sampleCount: 144,
-    cycles: 3,
-    amplitudeDivisor: 3,
+    sampleCount: DEFAULT_NUM.ONEFORTYFOUR,
+    cycles: DEFAULT_NUM.THREE,
+    amplitudeDivisor: DEFAULT_NUM.THREE,
     phaseOffset: 180,
-    crossTieCount: 33,
-    strandAlpha: 0.85,
-    rungAlpha: 0.6
+    crossTieCount: DEFAULT_NUM.THIRTYTHREE,
+    strandAlpha: 0.82,
+    rungAlpha: 0.65
   }
 };
 
@@ -137,7 +121,7 @@ export function renderHelix(ctx, options = {}) {
   ctx.setTransform(1, 0, 0, 1, 0, 0);
   fillBackground(ctx, width, height, palette.bg);
 
-  // Layer sequencing preserves depth without motion (why: layered geometry, ND-safe).
+  // Layered sequencing preserves depth without motion (why: ND-safe covenant).
   drawVesicaField(ctx, width, height, palette.layers[0], numerology, geometry.vesica);
   drawTreeOfLife(ctx, width, height, palette.layers[1], palette.layers[2], palette.ink, numerology, geometry.treeOfLife);
   drawFibonacciCurve(ctx, width, height, palette.layers[3], numerology, geometry.fibonacci);
@@ -148,7 +132,7 @@ export function renderHelix(ctx, options = {}) {
   }
 
   ctx.restore();
-  return { ok: true, constants: numerology };
+  return { ok: true, numerology };
 }
 
 function normalisePalette(input) {
@@ -177,7 +161,7 @@ function clonePalette(palette) {
     bg: palette.bg,
     ink: palette.ink,
     muted: palette.muted,
-    layers: [...palette.layers]
+    layers: palette.layers.slice()
   };
 }
 
@@ -219,15 +203,15 @@ function normaliseTree(data) {
   const safe = data && typeof data === "object" ? data : {};
   const fallbackNodes = fallback.nodes;
   const providedNodes = Array.isArray(safe.nodes) && safe.nodes.length > 0 ? safe.nodes : fallbackNodes;
-  const nodes = providedNodes.map((node, index) => {
-    const base = typeof node === "object" && node !== null ? node : {};
-    const reference = fallbackNodes.find((item) => item.id === base.id) || fallbackNodes[index % fallbackNodes.length];
+  const nodes = fallbackNodes.map((template, index) => {
+    const candidate = typeof providedNodes[index] === "object" && providedNodes[index] !== null ? providedNodes[index] : {};
+    const base = fallbackNodes[index % fallbackNodes.length];
     return {
-      id: typeof base.id === "string" && base.id ? base.id : reference.id,
-      title: typeof base.title === "string" && base.title ? base.title : reference.title,
-      meaning: typeof base.meaning === "string" && base.meaning ? base.meaning : reference.meaning,
-      level: finiteNumber(base.level, reference.level),
-      xFactor: clamp01(finiteNumber(base.xFactor, reference.xFactor))
+      id: typeof candidate.id === "string" && candidate.id ? candidate.id : base.id,
+      title: typeof candidate.title === "string" && candidate.title ? candidate.title : base.title,
+      meaning: typeof candidate.meaning === "string" ? candidate.meaning : base.meaning,
+      level: finiteNumber(candidate.level, base.level),
+      xFactor: clamp01(finiteNumber(candidate.xFactor, base.xFactor))
     };
   });
 
@@ -241,6 +225,7 @@ function normaliseTree(data) {
     marginDivisor: positiveNumber(safe.marginDivisor, fallback.marginDivisor),
     radiusDivisor: positiveNumber(safe.radiusDivisor, fallback.radiusDivisor),
     labelOffset: finiteNumber(safe.labelOffset, fallback.labelOffset),
+    labelLineHeight: positiveNumber(safe.labelLineHeight, fallback.labelLineHeight),
     labelFont: typeof safe.labelFont === "string" && safe.labelFont ? safe.labelFont : fallback.labelFont,
     nodes,
     edges
@@ -282,7 +267,6 @@ function drawVesicaField(ctx, width, height, color, N, settings) {
   const rows = Math.max(2, settings.rows);
   const columns = Math.max(2, settings.columns);
   const padding = Math.min(width, height) / settings.paddingDivisor;
-
   const horizontalSpan = width - padding * 2;
   const verticalSpan = height - padding * 2;
   const stepX = columns > 1 ? horizontalSpan / (columns - 1) : 0;
@@ -290,216 +274,107 @@ function drawVesicaField(ctx, width, height, color, N, settings) {
   const radius = Math.min(stepX, stepY) / settings.radiusFactor;
   const strokeWidth = Math.max(1, Math.min(width, height) / settings.strokeDivisor);
 
-  const stepX = columns > 1 ? (width - padding * 2) / (columns - 1) : 0;
-  const stepY = rows > 1 ? (height - padding * 2) / (rows - 1) : 0;
-  const verticalStep = stepY * (N.SEVEN / N.NINE);
-  const radius = Math.min(stepX, stepY) * (N.NINE / N.ELEVEN) / settings.radiusFactor;
-  const strokeWidth = Math.max(1, Math.min(width, height) / settings.strokeDivisor) * (N.THIRTYTHREE / N.NINETYNINE);
-
-
   ctx.save();
   ctx.strokeStyle = colorWithAlpha(color, settings.alpha);
   ctx.lineWidth = strokeWidth;
-  ctx.globalAlpha = 1;
+  ctx.lineCap = "round";
+  ctx.lineJoin = "round";
 
   for (let row = 0; row < rows; row += 1) {
+    const ratioY = rows > 1 ? row / (rows - 1) : 0;
+    const y = padding + Math.min(1, ratioY * (N.NINE / N.SEVEN)) * verticalSpan;
     const offset = row % 2 === 0 ? 0 : stepX / 2;
 
     for (let column = 0; column < columns; column += 1) {
-      const x = padding + offset + column * stepX;
-      const y = padding + row * stepY;
-      ctx.beginPath();
-      ctx.arc(x, y, radius, 0, Math.PI * 2);
-      ctx.stroke();
-
-    for (let col = 0; col < columns; col += 1) {
-      const x = padding + offset + col * stepX;
-      if (x < padding || x > width - padding) {
+      const ratioX = columns > 1 ? column / (columns - 1) : 0;
+      const x = padding + offset + ratioX * horizontalSpan;
+      if (x < padding - radius || x > width - padding + radius) {
         continue;
       }
-      const y = padding + row * verticalStep;
       strokeCircle(ctx, x, y, radius);
-      const mirroredX = x + stepX / 2;
-      if (mirroredX <= width - padding) {
-        strokeCircle(ctx, mirroredX, y, radius);
-      }
-      const mirroredY = y + verticalStep / 2;
-      if (mirroredY <= height - padding) {
-        strokeCircle(ctx, x, mirroredY, radius);
-      }
-
     }
   }
 
   ctx.restore();
 }
-
-
-function drawTreeOfLife(ctx, width, height, edgeColor, nodeColor, labelColor, N, settings) {
-  const margin = Math.min(width, height) / settings.marginDivisor;
-  const top = margin;
-  const bottom = height - margin;
-  const left = margin;
-  const right = width - margin;
-  const verticalSpan = bottom - top;
-  const horizontalSpan = right - left;
-  const radius = Math.max(4, Math.min(width, height) / settings.radiusDivisor);
-  const lineWidth = Math.max(1, Math.min(width, height) / N.NINETYNINE);
-
-  const maxLevel = settings.nodes.reduce((acc, node) => Math.max(acc, node.level), 0);
-  const levelStep = maxLevel > 0 ? verticalSpan / maxLevel : 0;
-
-  const positions = new Map();
-  settings.nodes.forEach((node) => {
-    const x = left + clamp01(node.xFactor) * horizontalSpan;
-    const y = top + node.level * levelStep;
-    positions.set(node.id, { x, y, node });
-  });
-
-  // Calm connective lines first (why: keeps lattice behind node glyphs).
-  ctx.save();
-  ctx.strokeStyle = edgeColor;
-  ctx.lineWidth = lineWidth;
-  ctx.globalAlpha = 0.75;
-  ctx.lineCap = "round";
-  settings.edges.forEach((edge) => {
-    const start = positions.get(edge[0]);
-    const end = positions.get(edge[1]);
-    if (!start || !end) {
-      return;
-    }
-    ctx.beginPath();
-    ctx.moveTo(start.x, start.y);
-    ctx.lineTo(end.x, end.y);
-    ctx.stroke();
-  });
 
 function drawTreeOfLife(ctx, width, height, pathColor, nodeColor, labelColor, N, tree) {
   const margin = Math.min(width, height) / tree.marginDivisor;
   const top = margin;
   const bottom = height - margin;
+  const verticalSpan = bottom - top;
   const maxLevel = tree.nodes.reduce((acc, node) => Math.max(acc, node.level), 0);
-  const levelStep = maxLevel > 0 ? (bottom - top) / maxLevel : 0;
-  const radius = Math.min(width, height) / tree.radiusDivisor;
-  const pathWidth = Math.max(1, Math.min(width, height) / N.NINETYNINE);
+  const levelStep = maxLevel > 0 ? verticalSpan / maxLevel : 0;
+  const radius = Math.max(4, Math.min(width, height) / tree.radiusDivisor);
+  const lineWidth = Math.max(1, Math.min(width, height) / N.NINETYNINE);
 
   const positions = new Map();
-  for (const node of tree.nodes) {
-    const clampedLevel = Math.max(0, Math.min(maxLevel, node.level));
-    const usableWidth = width - margin * 2;
-    const x = margin + clamp01(node.xFactor) * usableWidth;
-    const y = top + clampedLevel * levelStep;
+  tree.nodes.forEach((node) => {
+    const x = margin + clamp01(node.xFactor) * (width - margin * 2);
+    const y = top + node.level * levelStep;
     positions.set(node.id, { x, y, node });
-  }
+  });
 
+  // Calm connective lines first so nodes remain readable (why: layered depth).
   ctx.save();
-  ctx.strokeStyle = colorWithAlpha(pathColor, 0.66);
-  ctx.lineWidth = pathWidth;
+  ctx.strokeStyle = colorWithAlpha(pathColor, 0.75);
+  ctx.lineWidth = lineWidth;
   ctx.lineCap = "round";
   ctx.lineJoin = "round";
-  ctx.beginPath();
-  for (const edge of tree.edges) {
+  tree.edges.forEach((edge) => {
     const start = positions.get(edge[0]);
     const end = positions.get(edge[1]);
     if (!start || !end) {
-      continue;
-    }
-    ctx.moveTo(start.x, start.y);
-    ctx.lineTo(end.x, end.y);
-  }
-  ctx.stroke();
-
-  ctx.restore();
-
-  // Nodes overlay edges so depth stays readable.
-  ctx.save();
-
-  ctx.fillStyle = nodeColor;
-  ctx.strokeStyle = labelColor;
-  ctx.lineWidth = Math.max(1, lineWidth * 0.75);
-  settings.nodes.forEach((node) => {
-    const point = positions.get(node.id);
-    if (!point) {
       return;
     }
     ctx.beginPath();
-    ctx.arc(point.x, point.y, radius, 0, Math.PI * 2);
-    ctx.fill();
+    ctx.moveTo(start.x, start.y);
+    ctx.lineTo(end.x, end.y);
     ctx.stroke();
   });
+  ctx.restore();
 
-  ctx.fillStyle = colorWithAlpha(nodeColor, 0.9);
+  ctx.save();
+  ctx.fillStyle = nodeColor;
   ctx.strokeStyle = colorWithAlpha(nodeColor, 0.9);
-  ctx.lineWidth = Math.max(1, pathWidth * 0.75);
-  for (const entry of positions.values()) {
+  ctx.lineWidth = Math.max(1, lineWidth * 0.75);
+  positions.forEach((entry) => {
     ctx.beginPath();
     ctx.arc(entry.x, entry.y, radius, 0, Math.PI * 2);
     ctx.fill();
     ctx.stroke();
-  }
-
+  });
   ctx.restore();
 
   ctx.save();
   ctx.fillStyle = labelColor;
-
-  ctx.font = settings.labelFont;
-  ctx.textAlign = "center";
-  ctx.textBaseline = "middle";
-  settings.nodes.forEach((node) => {
-    const point = positions.get(node.id);
-    if (!point) {
-      return;
-    }
-    const labelY = point.y + settings.labelOffset;
-    ctx.fillText(node.title, point.x, labelY);
-  });
-
   ctx.font = tree.labelFont;
   ctx.textAlign = "center";
   ctx.textBaseline = "top";
-  for (const entry of positions.values()) {
-    const textY = entry.y + tree.labelOffset;
-    ctx.fillText(entry.node.title, entry.x, textY);
-    ctx.fillText(entry.node.meaning, entry.x, textY + 14);
-  }
-
+  const lineHeight = tree.labelLineHeight;
+  positions.forEach((entry) => {
+    const baseY = entry.y + tree.labelOffset;
+    ctx.fillText(entry.node.title, entry.x, baseY);
+    if (entry.node.meaning) {
+      ctx.fillText(entry.node.meaning, entry.x, baseY + lineHeight);
+    }
+  });
   ctx.restore();
 }
 
 function drawFibonacciCurve(ctx, width, height, color, N, settings) {
-
-  const count = Math.max(2, settings.sampleCount);
-  const turns = settings.turns;
-  const phi = settings.phi;
-  const angleTotal = turns * Math.PI * 2;
-  const growth = Math.pow(phi, turns);
-  const maxRadius = Math.min(width, height) / settings.baseRadiusDivisor;
-  const baseRadius = maxRadius / growth;
-  const centerX = width / 2;
-  const centerY = height / 2;
-  const strokeWidth = Math.max(1, Math.min(width, height) / N.NINETYNINE);
-
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = strokeWidth;
-  ctx.globalAlpha = settings.alpha;
-  ctx.beginPath();
-
-  for (let index = 0; index < count; index += 1) {
-    const t = count > 1 ? index / (count - 1) : 0;
-    const angle = t * angleTotal;
-    const radius = baseRadius * Math.pow(phi, t * turns);
-    const x = centerX + Math.cos(angle) * radius;
-    const y = centerY + Math.sin(angle) * radius;
-
-  const samples = Math.max(2, settings.sampleCount);
+  const sampleCount = Math.max(2, settings.sampleCount);
   const turns = Math.max(0, settings.turns);
-  const totalAngle = turns * Math.PI * 2;
-  const centerX = width * 0.72;
-  const centerY = height * 0.35;
-  const baseRadius = Math.min(width, height) / settings.baseRadiusDivisor;
+  if (turns === 0) {
+    return;
+  }
   const phi = Math.max(1.0001, settings.phi);
+  const totalAngle = turns * Math.PI * 2;
+  const maxRadius = Math.min(width, height) / settings.baseRadiusDivisor;
+  const growth = Math.pow(phi, turns);
+  const baseRadius = maxRadius / growth;
+  const centerX = width / 2 + width / N.TWENTYTWO;
+  const centerY = height / 2 - height / N.ELEVEN;
   const lineWidth = Math.max(1, Math.min(width, height) / N.NINETYNINE);
 
   ctx.save();
@@ -508,121 +383,44 @@ function drawFibonacciCurve(ctx, width, height, color, N, settings) {
   ctx.lineCap = "round";
   ctx.lineJoin = "round";
   ctx.beginPath();
-  for (let index = 0; index < samples; index += 1) {
-    const t = index / (samples - 1);
+
+  for (let index = 0; index < sampleCount; index += 1) {
+    const t = sampleCount > 1 ? index / (sampleCount - 1) : 0;
     const angle = t * totalAngle;
     const radius = baseRadius * Math.pow(phi, t * turns);
-    const x = centerX + radius * Math.cos(angle);
-    const y = centerY + radius * Math.sin(angle);
-
+    const x = centerX + Math.cos(angle) * radius;
+    const y = centerY + Math.sin(angle) * radius;
     if (index === 0) {
       ctx.moveTo(x, y);
     } else {
       ctx.lineTo(x, y);
     }
   }
+
   ctx.stroke();
   ctx.restore();
 }
 
 function drawHelixLattice(ctx, width, height, strandColor, rungColor, N, settings) {
-
-  const count = Math.max(2, settings.sampleCount);
-  const cycles = settings.cycles;
-  const amplitude = Math.min(width, height) / settings.amplitudeDivisor;
-  const phase = (settings.phaseOffset * Math.PI) / 180;
-  const topMargin = Math.min(width, height) / N.NINE;
-  const bottomMargin = topMargin;
-  const usableHeight = height - topMargin - bottomMargin;
-  const strokeWidth = Math.max(1, Math.min(width, height) / N.NINETYNINE);
-  const strandA = [];
-  const strandB = [];
-
-  for (let index = 0; index < count; index += 1) {
-    const t = count > 1 ? index / (count - 1) : 0;
-    const angle = t * cycles * Math.PI * 2;
-    const y = topMargin + t * usableHeight;
-    const centerX = width / 2;
-    const xA = centerX + Math.sin(angle) * amplitude;
-    const xB = centerX + Math.sin(angle + phase) * amplitude;
-    strandA.push({ x: xA, y });
-    strandB.push({ x: xB, y });
-  }
-
-  ctx.save();
-  ctx.lineWidth = strokeWidth;
-  ctx.globalAlpha = settings.strandAlpha;
-  ctx.strokeStyle = strandColor;
-  drawPolyline(ctx, strandA);
-  drawPolyline(ctx, strandB);
-  ctx.restore();
-
-  const rungCount = settings.crossTieCount;
-  ctx.save();
-  ctx.lineWidth = strokeWidth * 0.85;
-  ctx.globalAlpha = settings.rungAlpha;
-  ctx.strokeStyle = rungColor;
-  for (let rung = 0; rung < rungCount; rung += 1) {
-    const t = rungCount > 1 ? rung / (rungCount - 1) : 0;
-    const index = Math.floor(t * (count - 1));
-    const start = strandA[index];
-    const end = strandB[index];
-    if (!start || !end) {
-      continue;
-    }
-    ctx.beginPath();
-    ctx.moveTo(start.x, start.y);
-    ctx.lineTo(end.x, end.y);
-    ctx.stroke();
-  }
-  ctx.restore();
-}
-
-function drawPolyline(ctx, points) {
-  if (!points || points.length === 0) {
-    return;
-  }
-  ctx.beginPath();
-  points.forEach((point, index) => {
-    if (index === 0) {
-      ctx.moveTo(point.x, point.y);
-    } else {
-      ctx.lineTo(point.x, point.y);
-    }
-  });
-  ctx.stroke();
-}
-
-function drawNotice(ctx, width, height, color, message) {
-  const padding = 12;
-  ctx.save();
-  ctx.globalAlpha = 0.9;
-  ctx.fillStyle = color;
-  ctx.font = "12px system-ui, -apple-system, Segoe UI, sans-serif";
-  ctx.textAlign = "left";
-  ctx.textBaseline = "bottom";
-  ctx.fillText(message, padding, height - padding);
-  ctx.restore();
-
-  const samples = Math.max(2, settings.sampleCount);
+  const sampleCount = Math.max(2, settings.sampleCount);
+  const cycles = Math.max(0, settings.cycles);
   const marginX = width / N.ELEVEN;
   const startX = marginX;
   const endX = width - marginX;
-  const amplitude = Math.min(height / settings.amplitudeDivisor, height / 3);
+  const amplitude = Math.min(height / settings.amplitudeDivisor, height / N.THREE);
   const baseline = height / 2;
-  const cycles = Math.max(0, settings.cycles);
   const totalAngle = cycles * Math.PI * 2;
   const phase = (settings.phaseOffset * Math.PI) / 180;
   const strandWidth = Math.max(1, Math.min(width, height) / N.NINETYNINE);
 
   const strandA = [];
   const strandB = [];
-  for (let index = 0; index < samples; index += 1) {
-    const t = samples === 1 ? 0 : index / (samples - 1);
+  for (let index = 0; index < sampleCount; index += 1) {
+    const t = sampleCount > 1 ? index / (sampleCount - 1) : 0;
     const x = startX + t * (endX - startX);
     const angle = t * totalAngle;
-    const yA = baseline + amplitude * Math.sin(angle);
-    const yB = baseline + amplitude * Math.sin(angle + phase);
+    const yA = baseline + Math.sin(angle) * amplitude;
+    const yB = baseline + Math.sin(angle + phase) * amplitude;
     strandA.push({ x, y: yA });
     strandB.push({ x, y: yB });
   }
@@ -632,49 +430,26 @@ function drawNotice(ctx, width, height, color, message) {
   ctx.lineWidth = strandWidth;
   ctx.lineCap = "round";
   ctx.lineJoin = "round";
-  ctx.beginPath();
-  for (let index = 0; index < strandA.length; index += 1) {
-    const point = strandA[index];
-    if (index === 0) {
-      ctx.moveTo(point.x, point.y);
-    } else {
-      ctx.lineTo(point.x, point.y);
-    }
-  }
-  ctx.stroke();
+  drawPolyline(ctx, strandA);
+  drawPolyline(ctx, strandB);
   ctx.restore();
 
-  ctx.save();
-  ctx.strokeStyle = colorWithAlpha(strandColor, settings.strandAlpha);
-  ctx.lineWidth = strandWidth;
-  ctx.lineCap = "round";
-  ctx.lineJoin = "round";
-  ctx.beginPath();
-  for (let index = 0; index < strandB.length; index += 1) {
-    const point = strandB[index];
-    if (index === 0) {
-      ctx.moveTo(point.x, point.y);
-    } else {
-      ctx.lineTo(point.x, point.y);
-    }
-  }
-  ctx.stroke();
-  ctx.restore();
-
-  const rungCount = Math.max(1, settings.crossTieCount);
   ctx.save();
   ctx.strokeStyle = colorWithAlpha(rungColor, settings.rungAlpha);
-  ctx.lineWidth = Math.max(1, strandWidth * 0.75);
+  ctx.lineWidth = Math.max(1, strandWidth * 0.85);
   ctx.lineCap = "round";
+  const rungCount = Math.max(1, settings.crossTieCount);
   for (let rung = 0; rung < rungCount; rung += 1) {
-    const t = rungCount === 1 ? 0 : rung / (rungCount - 1);
-    const indexA = Math.round(t * (strandA.length - 1));
-    const indexB = Math.round(t * (strandB.length - 1));
-    const pointA = strandA[indexA];
-    const pointB = strandB[indexB];
+    const t = rungCount > 1 ? rung / (rungCount - 1) : 0;
+    const index = Math.floor(t * (strandA.length - 1));
+    const start = strandA[index];
+    const end = strandB[index];
+    if (!start || !end) {
+      continue;
+    }
     ctx.beginPath();
-    ctx.moveTo(pointA.x, pointA.y);
-    ctx.lineTo(pointB.x, pointB.y);
+    ctx.moveTo(start.x, start.y);
+    ctx.lineTo(end.x, end.y);
     ctx.stroke();
   }
   ctx.restore();
@@ -697,15 +472,24 @@ function strokeCircle(ctx, cx, cy, radius) {
   ctx.stroke();
 }
 
-function toNumber(value, fallback) {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : fallback;
-
+function drawPolyline(ctx, points) {
+  if (!Array.isArray(points) || points.length === 0) {
+    return;
+  }
+  ctx.beginPath();
+  points.forEach((point, index) => {
+    if (index === 0) {
+      ctx.moveTo(point.x, point.y);
+    } else {
+      ctx.lineTo(point.x, point.y);
+    }
+  });
+  ctx.stroke();
 }
 
 function toNumber(value, fallback) {
-  const number = Number(value);
-  return Number.isFinite(number) ? number : Number(fallback);
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : Number(fallback);
 }
 
 function positiveNumber(value, fallback) {
@@ -714,55 +498,14 @@ function positiveNumber(value, fallback) {
 }
 
 function positiveInteger(value, fallback) {
-
-  const number = Number(value);
-  return Number.isInteger(number) && number > 0 ? number : fallback;
-
   const parsed = Number(value);
   const rounded = Math.round(parsed);
-  return Number.isFinite(parsed) && rounded > 0 ? rounded : fallback;
-
+  return Number.isInteger(rounded) && rounded > 0 ? rounded : fallback;
 }
 
 function finiteNumber(value, fallback) {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : fallback;
-}
-
-
-function clamp01(value) {
-  const number = Number(value);
-  if (!Number.isFinite(number)) {
-    return 0;
-  }
-  if (number < 0) {
-    return 0;
-  }
-  if (number > 1) {
-    return 1;
-  }
-  return number;
-}
-
-function clampAlpha(value, fallback) {
-  const number = Number(value);
-  if (!Number.isFinite(number)) {
-    return fallback;
-  }
-  if (number < 0) {
-    return 0;
-  }
-  if (number > 1) {
-    return 1;
-  }
-  return number;
-
-function clampAlpha(value, fallback) {
-  const parsed = Number(value);
-  if (Number.isFinite(parsed)) {
-    return Math.min(1, Math.max(0, parsed));
-  }
-  return fallback;
 }
 
 function clamp01(value) {
@@ -779,17 +522,30 @@ function clamp01(value) {
   return parsed;
 }
 
+function clampAlpha(value, fallback) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+  if (parsed < 0) {
+    return 0;
+  }
+  if (parsed > 1) {
+    return 1;
+  }
+  return parsed;
+}
+
 function colorWithAlpha(hex, alpha) {
-  const normalized = typeof hex === "string" ? hex.trim() : "";
-  const value = normalized.startsWith("#") ? normalized.slice(1) : normalized;
-  if (value.length !== 6) {
+  const value = typeof hex === "string" ? hex.trim() : "";
+  const stripped = value.startsWith("#") ? value.slice(1) : value;
+  if (stripped.length !== 6) {
     const safeAlpha = clamp01(alpha);
     return `rgba(255,255,255,${safeAlpha})`;
   }
-  const r = parseInt(value.slice(0, 2), 16);
-  const g = parseInt(value.slice(2, 4), 16);
-  const b = parseInt(value.slice(4, 6), 16);
+  const r = parseInt(stripped.slice(0, 2), 16);
+  const g = parseInt(stripped.slice(2, 4), 16);
+  const b = parseInt(stripped.slice(4, 6), 16);
   const safeAlpha = clamp01(alpha);
   return `rgba(${r},${g},${b},${safeAlpha})`;
-
 }


### PR DESCRIPTION
## Summary
- rebuild the offline `index.html` wrapper so the canvas loads palette data with sealed fallbacks
- rewrite `helix-renderer.mjs` as a pure, layered renderer that encodes vesica, Tree-of-Life, Fibonacci, and helix geometry with numerology constants
- refresh the renderer README with ND-safe usage guidance and customisation notes

## Testing
- not run (static HTML/JS renderer)


------
https://chatgpt.com/codex/tasks/task_e_68cc7152f4088328b65f2c0ad7b90417