### PR TITLE
Create static ND-safe helix renderer shell

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,70 +1,45 @@
 # Cosmic Helix Renderer
 
-Static, offline-first canvas capsule tuned to the luminous cathedral reference (vesica vault, Tree-of-Life column, Fibonacci halo, and double-helix lattice). Everything remains ND-safe: no motion, soft gradients, and detailed commentary on why the geometry is layered.
+Static, offline-first canvas capsule tuned to the luminous cathedral canon. The renderer paints four still layers (vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice) using numerology anchors {3, 7, 9, 11, 22, 33, 99, 144}. Comments in the module explain why each choice keeps ND safety intact (no motion, soft contrast, layered depth).
 
 ## Files
-
-- `index.html` - offline entry point that loads the optional palette, seeds numerology constants, and invokes the renderer while reporting layer stats in the header.
-- `js/helix-renderer.mjs` - pure ES module of drawing helpers. Each function documents how the ND-safe order preserves depth.
-
-- `index.html` - offline entry point that loads the optional palette, syncs the resolved colours with the shell chrome, seeds numerology constants, gathers the render summary, and stays calm if a 2D context is denied.
-- `js/helix-renderer.mjs` - pure ES module of drawing helpers. Each function documents why the ND-safe order matters and references the covenant numbers.
-
-- `data/palette.json` - optional colour override. If missing the renderer applies its sealed fallback, posts a status message, and paints a canvas notice.
+- `index.html` — offline entry point. Loads the optional palette JSON, applies chrome colours, seeds the numerology constants, and reports render status without animation.
+- `js/helix-renderer.mjs` — pure ES module of drawing helpers. Each function is small, well-commented, and preserves the layered order.
+- `data/palette.json` — optional override palette. If absent or blocked the renderer falls back to sealed colours and displays a calm notice.
+- `README_RENDERER.md` — this guide.
 
 ## Usage
 1. Download or clone the repository.
-2. Double-click `index.html`. No build step or server is required.
-
-3. If `data/palette.json` is blocked by `file://` rules, the fallback palette activates automatically, the header notes the fallback, and a calm notice appears near the canvas base.
-
-## Layer order (back to front)
-1. **Vesica field** - seven-by-three grid of intersecting circles with mandorla halos and a dashed axis to echo the reference vault.
-2. **Tree-of-Life scaffold** - ten sephirot nodes, twenty-two numerological paths, vaulted arches, and a luminous central column.
-3. **Fibonacci curve** - static logarithmic halo sampled from Fibonacci numbers up to 144, rendered with smooth quadratics and marker pearls.
-4. **Double-helix lattice** - two phase-shifted strands with alternating rungs, pedestals, and anchor diamonds. Everything is static.
-
-
-3. When opened via `file://`, the loader first attempts a JSON module import of `data/palette.json`. If the browser declines JSON modules, it falls back to a fetch attempt and ultimately the sealed palette with a notice when none are available.
-
-
-3. When opened via `file://`, the loader first attempts a JSON module import of `data/palette.json`. If the browser declines JSON modules, it falls back to a fetch attempt and ultimately the sealed palette with a notice when none are available.
-
-3. If `data/palette.json` is blocked by `file://` rules, the fallback palette activates automatically, the page chrome updates to the safe defaults, and a notice appears on the canvas footer.
-4. The status line reiterates whether the fallback is active, reports the render summary, and confirms when geometry is skipped because the browser withholds a 2D context.
-
-
+2. Double-click `index.html`. No build step or server is required; the module runs offline.
+3. If the palette JSON is blocked (common on hardened `file://` contexts) the fallback palette activates automatically, the header notes the change, and the canvas prints "Palette fallback active" near the base for reassurance.
 
 ## Layer order (back to front)
