### PR TITLE
Refine cosmic helix offline renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -3,18 +3,18 @@
 Static, offline-first canvas capsule that renders four calm layers: the vesica lattice, Tree-of-Life scaffold, Fibonacci spiral, and a static double-helix lattice. Everything is ND-safe - no motion, soft contrast, and clear commentary.
 
 ## Files
-- `index.html` - offline entry point that loads the optional palette, seeds numerology constants, and invokes the renderer.
-- `js/helix-renderer.mjs` - pure ES module of drawing helpers. Each function documents why the ND-safe order matters.
-- `data/palette.json` - optional colour override. If missing the renderer applies its sealed fallback, posts a status message, and prints a canvas notice.
+- `index.html` - offline entry point that loads the optional palette, syncs the chrome colours, seeds numerology constants, and invokes the renderer.
+- `js/helix-renderer.mjs` - pure ES module of drawing helpers. Each function documents why the ND-safe order matters and references the covenant numbers.
+- `data/palette.json` - optional colour override. If missing the renderer applies its sealed fallback, posts a status message, and paints a canvas notice.
 
 ## Usage
 1. Download or clone the repository.
 2. Double-click `index.html`. No build step or server is required.
-3. If `data/palette.json` is blocked by `file://` rules, the fallback palette activates automatically and a notice appears on the canvas footer.
+3. If `data/palette.json` is blocked by `file://` rules, the fallback palette activates automatically, the page chrome updates to the safe defaults, and a notice appears on the canvas footer.
 
 ## Layer order (back to front)
 1. **Vesica field** - seven by three grid of intersecting circles, softened alpha to avoid glare.
-2. **Tree-of-Life scaffold** - ten sephirot nodes tied by twenty-two calm paths derived from numerology constants.
+2. **Tree-of-Life scaffold** - ten sephirot nodes tied by twenty-two calm paths. Vertical placement uses combinations of {3, 7, 9, 11, 22, 33, 99, 144} so the descent honours the numerology covenant.
 3. **Fibonacci curve** - static logarithmic spiral sampled from Fibonacci numbers up to 144.
 4. **Double-helix lattice** - two phase-shifted strands with alternating rungs; entirely static.
 
@@ -22,7 +22,7 @@ All routines stay parameterised by `{3, 7, 9, 11, 22, 33, 99, 144}` to honour th
 
 ## Accessibility & ND-safe rationale
 - No animation, autoplay, or async loops. Rendering happens once per load.
-- Calm palette defaults with clear status messaging when fallbacks are in play.
+- Calm palette defaults with clear status messaging when fallbacks are in play, including an inline canvas caption for assurance.
 - Layered drawing order maintains geometric depth without flattening into a single outline.
 - ASCII quotes, UTF-8, LF newlines, and small pure functions keep the module portable offline.
 

--- a/index.html
+++ b/index.html
@@ -18,8 +18,8 @@
 </head>
 <body>
   <header>
