### PR TITLE
Document offline JSON module preference and enhance loader

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -10,7 +10,7 @@ Static, offline-first canvas capsule that renders four calm layers: the vesica l
 ## Usage
 1. Download or clone the repository.
 2. Double-click `index.html`. No build step or server is required.
-3. If `data/palette.json` is blocked by `file://` rules, the fallback palette activates automatically and a notice appears on the canvas footer.
+3. When opened via `file://`, the loader first attempts a JSON module import of `data/palette.json`. If the browser declines JSON modules, it falls back to a fetch attempt and ultimately the sealed palette with a notice when none are available.
 
 ## Layer order (back to front)
 1. **Vesica field** - seven by three grid of intersecting circles, softened alpha to avoid glare.
@@ -30,4 +30,4 @@ All routines stay parameterised by `{3, 7, 9, 11, 22, 33, 99, 144}` to honour th
 - Adjust colours by editing `data/palette.json`. Provide `bg`, `ink`, and a six colour `layers` array.
 - Override numerology constants in `index.html` before calling `renderHelix` if alternate ratios are desired.
 - Compose new layers by duplicating the helper pattern in `js/helix-renderer.mjs`. Keep additions static and well-commented to preserve ND safety.
-- The loader prefers JSON module imports when opened via `file://` to avoid network access. Browsers without JSON module support fall back to the bundled palette safely.
+- On `file://` origins the loader prefers JSON module imports to keep everything offline-first. If JSON modules are unavailable the fetch path takes over, and if that also fails the bundled palette and notice keep rendering safe.

--- a/index.html
+++ b/index.html
@@ -18,8 +18,8 @@
 </head>
 <body>
   <header>
-    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Loading palette…</div>
+    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette...</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
@@ -32,25 +32,6 @@
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
 
-    async function loadJSON(path) {
-      try {
-        if (window.location && window.location.protocol === "file:") {
-          try {
-            // Offline-first: JSON module import avoids blocked fetch calls under file:// origins.
-            const module = await import(path, { assert: { type: "json" } });
-            return module.default;
-          } catch (importError) {
-            // Silent fallback: some browsers reject JSON assertions, so we retry with fetch below.
-          }
-        }
-        const res = await fetch(path, { cache: "no-store" });
-        if (!res.ok) throw new Error(String(res.status));
-        return await res.json();
-      } catch (err) {
-        return null;
-      }
-    }
-
     const defaults = {
       palette: {
         bg:"#0b0b12",
@@ -59,25 +40,62 @@
       }
     };
 
-    const palette = await loadJSON("./data/palette.json");
-    const usingFallback = !palette;
-    const active = palette || defaults.palette;
-    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+    async function importJSONModule(path) {
+      const module = await import(path, { assert: { type: "json" } });
+      if (module && module.default) {
+        return module.default;
+      }
+      throw new Error("JSON module missing default export");
+    }
+
+    async function fetchJSON(path) {
+      try {
+        const res = await fetch(path, { cache: "no-store" });
+        if (!res.ok) throw new Error(String(res.status));
+        return await res.json();
+      } catch (err) {
+        return null;
+      }
+    }
+
+    async function resolvePalette() {
+      const isFileOrigin = typeof window !== "undefined" && window.location && window.location.protocol === "file:";
+
+      if (isFileOrigin) {
+        try {
+          const modulePalette = await importJSONModule("./data/palette.json");
+          elStatus.textContent = "Palette loaded via JSON module.";
+          return { palette: modulePalette, notice: null };
+        } catch (moduleError) {
+          // Fallback to fetch below; some browsers decline JSON module assertions.
+        }
+      }
+
+      const fetchedPalette = await fetchJSON("./data/palette.json");
+      if (fetchedPalette) {
+        elStatus.textContent = "Palette loaded.";
+        return { palette: fetchedPalette, notice: null };
+      }
+
+      elStatus.textContent = "Palette missing; using safe fallback.";
+      return { palette: defaults.palette, notice: "Palette fallback active" };
+    }
+
+    const { palette: activePalette, notice } = await resolvePalette();
 
     // Numerology constants used by geometry routines
     const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
 
     // ND-safe rationale: no motion, high readability, soft colors, layered order
-    renderHelix(
-      ctx,
-      {
-        width: canvas.width,
-        height: canvas.height,
-        palette: active,
-        NUM,
-        notice: usingFallback ? "Palette fallback active" : null
-      }
-    );
+    const renderConfig = {
+      width: canvas.width,
+      height: canvas.height,
+      palette: activePalette,
+      NUM,
+      notice
+    };
+
+    renderHelix(ctx, renderConfig);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- document the file:// loader sequence and safe palette fallback in README_RENDERER
- prefer JSON module imports for palettes on file origins, falling back to fetch and the sealed palette with notice
- normalize UI copy to ASCII punctuation and pass renderHelix explicit configuration

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cc8fcd911c8328945628d1da9922fb