-1. **Vesica field** - seven by three grid of intersecting circles, softened alpha to avoid glare.
-2. **Tree-of-Life scaffold** - ten sephirot nodes tied by twenty-two calm paths. Horizontal pillar spacing and vertical placement both use combinations of {3, 7, 9, 11, 22, 33, 99, 144} so the descent honours the numerology covenant.
-3. **Fibonacci curve** - static logarithmic spiral sampled from Fibonacci numbers up to 144.
-4. **Double-helix lattice** - two phase-shifted strands with alternating rungs; entirely static.
+1. **Vesica field** — seven by three grid of intersecting vesica pairs with a mandorla halo and central axis. Soft alpha keeps the base calm while preserving depth.
+2. **Tree-of-Life scaffold** — sephirot nodes, 22 paths, vaulted arch, and central column. Positions rely on the covenant ladder so each descent honours {33, 99, 144} spans.
+3. **Fibonacci curve** — static logarithmic spiral built from Fibonacci numbers up to 144, rendered once with rounded joints and pearl markers.
+4. **Double-helix lattice** — two phase-shifted rails with alternating rungs, base walkway, and diamond anchors. Everything is static; no animation or flashing.
 
-
-All routines stay parameterised by `{3, 7, 9, 11, 22, 33, 99, 144}` to honour the cosmology canon while keeping the numerology adjustable.
-
-### Numerology grounding cheatsheet
-- **Tree columns** shift by 33 of the 144 horizontal units so each pillar leans on the covenant pair (33, 144).
-- **Supernal triad** rests on 33 divided by 3, placing Chokmah and Binah 11 steps below Kether.
-- **Hidden gate** (Daath) descends by 22 + 7 units, bridging the upper triad with the ethical triad.
-- **Middle triad** aligns to 33 + 9 (Chesed/Geburah) and 33 + 22 (Tiphareth) to keep balance between mercy, strength, and heart.
-- **Lower triad** drops to 99 - 3 for Netzach/Hod and 144 - 3 for Yesod, keeping the emotional/intellectual pair and the foundation within the harmonic ladder.
-- **Malkuth** completes the run at 144, mirroring the full descent mapped across the canvas height.
+## Numerology grounding
+- Vertical placement maps the 144-step ladder so Malkuth rests at 144 units and pillar offsets use 33-unit shifts.
+- Supernal descent seats Chokmah/Binah 11 units below Kether (33 ÷ 3), Daath bridges the triads at 22 + 7, and the middle triad steps through 33 + 9 and 33 + 22.
+- Lower triad uses 99 − 3 for Netzach/Hod, 144 − 3 for Yesod, and closes at 144 for Malkuth.
+- Fibonacci sampling stops at 144 while helix rails step through 22 stations with a phase offset governed by 3 and 11.
 
 ## Accessibility & ND-safe rationale
-- No animation, autoplay, or async loops. Rendering happens once per load.
+- No animation, autoplay, or async redraw loops; rendering happens once per load.
+- Calm palette defaults with clear status messaging when fallbacks are active (header text plus optional canvas notice).
+- Layered drawing order preserves depth without flattening geometry into a single outline.
+- Pure functions, ASCII quotes, UTF-8, and LF newlines keep the module portable for offline review.
 
-- Calm palette defaults with clear status messaging when fallbacks are in play.
-- Layered drawing order maintains geometric depth without flattening into a single outline, matching the reference architecture without motion.
+## Palette override
+Update `data/palette.json` with your preferred colours:
 
-- Calm palette defaults with clear status messaging when fallbacks are in play, including an inline canvas caption for assurance.
-- Layered drawing order maintains geometric depth without flattening into a single outline.
+```json
+{
+  "bg": "#101018",
+  "ink": "#f0e6d2",
+  "layers": ["#6ca0ff", "#6cd7d8", "#9ce69a", "#ffd28c", "#f8a3ff", "#d7d7f0"]
+}
+```
 
-- ASCII quotes, UTF-8, LF newlines, and small pure functions keep the module portable offline.
-
-## Customisation
-- Adjust colours by editing `data/palette.json`. Provide `bg`, `ink`, and a six colour `layers` array.
-- Override numerology constants in `index.html` before calling `renderHelix` if alternate ratios are desired.
-- Compose new layers by duplicating the helper pattern in `js/helix-renderer.mjs`. Keep additions static and well-commented to preserve ND safety.
-- On `file://` origins the loader prefers JSON module imports to keep everything offline-first. If JSON modules are unavailable the fetch path takes over, and if that also fails the bundled palette and notice keep rendering safe.
+Missing or malformed palettes never stop rendering; the fallback palette maintains ND safety and emits a calm notice.

--- a/index.html
+++ b/index.html
@@ -6,290 +6,132 @@
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
   <meta name="color-scheme" content="light dark">
   <style>
