### PR TITLE
Clean cosmic helix renderer and module

### DIFF
--- a/cosmic-helix/README_RENDERER.md
+++ b/cosmic-helix/README_RENDERER.md
@@ -1,79 +1,31 @@
 # Cosmic Helix Renderer (Offline, ND-safe)
 
-
-Static HTML + Canvas capsule that renders the layered cosmology without motion. Double-clicking `index.html` paints a 1440x900
-canvas with four calm layers: vesica grid, Tree-of-Life scaffold, Fibonacci curve, and a double-helix lattice. Everything runs
-offline with no build tools or external libraries.
+Static HTML + Canvas renderer that paints the requested four-layer cosmology on a fixed 1440x900 stage. Open `index.html` directly in any modern browser and the canvas renders once without motion.
 
 ## Files
-- `index.html` - offline entry point that loads the palette (with fallback), seeds numerology constants, and invokes the
-  renderer.
-- `js/helix-renderer.mjs` - ES module of small pure drawing helpers. Each helper documents why the ND-safe order matters.
-- `data/palette.json` - optional palette override. If missing, the renderer keeps a safe fallback and paints a notice on the
-  canvas.
+- `index.html` - offline entry that loads the optional palette and geometry files, applies sealed fallbacks, and calls the renderer.
+- `js/helix-renderer.mjs` - ES module of small pure helpers. Each helper documents the ND-safe layer order.
+- `data/palette.json` - optional colour overrides. Missing data triggers the sealed palette, a status note, and a canvas notice.
+- `data/geometry.json` - optional geometry overrides for spacing, node layout, and helix pacing.
 
 ## Usage (offline)
-1. Open `cosmic-helix/index.html` directly in any modern browser. No server or network connection is required.
-2. The header status reports whether the palette loaded. Missing data keeps the fallback colours and adds a gentle notice to the
-   canvas corner.
-3. The canvas renders the four layers once using the numerology constants (3, 7, 9, 11, 22, 33, 99, 144) baked into the helper
-   functions.
+1. Double-click `cosmic-helix/index.html`. No server, build step, or network connection is required.
+2. The header status confirms whether the palette and geometry files loaded. Missing files fall back gracefully and keep the canvas ND-safe.
+3. The renderer draws the vesica field, Tree-of-Life scaffold, Fibonacci curve, and double-helix lattice exactly once.
 
 ## Layer order (back to front)
-1. **Vesica field** - intersecting circle lattice spaced with 9x11 divisions to honour womb-of-forms geometry.
-2. **Tree-of-Life scaffold** - ten sephirot nodes joined by twenty-two steady paths, scaled by the numerology denominators for
-   clarity.
-3. **Fibonacci curve** - static logarithmic spiral sampled over 144 points with golden ratio pacing.
-4. **Double-helix lattice** - two phase-shifted strands with thirty-three cross ties and no motion.
+1. **Vesica field** - intersecting circle lattice spaced with 3/7/9/11 ratios to seed the womb-of-forms grid.
+2. **Tree-of-Life scaffold** - ten sephirot nodes joined by twenty-two calm paths derived from numerology constants.
+3. **Fibonacci curve** - logarithmic spiral polyline sampled over 144 points for gentle golden-ratio growth.
+4. **Double-helix lattice** - two still strands with thirty-three cross ties and no motion.
 
 ## ND-safe and trauma-informed choices
-- No animation or timers; everything draws once per load to avoid sensory spikes.
-- Calm palette defaults with status messaging explain fallbacks so nothing fails silently.
-- Comments explain why each layer order and spacing choice preserves depth without flattening geometry.
-- ASCII quotes, UTF-8, and LF newlines keep the module portable across offline environments.
+- No animation, autoplay, or timers. Rendering completes in a single pass.
+- Calm palette defaults with explicit status messaging so fallbacks never surprise viewers.
+- Layered geometry keeps sacred forms three-dimensional instead of flattening them into a single outline.
+- ASCII quotes, UTF-8, and LF newlines preserve portability for offline review.
 
 ## Customising safely
-- Adjust `data/palette.json` to change colours. Keys remain `bg`, `ink`, `muted`, and `layers` (array of six hex strings).
-- Pass a custom geometry object when calling `renderHelix` if deeper tuning is required; the function validates numbers and
-  keeps the ND-safe structure intact.
-=======
-Static HTML + Canvas renderer that draws the requested four-layer cosmology on a fixed 1440x900 stage. It lives in `cosmic-helix/` so the wider site keeps its lore-first entry point.
-
-## Files
-- `index.html` - offline entry point that loads the optional palette, seeds numerology constants, and invokes the renderer.
-- `js/helix-renderer.mjs` - ES module of small pure drawing helpers (one layer per function plus shared utilities).
-- `data/palette.json` - optional colour overrides. Missing data triggers a calm fallback and a gentle notice.
-
-## Usage (offline)
-1. Open `cosmic-helix/index.html` directly in any modern browser (no server required).
-2. The header status reports whether `data/palette.json` loaded successfully.
-3. The canvas renders the four layers once. If the palette file is missing under `file://` rules, the renderer prints a small notice while using the sealed fallback palette.
-
-## Layer order (back to front)
-1. **Vesica field** - intersecting circle lattice spaced with 3/7/9/11 ratios to set the womb-of-forms foundation.
-2. **Tree-of-Life scaffold** - ten sephirot nodes linked by twenty-two paths, scaled by 33/99/144 denominators for clarity.
-3. **Fibonacci curve** - logarithmic spiral polyline sampled over 144 points with golden-ratio pacing.
-4. **Double-helix lattice** - two static sine strands with cross ties drawn across 33 anchor points.
-
-## ND-safe and trauma-informed choices
-- **No motion:** the renderer draws once per load with no timers or autoplay hooks.
-- **Calm palette:** palette validation keeps contrast comfortable and applies sealed fallbacks when JSON is absent.
-- **Layered depth:** geometry is rendered as separate layers instead of flattening sacred forms into one outline.
-- **Commented intent:** inline comments explain why safety choices exist for future stewards.
-
-## Customising safely
-Update `data/palette.json` to supply custom colours:
-
-```json
-{
-  "bg": "#0b0b12",
-  "ink": "#e8e8f0",
-  "muted": "#a6a6c1",
-  "layers": ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-}
-```
-
-If the file is missing or malformed the renderer keeps the sealed palette, updates the status line, and posts the gentle notice on the canvas so nothing fails silently.
-
-
-Add new geometry by composing additional pure helpers inside `js/helix-renderer.mjs`. Maintain the covenant: ASCII quotes, UTF-8 with LF newlines, static rendering, and inline comments describing lore or safety rationale.
+- Adjust `data/palette.json` to supply custom colours. Provide `bg`, `ink`, `muted`, and a six colour `layers` array.
+- Tune spacing by editing `data/geometry.json` or by passing a `geometry` object to `renderHelix`. The module validates every override to keep ND-safe bounds.
+- Compose new layers by following the pure helper pattern inside `js/helix-renderer.mjs`. Keep additions static and well-commented to honour the covenant.

--- a/cosmic-helix/index.html
+++ b/cosmic-helix/index.html
@@ -6,8 +6,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
   <meta name="color-scheme" content="light dark">
   <style>