-    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Loading palette...</div>
+    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette…</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
@@ -33,6 +33,7 @@
     const ctx = canvas.getContext("2d");
 
     async function loadJSON(path) {
+      // Offline promise: only touches local file paths. If blocked (e.g. file:// fetch), null is returned.
       try {
         const res = await fetch(path, { cache: "no-store" });
         if (!res.ok) throw new Error(String(res.status));
@@ -51,15 +52,24 @@
     };
 
     const palette = await loadJSON("./data/palette.json");
-    const usingFallback = !palette;
     const active = palette || defaults.palette;
-    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+    const usingFallback = !palette;
 
-    // Numerology constants used by geometry routines
-    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
+    // Sync CSS tokens with whichever palette resolved so the chrome mirrors the canvas.
+    document.documentElement.style.setProperty("--bg", active.bg);
+    document.documentElement.style.setProperty("--ink", active.ink);
 
-    // ND-safe rationale: no motion, high readability, soft colors, layered order
-    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM, notice: usingFallback ? "Palette fallback active" : null });
+    elStatus.textContent = usingFallback ? "Palette missing; using safe fallback." : "Palette loaded.";
+
+    if (!ctx) {
+      elStatus.textContent += " Canvas 2D context unavailable.";
+    } else {
+      // Numerology constants used by geometry routines
+      const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
+
+      // ND-safe rationale: no motion, high readability, soft colors, layered order
+      renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM, notice: usingFallback ? "Palette fallback active" : null });
+    }
   </script>
 </body>
 </html>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -170,19 +170,29 @@ function buildTreeNodes(dims, numbers) {
   const marginY = dims.height / numbers.THIRTYTHREE;
   const centerX = dims.width / 2;
   const column = dims.width / numbers.THREE;
-  const stepY = (dims.height - marginY * 2) / (numbers.ELEVEN);
+  const innerHeight = dims.height - marginY * 2;
+  const stepY = innerHeight / numbers.ELEVEN;
+  const level = multiplier => marginY + stepY * multiplier;
+
+  // Multipliers derive from combinations of the covenant numbers to keep the geometry numerologically anchored.
+  const chokmahBinahLevel = numbers.THIRTYTHREE / numbers.TWENTYTWO; // 33/22 = 1.5 -> gentle descent from Kether.
+  const daathLevel = (numbers.TWENTYTWO + numbers.SEVEN) / numbers.ELEVEN; // (22+7)/11 ≈ 2.636 keeps Daath between the upper triad and Chesed/Geburah.
+  const chesedGeburahLevel = (numbers.THIRTYTHREE + numbers.NINE) / numbers.ELEVEN; // 42/11 ≈ 3.818 maintains balance on both pillars.
+  const tipharethLevel = (numbers.THIRTYTHREE + numbers.TWENTYTWO) / numbers.ELEVEN; // 55/11 = 5 holds the heart centre.
+  const netzachHodLevel = (numbers.ONEFORTYFOUR - numbers.TWENTYTWO) / numbers.TWENTYTWO; // 122/22 ≈ 5.545 descends smoothly from Tiphareth.
+  const yesodLevel = (numbers.ONEFORTYFOUR - numbers.THREE) / numbers.TWENTYTWO; // 141/22 ≈ 6.409 anchors the foundation before Malkuth.
 
   return {
     kether: { x: centerX, y: marginY },
-    chokmah: { x: centerX + column / 2, y: marginY + stepY * 1.5 },
-    binah: { x: centerX - column / 2, y: marginY + stepY * 1.5 },
-    daath: { x: centerX, y: marginY + stepY * 2.6 },
-    chesed: { x: centerX + column / 2, y: marginY + stepY * 3.8 },
-    geburah: { x: centerX - column / 2, y: marginY + stepY * 3.8 },
-    tiphareth: { x: centerX, y: marginY + stepY * 5.1 },
-    netzach: { x: centerX + column / 2, y: marginY + stepY * 6.7 },
-    hod: { x: centerX - column / 2, y: marginY + stepY * 6.7 },
-    yesod: { x: centerX, y: marginY + stepY * 8.4 },
+    chokmah: { x: centerX + column / 2, y: level(chokmahBinahLevel) },
+    binah: { x: centerX - column / 2, y: level(chokmahBinahLevel) },
+    daath: { x: centerX, y: level(daathLevel) },
+    chesed: { x: centerX + column / 2, y: level(chesedGeburahLevel) },
+    geburah: { x: centerX - column / 2, y: level(chesedGeburahLevel) },
+    tiphareth: { x: centerX, y: level(tipharethLevel) },
+    netzach: { x: centerX + column / 2, y: level(netzachHodLevel) },
+    hod: { x: centerX - column / 2, y: level(netzachHodLevel) },
+    yesod: { x: centerX, y: level(yesodLevel) },
     malkuth: { x: centerX, y: dims.height - marginY }
   };
 }


### PR DESCRIPTION
## Summary
- sync the renderer shell with the resolved palette and guard against missing 2D contexts so the offline entry point stays calm
- anchor the Tree-of-Life layout to numerology-derived multipliers to honour the covenant constants
- refresh the renderer README with updated guidance on fallbacks and numeric grounding

## Testing
- npm run build *(fails: missing ajv dependency; npm install blocked with 403)*
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc7c2d058483288d39e657bd82a3e4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatic palette fallback activates offline, syncing page chrome colors and showing a canvas footer notice.
  - Canvas availability is checked; if unavailable, a clear message is shown instead of rendering.

- Improvements
  - Tree of Life layout refined for smoother vertical spacing.
  - Status handling streamlined; palette status routed through renderer for cleaner UI.
  - CSS variables now sync with the active palette to match canvas chrome.

- Documentation
  - README clarifies offline behavior, fallback palette, and accessibility rationale.

- Style
  - Header punctuation refined (em dash, ellipsis).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->