-    /* ND-safe: calm contrast, no motion, layered background glow for depth */
+    /* ND-safe shell: calm contrast, no motion, maintain spacious margins */
     :root {
-      --bg:#0a0c16;
-      --ink:#f4e3c6;
-      --muted:#b49f82;
-      --edge:#1c2338;
+      --bg:#0b0b12;
+      --ink:#e8e8f0;
+      --muted:#a6a6c1;
+      --edge:#1e2030;
     }
-    html,body {
+    html, body {
       margin:0;
       padding:0;
-      background:radial-gradient(circle at 50% 18%, #1b2742 0%, var(--bg) 58%);
+      background:var(--bg);
       color:var(--ink);
-      font:14px/1.5 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+      font:14px/1.5 system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
     }
     header {
       padding:12px 16px 10px 16px;
       border-bottom:1px solid var(--edge);
-      background:linear-gradient(180deg, rgba(27,39,66,0.8), rgba(10,12,22,0.95));
     }
     .status {
+      margin-top:2px;
       color:var(--muted);
       font-size:12px;
-      margin-top:2px;
     }
     #stage {
       display:block;
       margin:18px auto 12px auto;
-      box-shadow:0 0 0 1px var(--edge), 0 12px 44px rgba(7,9,18,0.55);
+      width:1440px;
+      height:900px;
+      box-shadow:0 0 0 1px var(--edge),0 18px 48px rgba(0,0,0,0.45);
       background-color:transparent;
     }
     .note {
       max-width:920px;
-      margin:0 auto 18px;
+      margin:0 auto 24px auto;
+      padding:0 16px;
       color:var(--muted);
-      padding:0 16px 18px 16px;
     }
-    code {
-      background:#13182a;
-      padding:2px 4px;
-      border-radius:3px;
+    @media (max-width:1500px) {
+      #stage {
+        width:100%;
+        height:auto;
+        max-width:1440px;
+        aspect-ratio:1440/900;
+      }
     }
   </style>
 </head>
 <body>
   <header>
-
-    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
-
-
-    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
-
     <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
-
-
-    <div class="status" id="status">Loading palette...</div>
+    <div class="status" id="status">Loading palette…</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-
-  <div id="chapel-ring" style="position:relative;width:min(80vmin,820px);aspect-ratio:1;margin:40px auto"></div>
-  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
-  <script type="module" src="./codex/inject.loader.js"></script>
-
-  <p class="note">Static, offline canvas tuned to the cathedral style reference: vesica grid foundation, Tree-of-Life vault, Fibonacci halo, and double-helix lattice. Palette loads locally with a safe fallback notice for ND assurance.</p>
-
+  <p class="note">This static renderer paints four calm layers — vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice. Open directly; no network or build steps are required.</p>
 
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
 
-    const elStatus = document.getElementById("status");
+    const statusEl = document.getElementById("status");
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
 
-    const defaults = {
+    const DEFAULTS = {
       palette: {
-
         bg:"#0b0b12",
         ink:"#e8e8f0",
         layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
       }
     };
 
-    async function importJSONModule(path) {
-
-      // Try modern import attributes first, then legacy import assertions.
-      try {
-        // Modern
-        const m = await import(path, { with: { type: "json" } });
-        return m?.default ?? m;
-      } catch (e1) {
-        try {
-          // Legacy
-          const m = await import(path, { assert: { type: "json" } });
-          return m?.default ?? m;
-        } catch (e2) {
-          const err = new Error("JSON module import failed");
-          err.cause = e2;
-          throw err;
-
-      try {
-        const m = await import(path, { with: { type: "json" } });
-        if (m && m.default) return m.default;
-        throw new Error("JSON module missing default export");
-      } catch (e1) {
-        // Fallback for older Chromium builds that used `assert`
-        try {
-          const mOld = await import(path, { assert: { type: "json" } });
-          if (mOld && mOld.default) return mOld.default;
-          throw new Error("JSON module (assert) missing default export");
-        } catch (e2) {
-          throw e2;
-
-        }
-      }
-    }
-    async function fetchJSON(path) {
-      try {
-        const res = await fetch(path, { cache: "no-store" });
-        if (!res.ok) throw new Error(String(res.status));
-        return await res.json();
-      } catch (err) {
-        return null;
-      }
-    }
-
-
-    const defaults = {
-      palette: {
-        bg:"#0a0c16",
-        ink:"#f4e3c6",
-        layers:["#1f3f63","#265f7f","#c4974b","#f6d58b","#c987d6","#2c3b5d"]
-
-    async function resolvePalette() {
-      const isFileOrigin = typeof window !== "undefined" && window.location && window.location.protocol === "file:";
-
-      if (isFileOrigin) {
-        try {
-          const modulePalette = await importJSONModule("./data/palette.json");
-          elStatus.textContent = "Palette loaded via JSON module.";
-          return { palette: modulePalette, notice: null };
-        } catch (moduleError) {
-          // Fallback to fetch below; some browsers decline JSON module assertions.
-
-      }
-
-      const fetchedPalette = await fetchJSON("./data/palette.json");
-      if (fetchedPalette) {
-        elStatus.textContent = "Palette loaded.";
-        return { palette: fetchedPalette, notice: null };
-      }
-
-      elStatus.textContent = "Palette missing; using safe fallback.";
-      return { palette: defaults.palette, notice: "Palette fallback active" };
-    }
-
-    const { palette: activePalette, notice } = await resolvePalette();
-
-
-        bg: "#0b0b12",
-        ink: "#e8e8f0",
-        layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-
-      }
-
-      const fetchedPalette = await fetchJSON("./data/palette.json");
-      if (fetchedPalette) {
-        elStatus.textContent = "Palette loaded.";
-        return { palette: fetchedPalette, notice: null };
-
-      }
-
-      elStatus.textContent = "Palette missing; using safe fallback.";
-      return { palette: defaults.palette, notice: "Palette fallback active" };
-    }
-
-    const { palette: activePalette, notice } = await resolvePalette();
-
     const NUM = {
-      THREE: 3,
-      SEVEN: 7,
-      NINE: 9,
-      ELEVEN: 11,
-      TWENTYTWO: 22,
-      THIRTYTHREE: 33,
-      NINETYNINE: 99,
-      ONEFORTYFOUR: 144
+      THREE:3,
+      SEVEN:7,
+      NINE:9,
+      ELEVEN:11,
+      TWENTYTWO:22,
+      THIRTYTHREE:33,
+      NINETYNINE:99,
+      ONEFORTYFOUR:144
     };
-
-
-    const palette = await loadJSON("./data/palette.json");
-    const usingFallback = !palette;
-    const active = palette || defaults.palette;
-    const baseStatus = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
 
     initialise();
 
-    const statusParts = [usingFallback ? "Palette missing; using safe fallback." : "Palette loaded."];
-
-    if (!ctx) {
-      statusParts.push("Canvas 2D context unavailable; geometry skipped.");
-    } else {
-      // Numerology constants used by geometry routines
-      const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
-
-      // ND-safe rationale: no motion, high readability, soft colors, layered order
-      const outcome = renderHelix(ctx, {
-
     async function initialise() {
-      const palette = await loadPalette("./data/palette.json");
-      const active = palette || defaults.palette;
+      const paletteData = await loadPalette("./data/palette.json");
+      const usingFallback = !paletteData;
+      const palette = paletteData || DEFAULTS.palette;
 
-
-      applyChromePalette(active);
-
-      const usingFallback = !palette;
-      elStatus.textContent = usingFallback
-        ? "Palette missing; using safe fallback."
-        : "Palette loaded.";
+      applyChromePalette(palette);
 
       if (!ctx) {
-        elStatus.textContent += " Canvas 2D context unavailable.";
+        updateStatus(composeStatus(usingFallback, "Canvas 2D context unavailable; geometry skipped."));
         return;
       }
 
-      // ND-safe: renderer executes once with static geometry and optional notice when fallbacks are active.
-      renderHelix(ctx, {
-
-
-    // ND-safe rationale: no motion, high readability, soft glow, preserved layer order
-    const result = renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM, notice: usingFallback ? "Palette fallback active" : null });
-    elStatus.textContent = result && result.summary ? `${baseStatus} ${result.summary}` : baseStatus;
-
-    // ND-safe rationale: no motion, high readability, soft colors, layered order
-    const renderConfig = {
-      width: canvas.width,
-      height: canvas.height,
-      palette: activePalette,
-      NUM,
-      notice
-    };
-
-    renderHelix(ctx, renderConfig);
-
-        width: canvas.width,
-        height: canvas.height,
-        palette: active,
+      // Single-pass render keeps the scene static: no loops, no animation, ND-safe.
+      const outcome = renderHelix(ctx, {
+        width:canvas.width,
+        height:canvas.height,
+        palette,
         NUM,
         notice: usingFallback ? "Palette fallback active" : null
       });
 
-
-      if (outcome && typeof outcome.summary === "string") {
-        statusParts.push(outcome.summary);
-      } else {
-        statusParts.push("Geometry rendered once.");
-      }
-    }
-
-    elStatus.textContent = statusParts.join(" ");
-
+      const summary = outcome && typeof outcome.summary === "string"
+        ? outcome.summary
+        : "Geometry rendered once.";
+      updateStatus(composeStatus(usingFallback, summary));
     }
 
     async function loadPalette(path) {
-      if (typeof path !== "string") return null;
-
-      // Offline-first: when opened via file:// we avoid fetch (blocked in many browsers) and rely on JSON module support.
-      if (window.location && window.location.protocol === "file:") {
-        try {
-          const module = await import(path, { assert: { type: "json" } });
-          return module.default;
-        } catch (err) {
+      if (typeof path !== "string") {
+        return null;
+      }
+      try {
+        const response = await fetch(path, { cache:"no-store" });
+        if (!response || !response.ok) {
           return null;
         }
-      }
-
-      try {
-        const res = await fetch(path, { cache: "no-store" });
-        if (!res.ok) return null;
-        return await res.json();
-      } catch (err) {
+        return await response.json();
+      } catch (error) {
+        // Offline-first: browsers often block fetch for file:// origins; fallback keeps ND safety intact.
         return null;
       }
     }
-
 
     function applyChromePalette(palette) {
       document.documentElement.style.setProperty("--bg", palette.bg);
@@ -297,57 +139,20 @@
       const muted = Array.isArray(palette.layers) && palette.layers.length > 0
         ? palette.layers[palette.layers.length - 1]
         : palette.ink;
+      // Muted tone mirrors the outer lattice layer so notes remain legible on both schemes.
       document.documentElement.style.setProperty("--muted", muted);
     }
 
-
-
-  </script>
-  <style>
-  :root{ --lattice:#89a3ff; --halo:#d6b370; }
-  .bg-lattice{position:fixed; inset:0; z-index:-1; display:grid; place-items:center; pointer-events:none}
-  .lattice{
-    width:min(78vmin,880px); aspect-ratio:1; border-radius:50%; position:relative; isolation:isolate;
-    /* wireframe: meridians + parallels */
-    background:
-     repeating-conic-gradient(from 0deg, transparent 0 10deg, rgba(255,255,255,.08) 10deg 11deg),
-     repeating-radial-gradient(circle at 50% 50%, rgba(255,255,255,.08) 0 2px, transparent 2px 38px);
-    /* crisp ring */
-    box-shadow:
-      0 0 0 1px rgba(255,255,255,.10) inset,
-      0 0 120px color-mix(in oklab, var(--lattice) 40%, transparent);
-    backdrop-filter: blur(0.5px);
-  }
-  .lattice::after{ /* Jovian middle ring */
-    content:""; position:absolute; inset:14%; border-radius:50%;
-    border:1px solid color-mix(in oklab, var(--halo) 75%, transparent);
-    box-shadow: 0 0 42px color-mix(in oklab, var(--halo) 30%, transparent) inset;
-    transform: perspective(700px) rotateX(62deg);
-  }
-  </style>
-  <div class="bg-lattice" aria-hidden="true"><div class="lattice"></div></div>
-  <canvas id="nodes" width="1024" height="1024" style="position:fixed;inset:0;z-index:-1;pointer-events:none;"></canvas>
-  <script>
-  (() => {
-    const c = document.getElementById('nodes'); const d = c.getContext('2d'); const S = Math.min(innerWidth, innerHeight)*0.78;
-    c.width = c.height = S * devicePixelRatio; c.style.width = c.style.height = S+'px';
-    c.style.left = ((innerWidth - S)/2)+'px'; c.style.top = ((innerHeight - S)/2)+'px';
-    const N=72, R = (S*devicePixelRatio)/2 * 0.94, cx = c.width/2, cy = c.height/2;
-    d.clearRect(0,0,c.width,c.height);
-    for(let i=0;i<N;i++){
-      const a = (i/N)*Math.PI*2;
-      const x = cx + Math.cos(a)*R, y = cy + Math.sin(a*1.618)*R*0.65;
-      const g = d.createRadialGradient(x,y,0,x,y,10*devicePixelRatio);
-      g.addColorStop(0,'#ffffff'); g.addColorStop(1,'rgba(137,163,255,.05)');
-      d.fillStyle = g; d.beginPath(); d.arc(x,y,4*devicePixelRatio,0,Math.PI*2); d.fill();
+    function composeStatus(usingFallback, tail) {
+      const base = usingFallback
+        ? "Palette missing; using safe fallback."
+        : "Palette loaded.";
+      return `${base} ${tail}`;
     }
-  })();
-  </script>
-  <script>
-  window.addEventListener('cathedral:select', e => {
-    const tint = e.detail?.payload?.color || '#89a3ff';
-    document.documentElement.style.setProperty('--lattice', tint);
-  });
+
+    function updateStatus(message) {
+      statusEl.textContent = message;
+    }
   </script>
 </body>
 </html>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -13,9 +13,9 @@
 */
 
 const DEFAULT_PALETTE = {
-  bg: "#0a0c16",
-  ink: "#f4e3c6",
-  layers: ["#1f3f63", "#265f7f", "#c4974b", "#f6d58b", "#c987d6", "#2c3b5d"]
+  bg: "#0b0b12",
+  ink: "#e8e8f0",
+  layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
 };
 
 const DEFAULT_NUMBERS = {
@@ -30,29 +30,17 @@ const DEFAULT_NUMBERS = {
 };
 
 /**
-
  * Render a static, four-layer sacred-geometry helix composition onto a 2D canvas.
  *
- * Draws a Vesica field, Tree of Life scaffold, Fibonacci spiral, and double-helix lattice
- * in sequence using a normalized configuration derived from `input`. Saves and restores
- * the canvas state around the operation and may render an optional bottom notice.
+ * Draws, in sequence, a vesica field, a Tree of Life scaffold, a Fibonacci spiral, and a
+ * double-helix lattice. The renderer saves/restores the canvas state, applies an optional
+ * inline notice when fallbacks are active, and summarises the geometry counts for the
+ * caller.
  *
- * @param {CanvasRenderingContext2D} ctx - A 2D canvas rendering context to draw into.
- * @param {Object} [input] - Optional rendering configuration (palette, numbers, dims, notice).
- *   Only keys with non-default meanings need to be provided; missing values are filled by the renderer.
- * @returns {{summary: string}} An object containing a human-readable summary of the rendered layer counts.
- * @throws {Error} If `ctx` is not a valid 2D canvas context.
+ * @param {CanvasRenderingContext2D} ctx - Canvas 2D context to draw into.
+ * @param {Object} [input={}] - Optional configuration overrides (palette, NUM values, dims, notice).
+ * @returns {{summary: string}} A calm human-readable description of the rendered layers.
  */
-
- * Render a static four-layer helix composition onto a canvas.
- *
- * Draws, in sequence, a vesica field, a Tree of Life scaffold, a Fibonacci spiral, and a double-helix lattice,
- * then optionally renders an inline notice. If the provided canvas context is invalid or lacks `save()`,
- * the function returns immediately with a quiet summary object instead of throwing.
- *
- * @param {Object} [input={}] - Optional overrides for rendering (palette, numeric constants, notice text, explicit dimensions).
- * @return {{summary: string}} An object with a human-readable summary of which layers were rendered and basic counts.
-
 export function renderHelix(ctx, input = {}) {
   if (!ctx || typeof ctx.canvas === "undefined" || typeof ctx.save !== "function") {
     // Calm skip keeps the offline shell quiet when contexts are denied (rare on hardened browsers).
@@ -370,52 +358,20 @@ function drawTreeOfLife(ctx, dims, palette, numbers) {
 }
 
 /**
-
- * Compute 2D canvas coordinates for the 11 sephirot (Tree of Life nodes).
+ * Compute canvas coordinates for each Tree-of-Life sephirah using the covenant ladder.
  *
- * Uses canvas dimensions and numeric constants to place nodes in a vertical scaffold
- * with horizontal offsets for left/right columns and calibrated vertical spacing.
+ * Projects a 144-step vertical scale with 33-step pillar offsets so the geometry stays
+ * anchored to {3, 7, 9, 11, 22, 33, 99, 144}. Returns an object keyed by sephirah name.
  *
- * @param {{width:number,height:number}} dims - Canvas dimensions; must include width and height.
- * @param {{THREE:number, ELEVEN:number, THIRTYTHREE:number}} numbers - Numeric constants used for layout spacing.
- * @return {{kether:{x:number,y:number}, chokmah:{x:number,y:number}, binah:{x:number,y:number}, daath:{x:number,y:number}, chesed:{x:number,y:number}, geburah:{x:number,y:number}, tiphareth:{x:number,y:number}, netzach:{x:number,y:number}, hod:{x:number,y:number}, yesod:{x:number,y:number}, malkuth:{x:number,y:number}}}
-
-
- * Compute coordinates for the 12 Tree of Life sephirot laid out on a dual-pillar 144-step grid.
- *
- * The layout maps a 144-step vertical "covenant ladder" onto the available canvas dimensions,
- * placing nodes on a centered spine or on left/right pillars offset by a 33-step horizontal shift.
- * Y coordinates increase downward (canvas coordinate space).
- *
- * @param {{width: number, height: number}} dims - Drawing area dimensions; used to derive margins and scale.
- * @param {Object} numbers - Numeric constants (expects numeric properties such as ONEFORTYFOUR, THIRTYTHREE, TWENTYTWO, SEVEN, NINE, THREE, NINETYNINE). These drive the 144-step vertical scaling and pillar offsets.
- * @return {Object.<string,{x:number,y:number}>} An object mapping sephirot keys (kether, chokmah, binah, daath, chesed, geburah, tiphareth, netzach, hod, yesod, malkuth) to their {x,y} canvas coordinates.
-
- * Compute canvas coordinates for the 11 Tree of Life sephirot.
- *
- * Uses the canvas dimensions and numerology constants to produce a vertically distributed,
- * numerology-anchored layout for the sephirot (kether, chokmah, binah, daath, chesed,
- * geburah, tiphareth, netzach, hod, yesod, malkuth). Positions are in canvas pixels.
- *
- * The vertical placement is computed from a top/bottom margin and an inner height divided
- * into eleven steps; several level multipliers are derived from the provided numeric
- * constants so the geometry remains consistent with the module's numerology rules.
- *
- * @param {{width:number, height:number}} dims - Canvas dimensions in pixels.
- * @param {Object<string, number>} numbers - Numerology constants (expects keys like THREE, SEVEN, ELEVEN, TWENTYTWO, THIRTYTHREE, NINE, ONEFORTYFOUR). These values are used to compute vertical levels and column spacing.
- * @return {Object<string, {x:number,y:number}>} Mapping of sephirot names to their {x,y} canvas coordinates.
-
-
+ * @param {{width:number,height:number}} dims - Canvas dimensions in pixels.
+ * @param {Object<string,number>} numbers - Numerology constants controlling spacing.
+ * @return {Object<string,{x:number,y:number}>} Pixel coordinates for each sephirah.
  */
 function buildTreeNodes(dims, numbers) {
   const marginY = dims.height / numbers.THIRTYTHREE;
   const innerHeight = dims.height - marginY * 2;
   const verticalUnit = innerHeight / numbers.ONEFORTYFOUR; // 144-step descent honours the covenant ladder.
   const centerX = dims.width / 2;
-
-  const column = dims.width / numbers.THREE;
-  const stepY = (dims.height - marginY * 2) / numbers.ELEVEN;
-
 
   const horizontalUnit = dims.width / numbers.ONEFORTYFOUR;
   const pillarShift = horizontalUnit * numbers.THIRTYTHREE; // 33-step shift keeps the side pillars tethered to 144.


### PR DESCRIPTION
## Summary
- rebuild the offline index shell so it loads palettes safely, applies numerology constants, and invokes the renderer once with calm status messaging
- align the helix renderer module with the sealed palette, clarify numerology-driven helpers, and ensure each layer draws with ND-safe comments
- refresh the renderer README to describe usage, layer ordering, numerology grounding, and palette override guidance

## Testing
- node --check js/helix-renderer.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cd05e5da908328af6ce814b7f606ca