-
-    /* ND-safe chrome: calm contrast, no motion, layered depth preserved (why: reduces sensory load). */
+    /* ND-safe chrome: calm contrast, no motion, layered geometry preserved. */
     :root {
       --bg: #0b0b12;
       --ink: #e8e8f0;
@@ -20,17 +19,17 @@
       padding: 0;
       background: var(--bg);
       color: var(--ink);
-      font: 14px/1.4 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
     }
 
     header {
       padding: 12px 16px;
       border-bottom: 1px solid var(--outline);
-      background: linear-gradient(180deg, #10101a, transparent);
+      background: linear-gradient(180deg, rgba(17,17,26,0.9), rgba(11,11,18,0.2));
     }
 
     header strong {
-      font-weight: 600;
+      letter-spacing: 0.05em;
     }
 
     .status {
@@ -42,16 +41,24 @@
     #stage {
       display: block;
       margin: 16px auto;
-      width: 100%;
-      max-width: 1440px;
-      box-shadow: 0 0 0 1px var(--outline);
+      width: 1440px;
+      height: 900px;
+      max-width: calc(100vw - 32px);
+      max-height: calc(100vh - 160px);
       background: var(--bg);
+      box-shadow: 0 0 0 1px var(--outline);
+    }
+
+    canvas {
+      width: 100%;
+      height: 100%;
+      display: block;
     }
 
     .note {
       max-width: 900px;
-      margin: 0 auto 16px;
-      padding: 0 16px 24px;
+      margin: 0 auto 24px;
+      padding: 0 16px;
       color: var(--muted);
     }
 
@@ -60,49 +67,36 @@
       padding: 2px 4px;
       border-radius: 3px;
     }
-
-    /* ND-safe: calm contrast, no motion, generous spacing */
-    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
-    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
-    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; background:linear-gradient(180deg, rgba(255,255,255,0.05), transparent); }
-    header strong { font-weight:600; letter-spacing:0.06em; }
-    .status { margin-top:4px; color:var(--muted); font-size:12px; }
-    #stage { display:block; margin:16px auto; width:1440px; height:900px; box-shadow:0 0 0 1px #1d1d2a; background:var(--bg); max-width:calc(100vw - 32px); max-height:calc(100vh - 160px); }
-    canvas { width:100%; height:100%; display:block; }
-    .note { max-width:900px; margin:0 auto 24px; padding:0 16px; color:var(--muted); }
-    code { background:#11111a; padding:2px 4px; border-radius:3px; }
-
   </style>
 </head>
 <body>
   <header>
     <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
-
     <div class="status" id="status">Loading palette...</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">Static renderer for vesica grid, Tree-of-Life nodes, Fibonacci curve, and a double-helix lattice. Open this file directly (no server, no animation, ND-safe palette).</p>
-
-    <div class="status" id="status">Preparing palette...</div>
-  </header>
-
-  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">Static renderer encoding Vesica field, Tree-of-Life scaffold, Fibonacci curve, and a double-helix lattice. No animation, no autoplay, no external libraries. Open this file directly.</p>
-
+  <p class="note">Static renderer encoding the vesica field, Tree-of-Life scaffold, Fibonacci curve, and a double-helix lattice. Open this file directly; no build tools, no animation, ND-safe palette only.</p>
 
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
 
-
-    const elStatus = document.getElementById("status");
-
     const statusEl = document.getElementById("status");
-
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
 
-    async function loadPalette(path) {
+    const DEFAULTS = {
+      palette: {
+        bg: "#0b0b12",
+        ink: "#e8e8f0",
+        muted: "#a6a6c1",
+        layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
+      }
+    };
+
+    const NUM = { THREE: 3, SEVEN: 7, NINE: 9, ELEVEN: 11, TWENTYTWO: 22, THIRTYTHREE: 33, NINETYNINE: 99, ONEFORTYFOUR: 144 };
+
+    async function loadJSON(path) {
       try {
         const response = await fetch(path, { cache: "no-store" });
         if (!response.ok) {
@@ -111,83 +105,42 @@
         return await response.json();
       } catch (error) {
         return null;
-
       }
     }
 
-    const defaults = {
-      palette: {
-        bg: "#0b0b12",
-        ink: "#e8e8f0",
-        muted: "#a6a6c1",
-        layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-      }
-    };
+    function applyTheme(palette) {
+      const root = document.documentElement;
+      root.style.setProperty("--bg", palette.bg);
+      root.style.setProperty("--ink", palette.ink);
+      root.style.setProperty("--muted", palette.muted || palette.ink);
+    }
 
-    const NUM = {
-      THREE: 3,
-      SEVEN: 7,
-      NINE: 9,
-      ELEVEN: 11,
-      TWENTYTWO: 22,
-      THIRTYTHREE: 33,
-      NINETYNINE: 99,
-      ONEFORTYFOUR: 144
-    };
+    if (!ctx) {
+      statusEl.textContent = "Canvas unavailable in this browser.";
+    } else {
+      const paletteData = await loadJSON("./data/palette.json");
+      const geometryData = await loadJSON("./data/geometry.json");
+      const palette = paletteData || DEFAULTS.palette;
+      applyTheme(palette);
 
-    (async () => {
-      const palette = await loadPalette("./data/palette.json");
-      const activePalette = palette || defaults.palette;
-      const notice = palette ? "" : "Palette missing; using ND-safe fallback.";
-      elStatus.textContent = palette ? "Palette loaded." : "Palette missing; fallback active.";
-
-      if (!ctx) {
-        elStatus.textContent = "Canvas unavailable in this browser.";
-        return;
-      }
-
-      // ND-safe order: draw once, preserve calm layering, flag fallbacks visually.
-      renderHelix(ctx, {
+      const notice = paletteData ? "" : "Palette fallback active.";
+      const result = renderHelix(ctx, {
         width: canvas.width,
         height: canvas.height,
-        palette: activePalette,
+        palette,
+        geometry: geometryData || undefined,
         NUM,
         notice
       });
-    })();
 
+      if (result.ok) {
+        const paletteMessage = paletteData ? "Palette loaded." : "Palette missing; using sealed fallback.";
+        const geometryMessage = geometryData ? " Geometry loaded." : " Geometry fallback in use.";
+        statusEl.textContent = paletteMessage + geometryMessage;
+      } else {
+        statusEl.textContent = "Renderer error: " + (result.reason || "unknown");
       }
     }
-
-    const FALLBACK = {
-      palette: {
-        bg: "#0b0b12",
-        ink: "#e8e8f0",
-        muted: "#a6a6c1",
-        layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-      }
-    };
-
-    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
-
-    const palette = await loadPalette("./data/palette.json");
-    const usingFallback = !palette;
-
-    const notice = usingFallback ? "Palette file missing - sealed fallback engaged." : "";
-    const result = renderHelix(ctx, {
-      width: canvas.width,
-      height: canvas.height,
-      palette: palette || FALLBACK.palette,
-      NUM,
-      notice
-    });
-
-    if (result.ok) {
-      statusEl.textContent = usingFallback ? "Palette missing; using sealed fallback palette." : "Palette loaded from data/palette.json.";
-    } else {
-      statusEl.textContent = "Renderer error: " + (result.reason || "unknown");
-    }
-
   </script>
 </body>
 </html>

--- a/cosmic-helix/js/helix-renderer.mjs
+++ b/cosmic-helix/js/helix-renderer.mjs
@@ -1,41 +1,28 @@
 /*
   helix-renderer.mjs
-
-  Static renderer for the Cosmic Helix canvas. All helpers are pure functions so the
-  module stays predictable and ND-safe (why: keeps rendering single-pass and calm).
+  Offline ND-safe renderer for the Cosmic Helix canvas.
 
   Layer order (back to front):
-    1) Vesica field - intersecting circles establishing the womb-of-forms grid.
-    2) Tree-of-Life scaffold - ten sephirot linked by twenty-two steady paths.
-    3) Fibonacci curve - logarithmic spiral encoded with golden ratio pacing.
-    4) Double-helix lattice - two static strands with gentle cross ties.
+    1) Vesica field - intersecting circles grounding the vesica piscis grid.
+    2) Tree-of-Life scaffold - ten sephirot nodes with twenty-two calm paths.
+    3) Fibonacci curve - static logarithmic spiral sampled from the Fibonacci family.
+    4) Double-helix lattice - two phase-shifted strands tied by gentle rungs.
 
-  Numerology constants (3, 7, 9, 11, 22, 33, 99, 144) shape spacing, sampling,
-  and proportions throughout the helpers to honour the requested symbolism.
-
-  ND-safe static renderer for layered sacred geometry.
-
-  Layers (rendered back to front):
-    1) Vesica field - intersecting circle lattice for the womb-of-forms motif.
-    2) Tree-of-Life scaffold - ten sephirot joined by twenty-two calm paths.
-    3) Fibonacci curve - logarithmic spiral polyline with golden-ratio pacing.
-    4) Double-helix lattice - two still strands with gentle cross ties.
-
-  Rationale:
-    - No animation: everything draws once on load to respect ND-safe pacing.
-    - Calm palette: soft contrast keeps lines readable without sensory spikes.
-    - Numerology constants (3, 7, 9, 11, 22, 33, 99, 144) guide proportions.
-
+  Why this structure:
+    - Zero animation: everything renders in one pass to preserve ND-safe pacing.
+    - Layer separation keeps sacred geometry three-dimensional instead of flattened.
+    - Numerology constants (3, 7, 9, 11, 22, 33, 99, 144) shape spacing and sampling.
+    - Pure helper functions keep the module portable for offline review.
 */
 
-const FALLBACK_PALETTE = {
+const DEFAULT_PALETTE = {
   bg: "#0b0b12",
   ink: "#e8e8f0",
   muted: "#a6a6c1",
-  layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
+  layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"],
 };
 
-const DEFAULT_NUM = {
+const DEFAULT_NUMBERS = {
   THREE: 3,
   SEVEN: 7,
   NINE: 9,
@@ -43,36 +30,34 @@ const DEFAULT_NUM = {
   TWENTYTWO: 22,
   THIRTYTHREE: 33,
   NINETYNINE: 99,
-  ONEFORTYFOUR: 144
+  ONEFORTYFOUR: 144,
 };
 
-const FALLBACK_GEOMETRY = {
-  // Vesica lattice references 9x11 grid divisions (why: ties to 9/11 numerology).
+const DEFAULT_GEOMETRY = {
   vesica: {
     rows: 9,
     columns: 11,
     paddingDivisor: 11,
     radiusFactor: 1.5,
     strokeDivisor: 99,
-    alpha: 0.55
+    alpha: 0.6,
   },
-  // Tree-of-Life scaffold uses ten nodes with 22 connective paths.
   treeOfLife: {
     marginDivisor: 11,
     radiusDivisor: 22,
     labelOffset: -24,
     labelFont: "13px system-ui, -apple-system, Segoe UI, sans-serif",
     nodes: [
-      { id: "kether", title: "Kether", meaning: "Crown", level: 0, xFactor: 0.5 },
-      { id: "chokmah", title: "Chokmah", meaning: "Wisdom", level: 1, xFactor: 0.7 },
-      { id: "binah", title: "Binah", meaning: "Understanding", level: 1, xFactor: 0.3 },
-      { id: "chesed", title: "Chesed", meaning: "Mercy", level: 2, xFactor: 0.68 },
-      { id: "geburah", title: "Geburah", meaning: "Severity", level: 2, xFactor: 0.32 },
-      { id: "tiphareth", title: "Tiphareth", meaning: "Beauty", level: 3, xFactor: 0.5 },
-      { id: "netzach", title: "Netzach", meaning: "Victory", level: 4, xFactor: 0.66 },
-      { id: "hod", title: "Hod", meaning: "Glory", level: 4, xFactor: 0.34 },
-      { id: "yesod", title: "Yesod", meaning: "Foundation", level: 5, xFactor: 0.5 },
-      { id: "malkuth", title: "Malkuth", meaning: "Kingdom", level: 6, xFactor: 0.5 }
+      { id: "kether", title: "Kether", level: 0, xFactor: 0.5 },
+      { id: "chokmah", title: "Chokmah", level: 1, xFactor: 0.7 },
+      { id: "binah", title: "Binah", level: 1, xFactor: 0.3 },
+      { id: "chesed", title: "Chesed", level: 2, xFactor: 0.68 },
+      { id: "geburah", title: "Geburah", level: 2, xFactor: 0.32 },
+      { id: "tiphareth", title: "Tiphareth", level: 3, xFactor: 0.5 },
+      { id: "netzach", title: "Netzach", level: 4, xFactor: 0.66 },
+      { id: "hod", title: "Hod", level: 4, xFactor: 0.34 },
+      { id: "yesod", title: "Yesod", level: 5, xFactor: 0.5 },
+      { id: "malkuth", title: "Malkuth", level: 6, xFactor: 0.5 },
     ],
     edges: [
       ["kether", "chokmah"],
@@ -96,15 +81,15 @@ const FALLBACK_GEOMETRY = {
       ["netzach", "hod"],
       ["netzach", "yesod"],
       ["hod", "yesod"],
-      ["yesod", "malkuth"]
-    ]
+      ["yesod", "malkuth"],
+    ],
   },
   fibonacci: {
     sampleCount: 144,
     turns: 3,
     baseRadiusDivisor: 3,
     phi: 1.618033988749895,
-    alpha: 0.85
+    alpha: 0.85,
   },
   helix: {
     sampleCount: 144,
@@ -113,8 +98,8 @@ const FALLBACK_GEOMETRY = {
     phaseOffset: 180,
     crossTieCount: 33,
     strandAlpha: 0.85,
-    rungAlpha: 0.6
-  }
+    rungAlpha: 0.6,
+  },
 };
 
 export function renderHelix(ctx, options = {}) {
@@ -122,385 +107,338 @@ export function renderHelix(ctx, options = {}) {
     return { ok: false, reason: "missing-context" };
   }
 
-  const width = toNumber(options.width, ctx.canvas.width);
-  const height = toNumber(options.height, ctx.canvas.height);
-  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
-    return { ok: false, reason: "invalid-dimensions" };
-  }
-
-  const palette = normalisePalette(options.palette);
-  const numerology = normaliseNumerology(options.NUM);
-  const geometry = normaliseGeometry(options.geometry);
-  const notice = typeof options.notice === "string" ? options.notice.trim() : "";
+  const dims = normaliseDimensions(ctx, options);
+  const palette = mergePalette(options.palette);
+  const numbers = mergeNumbers(options.NUM);
+  const geometry = mergeGeometry(options.geometry);
+  const notice =
+    typeof options.notice === "string" && options.notice.trim()
+      ? options.notice.trim()
+      : "";
 
   ctx.save();
-  ctx.setTransform(1, 0, 0, 1, 0, 0);
-  fillBackground(ctx, width, height, palette.bg);
+  clearStage(ctx, dims, palette.bg);
 
-  // Layer sequencing preserves depth without motion (why: layered geometry, ND-safe).
-  drawVesicaField(ctx, width, height, palette.layers[0], numerology, geometry.vesica);
-  drawTreeOfLife(ctx, width, height, palette.layers[1], palette.layers[2], palette.ink, numerology, geometry.treeOfLife);
-  drawFibonacciCurve(ctx, width, height, palette.layers[3], numerology, geometry.fibonacci);
-  drawHelixLattice(ctx, width, height, palette.layers[4], palette.layers[5], numerology, geometry.helix);
+  const vesicaStats = drawVesicaField(
+    ctx,
+    dims,
+    palette.layers[0],
+    numbers,
+    geometry.vesica,
+  );
+  const treeStats = drawTreeOfLife(
+    ctx,
+    dims,
+    palette,
+    numbers,
+    geometry.treeOfLife,
+  );
+  const fibonacciStats = drawFibonacciCurve(
+    ctx,
+    dims,
+    palette.layers[3],
+    numbers,
+    geometry.fibonacci,
+  );
+  const helixStats = drawHelixLattice(
+    ctx,
+    dims,
+    palette,
+    numbers,
+    geometry.helix,
+  );
 
   if (notice) {
-    drawNotice(ctx, width, height, palette.ink, notice);
+    drawCanvasNotice(ctx, dims, palette.ink, notice);
   }
 
   ctx.restore();
-  return { ok: true, constants: numerology };
-}
 
-function normalisePalette(input) {
-  if (!input || typeof input !== "object") {
-    return clonePalette(FALLBACK_PALETTE);
-  }
-
-  const result = {
-    bg: typeof input.bg === "string" ? input.bg : FALLBACK_PALETTE.bg,
-    ink: typeof input.ink === "string" ? input.ink : FALLBACK_PALETTE.ink,
-    muted: typeof input.muted === "string" ? input.muted : FALLBACK_PALETTE.muted,
-    layers: []
-  };
-
-  const sourceLayers = Array.isArray(input.layers) ? input.layers : [];
-  for (let index = 0; index < FALLBACK_PALETTE.layers.length; index += 1) {
-    const candidate = sourceLayers[index];
-    result.layers.push(typeof candidate === "string" ? candidate : FALLBACK_PALETTE.layers[index]);
-  }
-
-  return result;
-}
-
-function clonePalette(palette) {
   return {
-    bg: palette.bg,
-    ink: palette.ink,
-    muted: palette.muted,
-    layers: [...palette.layers]
+    ok: true,
+    summary: summariseLayers({
+      vesicaStats,
+      treeStats,
+      fibonacciStats,
+      helixStats,
+    }),
   };
 }
 
-function normaliseNumerology(input) {
-  const source = input && typeof input === "object" ? input : {};
-  const result = {};
-  for (const key of Object.keys(DEFAULT_NUM)) {
-    const value = Number(source[key]);
-    result[key] = Number.isFinite(value) && value > 0 ? value : DEFAULT_NUM[key];
+function normaliseDimensions(ctx, options) {
+  const width = toPositiveNumber(options.width, ctx.canvas.width);
+  const height = toPositiveNumber(options.height, ctx.canvas.height);
+  return { width, height };
+}
+
+function mergePalette(candidate = {}) {
+  const layers = Array.isArray(candidate.layers)
+    ? candidate.layers.slice(0, DEFAULT_PALETTE.layers.length)
+    : [];
+  while (layers.length < DEFAULT_PALETTE.layers.length) {
+    layers.push(DEFAULT_PALETTE.layers[layers.length]);
   }
-  return result;
-}
-
-function normaliseGeometry(input) {
-  const source = input && typeof input === "object" ? input : {};
   return {
-    vesica: normaliseVesica(source.vesica),
-    treeOfLife: normaliseTree(source.treeOfLife),
-    fibonacci: normaliseFibonacci(source.fibonacci),
-    helix: normaliseHelix(source.helix)
+    bg: typeof candidate.bg === "string" ? candidate.bg : DEFAULT_PALETTE.bg,
+    ink:
+      typeof candidate.ink === "string" ? candidate.ink : DEFAULT_PALETTE.ink,
+    muted:
+      typeof candidate.muted === "string"
+        ? candidate.muted
+        : DEFAULT_PALETTE.muted,
+    layers,
   };
 }
 
-function normaliseVesica(data) {
-  const fallback = FALLBACK_GEOMETRY.vesica;
-  const safe = data && typeof data === "object" ? data : {};
+function mergeNumbers(candidate = {}) {
+  const merged = { ...DEFAULT_NUMBERS };
+  for (const key of Object.keys(DEFAULT_NUMBERS)) {
+    const value = candidate[key];
+    if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+      merged[key] = value;
+    }
+  }
+  return merged;
+}
+
+function mergeGeometry(candidate = {}) {
   return {
-    rows: positiveInteger(safe.rows, fallback.rows),
-    columns: positiveInteger(safe.columns, fallback.columns),
-    paddingDivisor: positiveNumber(safe.paddingDivisor, fallback.paddingDivisor),
-    radiusFactor: positiveNumber(safe.radiusFactor, fallback.radiusFactor),
-    strokeDivisor: positiveNumber(safe.strokeDivisor, fallback.strokeDivisor),
-    alpha: clampAlpha(safe.alpha, fallback.alpha)
+    vesica: mergeVesica(candidate.vesica),
+    treeOfLife: mergeTree(candidate.treeOfLife),
+    fibonacci: mergeFibonacci(candidate.fibonacci),
+    helix: mergeHelix(candidate.helix),
   };
 }
 
-function normaliseTree(data) {
-  const fallback = FALLBACK_GEOMETRY.treeOfLife;
-  const safe = data && typeof data === "object" ? data : {};
-  const fallbackNodes = fallback.nodes;
-  const providedNodes = Array.isArray(safe.nodes) && safe.nodes.length > 0 ? safe.nodes : fallbackNodes;
-  const nodes = providedNodes.map((node, index) => {
-    const base = typeof node === "object" && node !== null ? node : {};
-    const reference = fallbackNodes.find((item) => item.id === base.id) || fallbackNodes[index % fallbackNodes.length];
+function mergeVesica(config = {}) {
+  const base = DEFAULT_GEOMETRY.vesica;
+  return {
+    rows: toPositiveInteger(config.rows, base.rows),
+    columns: toPositiveInteger(config.columns, base.columns),
+    paddingDivisor: toPositiveNumber(
+      config.paddingDivisor,
+      base.paddingDivisor,
+    ),
+    radiusFactor: toPositiveNumber(config.radiusFactor, base.radiusFactor),
+    strokeDivisor: toPositiveNumber(config.strokeDivisor, base.strokeDivisor),
+    alpha: clampAlpha(config.alpha, base.alpha),
+  };
+}
+
+function mergeTree(config = {}) {
+  const base = DEFAULT_GEOMETRY.treeOfLife;
+  const nodes =
+    Array.isArray(config.nodes) && config.nodes.length > 0
+      ? config.nodes
+      : base.nodes;
+  const safeNodes = nodes.map((node, index) => {
+    const reference = base.nodes[index % base.nodes.length];
+    const data = typeof node === "object" && node !== null ? node : {};
     return {
-      id: typeof base.id === "string" && base.id ? base.id : reference.id,
-      title: typeof base.title === "string" && base.title ? base.title : reference.title,
-      meaning: typeof base.meaning === "string" && base.meaning ? base.meaning : reference.meaning,
-      level: finiteNumber(base.level, reference.level),
-      xFactor: clamp01(finiteNumber(base.xFactor, reference.xFactor))
+      id: typeof data.id === "string" && data.id ? data.id : reference.id,
+      title:
+        typeof data.title === "string" && data.title
+          ? data.title
+          : reference.title,
+      level: Number.isFinite(data.level) ? data.level : reference.level,
+      xFactor: clamp01(
+        Number.isFinite(data.xFactor) ? data.xFactor : reference.xFactor,
+      ),
     };
   });
 
-  const nodeIds = new Set(nodes.map((node) => node.id));
-  const sourceEdges = Array.isArray(safe.edges) && safe.edges.length > 0 ? safe.edges : fallback.edges;
-  const edges = sourceEdges
+  const nodeIds = new Set(safeNodes.map((node) => node.id));
+  const edges =
+    Array.isArray(config.edges) && config.edges.length > 0
+      ? config.edges
+      : base.edges;
+  const safeEdges = edges
     .map((edge) => (Array.isArray(edge) ? edge.slice(0, 2) : []))
-    .filter((edge) => edge.length === 2 && nodeIds.has(edge[0]) && nodeIds.has(edge[1]));
+    .filter(
+      (edge) =>
+        edge.length === 2 && nodeIds.has(edge[0]) && nodeIds.has(edge[1]),
+    );
 
   return {
-    marginDivisor: positiveNumber(safe.marginDivisor, fallback.marginDivisor),
-    radiusDivisor: positiveNumber(safe.radiusDivisor, fallback.radiusDivisor),
-    labelOffset: finiteNumber(safe.labelOffset, fallback.labelOffset),
-    labelFont: typeof safe.labelFont === "string" && safe.labelFont ? safe.labelFont : fallback.labelFont,
-    nodes,
-    edges
+    marginDivisor: toPositiveNumber(config.marginDivisor, base.marginDivisor),
+    radiusDivisor: toPositiveNumber(config.radiusDivisor, base.radiusDivisor),
+    labelOffset: Number.isFinite(config.labelOffset)
+      ? config.labelOffset
+      : base.labelOffset,
+    labelFont:
+      typeof config.labelFont === "string" && config.labelFont
+        ? config.labelFont
+        : base.labelFont,
+    nodes: safeNodes,
+    edges: safeEdges,
   };
 }
 
-function normaliseFibonacci(data) {
-  const fallback = FALLBACK_GEOMETRY.fibonacci;
-  const safe = data && typeof data === "object" ? data : {};
+function mergeFibonacci(config = {}) {
+  const base = DEFAULT_GEOMETRY.fibonacci;
   return {
-    sampleCount: positiveInteger(safe.sampleCount, fallback.sampleCount),
-    turns: positiveNumber(safe.turns, fallback.turns),
-    baseRadiusDivisor: positiveNumber(safe.baseRadiusDivisor, fallback.baseRadiusDivisor),
-    phi: positiveNumber(safe.phi, fallback.phi),
-    alpha: clampAlpha(safe.alpha, fallback.alpha)
+    sampleCount: toPositiveInteger(config.sampleCount, base.sampleCount),
+    turns: toPositiveNumber(config.turns, base.turns),
+    baseRadiusDivisor: toPositiveNumber(
+      config.baseRadiusDivisor,
+      base.baseRadiusDivisor,
+    ),
+    phi: toPositiveNumber(config.phi, base.phi),
+    alpha: clampAlpha(config.alpha, base.alpha),
   };
 }
 
-function normaliseHelix(data) {
-  const fallback = FALLBACK_GEOMETRY.helix;
-  const safe = data && typeof data === "object" ? data : {};
+function mergeHelix(config = {}) {
+  const base = DEFAULT_GEOMETRY.helix;
   return {
-    sampleCount: positiveInteger(safe.sampleCount, fallback.sampleCount),
-    cycles: positiveNumber(safe.cycles, fallback.cycles),
-    amplitudeDivisor: positiveNumber(safe.amplitudeDivisor, fallback.amplitudeDivisor),
-    phaseOffset: finiteNumber(safe.phaseOffset, fallback.phaseOffset),
-    crossTieCount: positiveInteger(safe.crossTieCount, fallback.crossTieCount),
-    strandAlpha: clampAlpha(safe.strandAlpha, fallback.strandAlpha),
-    rungAlpha: clampAlpha(safe.rungAlpha, fallback.rungAlpha)
+    sampleCount: toPositiveInteger(config.sampleCount, base.sampleCount),
+    cycles: toPositiveNumber(config.cycles, base.cycles),
+    amplitudeDivisor: toPositiveNumber(
+      config.amplitudeDivisor,
+      base.amplitudeDivisor,
+    ),
+    phaseOffset: Number.isFinite(config.phaseOffset)
+      ? config.phaseOffset
+      : base.phaseOffset,
+    crossTieCount: toPositiveInteger(config.crossTieCount, base.crossTieCount),
+    strandAlpha: clampAlpha(config.strandAlpha, base.strandAlpha),
+    rungAlpha: clampAlpha(config.rungAlpha, base.rungAlpha),
   };
 }
 
-function fillBackground(ctx, width, height, color) {
+function clearStage(ctx, dims, color) {
   ctx.fillStyle = color;
-  ctx.fillRect(0, 0, width, height);
+  ctx.fillRect(0, 0, dims.width, dims.height);
 }
 
-function drawVesicaField(ctx, width, height, color, N, settings) {
-  const rows = Math.max(2, settings.rows);
-  const columns = Math.max(2, settings.columns);
-  const padding = Math.min(width, height) / settings.paddingDivisor;
-
-  const horizontalSpan = width - padding * 2;
-  const verticalSpan = height - padding * 2;
-  const stepX = columns > 1 ? horizontalSpan / (columns - 1) : 0;
-  const stepY = rows > 1 ? verticalSpan / (rows - 1) : 0;
+function drawVesicaField(ctx, dims, color, numbers, settings) {
+  const rows = Math.max(1, settings.rows);
+  const columns = Math.max(1, settings.columns);
+  const padding = Math.min(dims.width, dims.height) / settings.paddingDivisor;
+  const availableWidth = dims.width - padding * 2;
+  const availableHeight = dims.height - padding * 2;
+  const stepX = columns > 1 ? availableWidth / (columns - 1) : 0;
+  const stepY = rows > 1 ? availableHeight / (rows - 1) : 0;
   const radius = Math.min(stepX, stepY) / settings.radiusFactor;
-  const strokeWidth = Math.max(1, Math.min(width, height) / settings.strokeDivisor);
-
-  const stepX = columns > 1 ? (width - padding * 2) / (columns - 1) : 0;
-  const stepY = rows > 1 ? (height - padding * 2) / (rows - 1) : 0;
-  const verticalStep = stepY * (N.SEVEN / N.NINE);
-  const radius = Math.min(stepX, stepY) * (N.NINE / N.ELEVEN) / settings.radiusFactor;
-  const strokeWidth = Math.max(1, Math.min(width, height) / settings.strokeDivisor) * (N.THIRTYTHREE / N.NINETYNINE);
-
+  const offset = radius * (numbers.ELEVEN / numbers.TWENTYTWO);
+  const strokeWidth = Math.max(
+    1,
+    Math.min(dims.width, dims.height) / settings.strokeDivisor,
+  );
 
   ctx.save();
   ctx.strokeStyle = colorWithAlpha(color, settings.alpha);
   ctx.lineWidth = strokeWidth;
-  ctx.globalAlpha = 1;
+  ctx.lineCap = "round";
 
+  let circles = 0;
   for (let row = 0; row < rows; row += 1) {
-    const offset = row % 2 === 0 ? 0 : stepX / 2;
-
     for (let column = 0; column < columns; column += 1) {
-      const x = padding + offset + column * stepX;
-      const y = padding + row * stepY;
-      ctx.beginPath();
-      ctx.arc(x, y, radius, 0, Math.PI * 2);
-      ctx.stroke();
-
-    for (let col = 0; col < columns; col += 1) {
-      const x = padding + offset + col * stepX;
-      if (x < padding || x > width - padding) {
-        continue;
-      }
-      const y = padding + row * verticalStep;
-      strokeCircle(ctx, x, y, radius);
-      const mirroredX = x + stepX / 2;
-      if (mirroredX <= width - padding) {
-        strokeCircle(ctx, mirroredX, y, radius);
-      }
-      const mirroredY = y + verticalStep / 2;
-      if (mirroredY <= height - padding) {
-        strokeCircle(ctx, x, mirroredY, radius);
-      }
-
+      const cx = padding + column * stepX;
+      const cy = padding + row * stepY;
+      strokeVesicaPair(ctx, cx, cy, radius, offset);
+      circles += 2;
     }
   }
 
   ctx.restore();
+  return { circles, radius };
 }
 
+function strokeVesicaPair(ctx, cx, cy, radius, offset) {
+  ctx.beginPath();
+  ctx.arc(cx - offset, cy, radius, 0, Math.PI * 2);
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.arc(cx + offset, cy, radius, 0, Math.PI * 2);
+  ctx.stroke();
+}
 
-function drawTreeOfLife(ctx, width, height, edgeColor, nodeColor, labelColor, N, settings) {
-  const margin = Math.min(width, height) / settings.marginDivisor;
-  const top = margin;
-  const bottom = height - margin;
-  const left = margin;
-  const right = width - margin;
-  const verticalSpan = bottom - top;
-  const horizontalSpan = right - left;
-  const radius = Math.max(4, Math.min(width, height) / settings.radiusDivisor);
-  const lineWidth = Math.max(1, Math.min(width, height) / N.NINETYNINE);
+function drawTreeOfLife(ctx, dims, palette, numbers, settings) {
+  const margin = Math.min(dims.width, dims.height) / settings.marginDivisor;
+  const usableWidth = dims.width - margin * 2;
+  const usableHeight = dims.height - margin * 2;
+  const radius = Math.max(
+    4,
+    Math.min(dims.width, dims.height) / settings.radiusDivisor,
+  );
+  const pathWidth = Math.max(
+    1,
+    Math.min(dims.width, dims.height) / numbers.NINETYNINE,
+  );
 
-  const maxLevel = settings.nodes.reduce((acc, node) => Math.max(acc, node.level), 0);
-  const levelStep = maxLevel > 0 ? verticalSpan / maxLevel : 0;
-
-  const positions = new Map();
-  settings.nodes.forEach((node) => {
-    const x = left + clamp01(node.xFactor) * horizontalSpan;
-    const y = top + node.level * levelStep;
-    positions.set(node.id, { x, y, node });
-  });
-
-  // Calm connective lines first (why: keeps lattice behind node glyphs).
-  ctx.save();
-  ctx.strokeStyle = edgeColor;
-  ctx.lineWidth = lineWidth;
-  ctx.globalAlpha = 0.75;
-  ctx.lineCap = "round";
-  settings.edges.forEach((edge) => {
-    const start = positions.get(edge[0]);
-    const end = positions.get(edge[1]);
-    if (!start || !end) {
-      return;
-    }
-    ctx.beginPath();
-    ctx.moveTo(start.x, start.y);
-    ctx.lineTo(end.x, end.y);
-    ctx.stroke();
-  });
-
-function drawTreeOfLife(ctx, width, height, pathColor, nodeColor, labelColor, N, tree) {
-  const margin = Math.min(width, height) / tree.marginDivisor;
-  const top = margin;
-  const bottom = height - margin;
-  const maxLevel = tree.nodes.reduce((acc, node) => Math.max(acc, node.level), 0);
-  const levelStep = maxLevel > 0 ? (bottom - top) / maxLevel : 0;
-  const radius = Math.min(width, height) / tree.radiusDivisor;
-  const pathWidth = Math.max(1, Math.min(width, height) / N.NINETYNINE);
+  const maxLevel = settings.nodes.reduce(
+    (acc, node) => Math.max(acc, node.level),
+    0,
+  );
+  const levelStep = maxLevel > 0 ? usableHeight / maxLevel : 0;
 
   const positions = new Map();
-  for (const node of tree.nodes) {
-    const clampedLevel = Math.max(0, Math.min(maxLevel, node.level));
-    const usableWidth = width - margin * 2;
+  for (const node of settings.nodes) {
     const x = margin + clamp01(node.xFactor) * usableWidth;
-    const y = top + clampedLevel * levelStep;
+    const y = margin + node.level * levelStep;
     positions.set(node.id, { x, y, node });
   }
 
   ctx.save();
-  ctx.strokeStyle = colorWithAlpha(pathColor, 0.66);
+  ctx.strokeStyle = colorWithAlpha(palette.layers[1], 0.7);
   ctx.lineWidth = pathWidth;
   ctx.lineCap = "round";
   ctx.lineJoin = "round";
-  ctx.beginPath();
-  for (const edge of tree.edges) {
-    const start = positions.get(edge[0]);
-    const end = positions.get(edge[1]);
-    if (!start || !end) {
+  for (const [fromId, toId] of settings.edges) {
+    const from = positions.get(fromId);
+    const to = positions.get(toId);
+    if (!from || !to) {
       continue;
     }
-    ctx.moveTo(start.x, start.y);
-    ctx.lineTo(end.x, end.y);
+    ctx.beginPath();
+    ctx.moveTo(from.x, from.y);
+    ctx.lineTo(to.x, to.y);
+    ctx.stroke();
   }
-  ctx.stroke();
-
   ctx.restore();
 
-  // Nodes overlay edges so depth stays readable.
   ctx.save();
-
-  ctx.fillStyle = nodeColor;
-  ctx.strokeStyle = labelColor;
-  ctx.lineWidth = Math.max(1, lineWidth * 0.75);
-  settings.nodes.forEach((node) => {
-    const point = positions.get(node.id);
-    if (!point) {
-      return;
-    }
+  ctx.fillStyle = palette.layers[2];
+  ctx.strokeStyle = palette.ink;
+  ctx.lineWidth = Math.max(1, pathWidth * 0.75);
+  for (const point of positions.values()) {
     ctx.beginPath();
     ctx.arc(point.x, point.y, radius, 0, Math.PI * 2);
     ctx.fill();
     ctx.stroke();
-  });
-
-  ctx.fillStyle = colorWithAlpha(nodeColor, 0.9);
-  ctx.strokeStyle = colorWithAlpha(nodeColor, 0.9);
-  ctx.lineWidth = Math.max(1, pathWidth * 0.75);
-  for (const entry of positions.values()) {
-    ctx.beginPath();
-    ctx.arc(entry.x, entry.y, radius, 0, Math.PI * 2);
-    ctx.fill();
-    ctx.stroke();
   }
-
   ctx.restore();
 
-  ctx.save();
-  ctx.fillStyle = labelColor;
-
-  ctx.font = settings.labelFont;
-  ctx.textAlign = "center";
-  ctx.textBaseline = "middle";
-  settings.nodes.forEach((node) => {
-    const point = positions.get(node.id);
-    if (!point) {
-      return;
+  if (settings.labelOffset !== 0 && settings.labelFont) {
+    ctx.save();
+    ctx.fillStyle = palette.ink;
+    ctx.font = settings.labelFont;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    for (const point of positions.values()) {
+      const labelY = point.y + settings.labelOffset;
+      ctx.fillText(point.node.title, point.x, labelY);
     }
-    const labelY = point.y + settings.labelOffset;
-    ctx.fillText(node.title, point.x, labelY);
-  });
-
-  ctx.font = tree.labelFont;
-  ctx.textAlign = "center";
-  ctx.textBaseline = "top";
-  for (const entry of positions.values()) {
-    const textY = entry.y + tree.labelOffset;
-    ctx.fillText(entry.node.title, entry.x, textY);
-    ctx.fillText(entry.node.meaning, entry.x, textY + 14);
+    ctx.restore();
   }
 
-  ctx.restore();
+  return { nodes: positions.size, paths: settings.edges.length };
 }
 
-function drawFibonacciCurve(ctx, width, height, color, N, settings) {
-
-  const count = Math.max(2, settings.sampleCount);
-  const turns = settings.turns;
-  const phi = settings.phi;
-  const angleTotal = turns * Math.PI * 2;
-  const growth = Math.pow(phi, turns);
-  const maxRadius = Math.min(width, height) / settings.baseRadiusDivisor;
-  const baseRadius = maxRadius / growth;
-  const centerX = width / 2;
-  const centerY = height / 2;
-  const strokeWidth = Math.max(1, Math.min(width, height) / N.NINETYNINE);
-
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = strokeWidth;
-  ctx.globalAlpha = settings.alpha;
-  ctx.beginPath();
-
-  for (let index = 0; index < count; index += 1) {
-    const t = count > 1 ? index / (count - 1) : 0;
-    const angle = t * angleTotal;
-    const radius = baseRadius * Math.pow(phi, t * turns);
-    const x = centerX + Math.cos(angle) * radius;
-    const y = centerY + Math.sin(angle) * radius;
-
+function drawFibonacciCurve(ctx, dims, color, numbers, settings) {
   const samples = Math.max(2, settings.sampleCount);
-  const turns = Math.max(0, settings.turns);
-  const totalAngle = turns * Math.PI * 2;
-  const centerX = width * 0.72;
-  const centerY = height * 0.35;
-  const baseRadius = Math.min(width, height) / settings.baseRadiusDivisor;
+  const turns = settings.turns;
   const phi = Math.max(1.0001, settings.phi);
-  const lineWidth = Math.max(1, Math.min(width, height) / N.NINETYNINE);
+  const totalAngle = turns * Math.PI * 2;
+  const baseRadius =
+    Math.min(dims.width, dims.height) / settings.baseRadiusDivisor;
+  const lineWidth = Math.max(
+    1,
+    Math.min(dims.width, dims.height) / numbers.NINETYNINE,
+  );
+  const centerX = dims.width * 0.72;
+  const centerY = dims.height * 0.28;
 
   ctx.save();
   ctx.strokeStyle = colorWithAlpha(color, settings.alpha);
@@ -508,288 +446,164 @@ function drawFibonacciCurve(ctx, width, height, color, N, settings) {
   ctx.lineCap = "round";
   ctx.lineJoin = "round";
   ctx.beginPath();
+
   for (let index = 0; index < samples; index += 1) {
-    const t = index / (samples - 1);
+    const t = samples > 1 ? index / (samples - 1) : 0;
     const angle = t * totalAngle;
     const radius = baseRadius * Math.pow(phi, t * turns);
-    const x = centerX + radius * Math.cos(angle);
-    const y = centerY + radius * Math.sin(angle);
-
+    const x = centerX + Math.cos(angle) * radius;
+    const y = centerY + Math.sin(angle) * radius;
     if (index === 0) {
       ctx.moveTo(x, y);
     } else {
       ctx.lineTo(x, y);
     }
   }
+
   ctx.stroke();
   ctx.restore();
+
+  return { points: samples };
 }
 
-function drawHelixLattice(ctx, width, height, strandColor, rungColor, N, settings) {
-
-  const count = Math.max(2, settings.sampleCount);
-  const cycles = settings.cycles;
-  const amplitude = Math.min(width, height) / settings.amplitudeDivisor;
-  const phase = (settings.phaseOffset * Math.PI) / 180;
-  const topMargin = Math.min(width, height) / N.NINE;
-  const bottomMargin = topMargin;
-  const usableHeight = height - topMargin - bottomMargin;
-  const strokeWidth = Math.max(1, Math.min(width, height) / N.NINETYNINE);
-  const strandA = [];
-  const strandB = [];
-
-  for (let index = 0; index < count; index += 1) {
-    const t = count > 1 ? index / (count - 1) : 0;
-    const angle = t * cycles * Math.PI * 2;
-    const y = topMargin + t * usableHeight;
-    const centerX = width / 2;
-    const xA = centerX + Math.sin(angle) * amplitude;
-    const xB = centerX + Math.sin(angle + phase) * amplitude;
-    strandA.push({ x: xA, y });
-    strandB.push({ x: xB, y });
-  }
-
-  ctx.save();
-  ctx.lineWidth = strokeWidth;
-  ctx.globalAlpha = settings.strandAlpha;
-  ctx.strokeStyle = strandColor;
-  drawPolyline(ctx, strandA);
-  drawPolyline(ctx, strandB);
-  ctx.restore();
-
-  const rungCount = settings.crossTieCount;
-  ctx.save();
-  ctx.lineWidth = strokeWidth * 0.85;
-  ctx.globalAlpha = settings.rungAlpha;
-  ctx.strokeStyle = rungColor;
-  for (let rung = 0; rung < rungCount; rung += 1) {
-    const t = rungCount > 1 ? rung / (rungCount - 1) : 0;
-    const index = Math.floor(t * (count - 1));
-    const start = strandA[index];
-    const end = strandB[index];
-    if (!start || !end) {
-      continue;
-    }
-    ctx.beginPath();
-    ctx.moveTo(start.x, start.y);
-    ctx.lineTo(end.x, end.y);
-    ctx.stroke();
-  }
-  ctx.restore();
-}
-
-function drawPolyline(ctx, points) {
-  if (!points || points.length === 0) {
-    return;
-  }
-  ctx.beginPath();
-  points.forEach((point, index) => {
-    if (index === 0) {
-      ctx.moveTo(point.x, point.y);
-    } else {
-      ctx.lineTo(point.x, point.y);
-    }
-  });
-  ctx.stroke();
-}
-
-function drawNotice(ctx, width, height, color, message) {
-  const padding = 12;
-  ctx.save();
-  ctx.globalAlpha = 0.9;
-  ctx.fillStyle = color;
-  ctx.font = "12px system-ui, -apple-system, Segoe UI, sans-serif";
-  ctx.textAlign = "left";
-  ctx.textBaseline = "bottom";
-  ctx.fillText(message, padding, height - padding);
-  ctx.restore();
-
+function drawHelixLattice(ctx, dims, palette, numbers, settings) {
   const samples = Math.max(2, settings.sampleCount);
-  const marginX = width / N.ELEVEN;
-  const startX = marginX;
-  const endX = width - marginX;
-  const amplitude = Math.min(height / settings.amplitudeDivisor, height / 3);
-  const baseline = height / 2;
-  const cycles = Math.max(0, settings.cycles);
-  const totalAngle = cycles * Math.PI * 2;
+  const cycles = settings.cycles;
+  const amplitude = dims.height / settings.amplitudeDivisor;
   const phase = (settings.phaseOffset * Math.PI) / 180;
-  const strandWidth = Math.max(1, Math.min(width, height) / N.NINETYNINE);
+  const centerY = dims.height * 0.7;
+  const marginX = dims.width / numbers.THIRTYTHREE;
+  const spanX = dims.width - marginX * 2;
+  const stepX = samples > 1 ? spanX / (samples - 1) : 0;
+  const angleStep =
+    cycles > 0 ? (Math.PI * 2 * cycles) / Math.max(1, samples - 1) : 0;
 
   const strandA = [];
   const strandB = [];
   for (let index = 0; index < samples; index += 1) {
-    const t = samples === 1 ? 0 : index / (samples - 1);
-    const x = startX + t * (endX - startX);
-    const angle = t * totalAngle;
-    const yA = baseline + amplitude * Math.sin(angle);
-    const yB = baseline + amplitude * Math.sin(angle + phase);
+    const x = marginX + stepX * index;
+    const angle = angleStep * index;
+    const yA = centerY + Math.sin(angle) * amplitude;
+    const yB = centerY + Math.sin(angle + phase) * amplitude;
     strandA.push({ x, y: yA });
     strandB.push({ x, y: yB });
   }
 
   ctx.save();
-  ctx.strokeStyle = colorWithAlpha(strandColor, settings.strandAlpha);
-  ctx.lineWidth = strandWidth;
-  ctx.lineCap = "round";
-  ctx.lineJoin = "round";
-  ctx.beginPath();
-  for (let index = 0; index < strandA.length; index += 1) {
-    const point = strandA[index];
-    if (index === 0) {
-      ctx.moveTo(point.x, point.y);
-    } else {
-      ctx.lineTo(point.x, point.y);
-    }
-  }
-  ctx.stroke();
-  ctx.restore();
+  ctx.lineWidth = Math.max(
+    1.2,
+    Math.min(dims.width, dims.height) / numbers.ONEFORTYFOUR,
+  );
 
-  ctx.save();
-  ctx.strokeStyle = colorWithAlpha(strandColor, settings.strandAlpha);
-  ctx.lineWidth = strandWidth;
-  ctx.lineCap = "round";
-  ctx.lineJoin = "round";
-  ctx.beginPath();
-  for (let index = 0; index < strandB.length; index += 1) {
-    const point = strandB[index];
-    if (index === 0) {
-      ctx.moveTo(point.x, point.y);
-    } else {
-      ctx.lineTo(point.x, point.y);
-    }
-  }
-  ctx.stroke();
-  ctx.restore();
+  ctx.strokeStyle = colorWithAlpha(palette.layers[4], settings.strandAlpha);
+  drawPolyline(ctx, strandA);
+
+  ctx.strokeStyle = colorWithAlpha(palette.layers[5], settings.strandAlpha);
+  drawPolyline(ctx, strandB);
 
   const rungCount = Math.max(1, settings.crossTieCount);
-  ctx.save();
-  ctx.strokeStyle = colorWithAlpha(rungColor, settings.rungAlpha);
-  ctx.lineWidth = Math.max(1, strandWidth * 0.75);
-  ctx.lineCap = "round";
-  for (let rung = 0; rung < rungCount; rung += 1) {
-    const t = rungCount === 1 ? 0 : rung / (rungCount - 1);
-    const indexA = Math.round(t * (strandA.length - 1));
-    const indexB = Math.round(t * (strandB.length - 1));
-    const pointA = strandA[indexA];
-    const pointB = strandB[indexB];
+  const rungStep = Math.max(1, Math.floor(samples / rungCount));
+  ctx.strokeStyle = colorWithAlpha(palette.ink, settings.rungAlpha);
+  ctx.lineWidth = Math.max(
+    1,
+    Math.min(dims.width, dims.height) / numbers.ONEFORTYFOUR,
+  );
+  let drawn = 0;
+  for (let index = 0; index < samples; index += rungStep) {
+    const a = strandA[index];
+    const b = strandB[index];
+    if (!a || !b) {
+      continue;
+    }
     ctx.beginPath();
-    ctx.moveTo(pointA.x, pointA.y);
-    ctx.lineTo(pointB.x, pointB.y);
+    ctx.moveTo(a.x, a.y);
+    ctx.lineTo(b.x, b.y);
     ctx.stroke();
+    drawn += 1;
   }
+
   ctx.restore();
+  return { rungs: drawn };
 }
 
-function drawNotice(ctx, width, height, color, message) {
-  const padding = Math.min(width, height) / DEFAULT_NUM.THIRTYTHREE;
-  ctx.save();
-  ctx.fillStyle = colorWithAlpha(color, 0.85);
-  ctx.font = "12px system-ui, -apple-system, Segoe UI, sans-serif";
-  ctx.textAlign = "left";
-  ctx.textBaseline = "bottom";
-  ctx.fillText(message, padding, height - padding);
-  ctx.restore();
-}
-
-function strokeCircle(ctx, cx, cy, radius) {
+function drawPolyline(ctx, points) {
+  if (points.length === 0) {
+    return;
+  }
   ctx.beginPath();
-  ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+  ctx.moveTo(points[0].x, points[0].y);
+  for (let index = 1; index < points.length; index += 1) {
+    const point = points[index];
+    ctx.lineTo(point.x, point.y);
+  }
   ctx.stroke();
 }
 
-function toNumber(value, fallback) {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : fallback;
-
+function drawCanvasNotice(ctx, dims, color, message) {
+  const padding =
+    Math.min(dims.width, dims.height) / DEFAULT_NUMBERS.THIRTYTHREE;
+  ctx.save();
+  ctx.fillStyle = colorWithAlpha(color, 0.9);
+  ctx.font = `${Math.max(14, dims.width / 72)}px system-ui, -apple-system, Segoe UI, sans-serif`;
+  ctx.textAlign = "center";
+  ctx.textBaseline = "bottom";
+  ctx.fillText(message, dims.width / 2, dims.height - padding);
+  ctx.restore();
 }
 
-function toNumber(value, fallback) {
-  const number = Number(value);
-  return Number.isFinite(number) ? number : Number(fallback);
-}
-
-function positiveNumber(value, fallback) {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
-}
-
-function positiveInteger(value, fallback) {
-
-  const number = Number(value);
-  return Number.isInteger(number) && number > 0 ? number : fallback;
-
-  const parsed = Number(value);
-  const rounded = Math.round(parsed);
-  return Number.isFinite(parsed) && rounded > 0 ? rounded : fallback;
-
-}
-
-function finiteNumber(value, fallback) {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : fallback;
-}
-
-
-function clamp01(value) {
-  const number = Number(value);
-  if (!Number.isFinite(number)) {
-    return 0;
-  }
-  if (number < 0) {
-    return 0;
-  }
-  if (number > 1) {
-    return 1;
-  }
-  return number;
-}
-
-function clampAlpha(value, fallback) {
-  const number = Number(value);
-  if (!Number.isFinite(number)) {
-    return fallback;
-  }
-  if (number < 0) {
-    return 0;
-  }
-  if (number > 1) {
-    return 1;
-  }
-  return number;
-
-function clampAlpha(value, fallback) {
-  const parsed = Number(value);
-  if (Number.isFinite(parsed)) {
-    return Math.min(1, Math.max(0, parsed));
-  }
-  return fallback;
-}
-
-function clamp01(value) {
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed)) {
-    return 0;
-  }
-  if (parsed < 0) {
-    return 0;
-  }
-  if (parsed > 1) {
-    return 1;
-  }
-  return parsed;
+function summariseLayers(stats) {
+  const vesica = `${stats.vesicaStats.circles} vesica circles`;
+  const tree = `${stats.treeStats.paths} paths / ${stats.treeStats.nodes} nodes`;
+  const fibonacci = `${stats.fibonacciStats.points} spiral points`;
+  const helix = `${stats.helixStats.rungs} helix rungs`;
+  return `Layers rendered - ${vesica}; ${tree}; ${fibonacci}; ${helix}.`;
 }
 
 function colorWithAlpha(hex, alpha) {
   const normalized = typeof hex === "string" ? hex.trim() : "";
   const value = normalized.startsWith("#") ? normalized.slice(1) : normalized;
+  const safeAlpha = clamp01(alpha);
   if (value.length !== 6) {
-    const safeAlpha = clamp01(alpha);
     return `rgba(255,255,255,${safeAlpha})`;
   }
   const r = parseInt(value.slice(0, 2), 16);
   const g = parseInt(value.slice(2, 4), 16);
   const b = parseInt(value.slice(4, 6), 16);
-  const safeAlpha = clamp01(alpha);
   return `rgba(${r},${g},${b},${safeAlpha})`;
+}
 
+function toPositiveNumber(value, fallback) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : Number(fallback);
+}
+
+function toPositiveInteger(value, fallback) {
+  const number = Number(value);
+  const rounded = Math.round(number);
+  return Number.isFinite(number) && rounded > 0 ? rounded : Number(fallback);
+}
+
+function clamp01(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    return 0;
+  }
+  if (number < 0) {
+    return 0;
+  }
+  if (number > 1) {
+    return 1;
+  }
+  return number;
+}
+
+function clampAlpha(value, fallback) {
+  if (value === 0) {
+    return 0;
+  }
+  const number = Number(value);
+  if (Number.isFinite(number)) {
+    return clamp01(number);
+  }
+  return fallback;
 }


### PR DESCRIPTION
## Summary
- rebuild `cosmic-helix/index.html` to apply sealed palette fallbacks, optional geometry loading, and clearer ND-safe status messaging
- replace `cosmic-helix/js/helix-renderer.mjs` with a validated set of small pure helpers that honour the numerology constants and draw the canvas notice when fallbacks are active
- refresh `cosmic-helix/README_RENDERER.md` to document the offline workflow, layer order, and customisation entry points

## Testing
- ./scripts/run-check.sh *(fails: existing repository files violate Prettier formatting; unrelated to this change)*
- npx prettier -c cosmic-helix/index.html cosmic-helix/js/helix-renderer.mjs cosmic-helix/README_RENDERER.md

------
https://chatgpt.com/codex/tasks/task_e_68cc7b6273bc8328bae24d0182551e81