### PR TITLE
Refine offline helix renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,51 +1,31 @@
 # Cosmic Helix Renderer
 
-Static, offline-first canvas capsule tuned to the luminous cathedral canon. The renderer paints four still layers (vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice) using numerology anchors {3, 7, 9, 11, 22, 33, 99, 144}. Comments in the module explain why each choice keeps ND safety intact (no motion, soft contrast, layered depth).
+Static, offline-first canvas capsule tuned to the luminous cathedral canon. The renderer paints four still layers (vesica field,
+Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice) using the numerology anchors {3, 7, 9, 11, 22, 33, 99,
+144}. Comments in the module explain how each choice keeps ND safety intact (no motion, soft contrast, layered depth).
 
 ## Files
-
-- `index.html` - offline entry point that loads the optional palette, seeds numerology constants, and invokes the renderer while reporting layer stats in the header.
-- `js/helix-renderer.mjs` - pure ES module of drawing helpers. Each function documents how the ND-safe order preserves depth.
-
-- `index.html` - offline entry point that loads the optional palette, syncs the resolved colours with the shell chrome, seeds numerology constants, gathers the render summary, and stays calm if a 2D context is denied.
-- `js/helix-renderer.mjs` - pure ES module of drawing helpers. Each function documents why the ND-safe order matters and references the covenant numbers.
-
-- `data/palette.json` - optional colour override. If missing the renderer applies its sealed fallback, posts a status message, and paints a canvas notice.
-- `data/cosmic-nodes.json` - optional registry of arcana, sephirot, and paths. Labels and helix markers draw from this list; when absent the defaults embedded in `index.html` keep the canvas layered and annotated.
-- `index.html` — offline entry point. Loads the optional palette JSON, applies chrome colours, seeds the numerology constants, and reports render status without animation.
-- `js/helix-renderer.mjs` — pure ES module of drawing helpers. Each function is small, well-commented, and preserves the layered order.
-- `data/palette.json` — optional override palette. If absent or blocked the renderer falls back to sealed colours and displays a calm notice.
-- `README_RENDERER.md` — this guide.
+- `index.html` – Offline entry point that loads the optional palette, applies the resolved colours to the shell chrome, and calls the renderer.
+- `js/helix-renderer.mjs` – Pure ES module of drawing helpers. Each function is small, well-commented, and preserves the layered order.
+- `data/palette.json` – Optional colour override. If absent the renderer applies a sealed fallback, updates the header status, and shows a canvas notice.
+- `README_RENDERER.md` – This guide.
 
 ## Usage
 1. Download or clone the repository.
-2. Double-click `index.html`. No build step or server is required; the module runs offline.
-3. If the palette JSON is blocked (common on hardened `file://` contexts) the fallback palette activates automatically, the header notes the change, and the canvas prints "Palette fallback active" near the base for reassurance.
+2. Double-click `index.html`. No build step or server is required; the module runs entirely offline.
+3. If the palette JSON is blocked (common on hardened `file://` contexts) the fallback palette activates automatically, the header notes the change, and the canvas prints "Palette fallback active" for reassurance.
 
 ## Layer order (back to front)
-1. **Vesica field** — seven by three grid of intersecting vesica pairs with a mandorla halo and central axis. Soft alpha keeps the base calm while preserving depth.
-2. **Tree-of-Life scaffold** — sephirot nodes, 22 paths, vaulted arch, and central column. Positions rely on the covenant ladder so each descent honours {33, 99, 144} spans.
-3. **Fibonacci curve** — static logarithmic spiral built from Fibonacci numbers up to 144, rendered once with rounded joints and pearl markers.
-4. **Double-helix lattice** — two phase-shifted rails with alternating rungs, base walkway, and diamond anchors. Everything is static; no animation or flashing.
-
-
-## Layer order (back to front)
-1. **Vesica field** - seven by three grid of intersecting circles, softened alpha to avoid glare.
-2. **Tree-of-Life scaffold** - ten sephirot nodes tied by twenty-two calm paths. Horizontal pillar spacing and vertical placement both use combinations of {3, 7, 9, 11, 22, 33, 99, 144} so the descent honours the numerology covenant.
-3. If either JSON file is blocked by `file://` rules, the sealed fallbacks activate automatically, the page chrome updates to the safe defaults, and a notice appears on the canvas footer.
-
-## Layer order (back to front)
-1. **Vesica field** - seven by three grid of intersecting circles, softened alpha to avoid glare.
-2. **Tree-of-Life scaffold** - ten sephirot nodes tied by twenty-two calm paths. Vertical placement uses combinations of {3, 7, 9, 11, 22, 33, 99, 144} so the descent honours the numerology covenant, and each node receives a registry-driven label plus optional lab subtitle.
-3. **Fibonacci curve** - static logarithmic spiral sampled from Fibonacci numbers up to 144.
-4. **Double-helix lattice** - two phase-shifted strands with alternating rungs; entirely static. Arcana markers ride the rails, numbered by their numerology, with lab entries encircled for quick orientation.
-
+1. **Vesica field** – Seven-by-three grid of intersecting vesica pairs with a mandorla halo and central axis. Soft alpha keeps the base calm while preserving depth.
+2. **Tree-of-Life scaffold** – Sephirot nodes, twenty-two paths, vaulted arch, and central column. Positions rely on the covenant ladder so each descent honours {33, 99, 144} spans.
+3. **Fibonacci curve** – Static logarithmic-style spiral built from Fibonacci numbers up to 144, rendered once with rounded joints and pearl markers.
+4. **Double-helix lattice** – Two phase-shifted rails with alternating rungs, base walkway, and diamond anchors. Everything is static; no animation or flashing.
 
 All routines stay parameterised by `{3, 7, 9, 11, 22, 33, 99, 144}` to honour the cosmology canon while keeping the numerology adjustable.
 
-### Numerology grounding cheatsheet
+## Numerology grounding cheatsheet
 - **Tree columns** shift by 33 of the 144 horizontal units so each pillar leans on the covenant pair (33, 144).
-- **Supernal triad** rests on 33 divided by 3, placing Chokmah and Binah 11 steps below Kether.
+- **Supernal triad** sets Chokmah and Binah 11 steps below Kether.
 - **Hidden gate** (Daath) descends by 22 + 7 units, bridging the upper triad with the ethical triad.
 - **Middle triad** aligns to 33 + 9 (Chesed/Geburah) and 33 + 22 (Tiphareth) to keep balance between mercy, strength, and heart.
 - **Lower triad** drops to 99 - 3 for Netzach/Hod and 144 - 3 for Yesod, keeping the emotional/intellectual pair and the foundation within the harmonic ladder.
@@ -53,42 +33,11 @@ All routines stay parameterised by `{3, 7, 9, 11, 22, 33, 99, 144}` to honour th
 
 ## Accessibility & ND-safe rationale
 - No animation, autoplay, or async loops. Rendering happens once per load.
-
-- Calm palette defaults with clear status messaging when fallbacks are in play.
-- Layered drawing order maintains geometric depth without flattening into a single outline, matching the reference architecture without motion.
-
-- Calm palette defaults with clear status messaging when fallbacks are in play, including an inline canvas caption for assurance.
+- Calm palette defaults with clear status messaging when fallbacks are active, including an inline canvas caption for assurance.
 - Layered drawing order maintains geometric depth without flattening into a single outline.
-
-- ASCII quotes, UTF-8, LF newlines, and small pure functions keep the module portable offline.
+- Pure functions, ASCII quotes, UTF-8, and LF newlines keep the module portable for offline review.
 
 ## Customisation
 - Adjust colours by editing `data/palette.json`. Provide `bg`, `ink`, and a six colour `layers` array.
-- Adjust labels and helix markers by editing `data/cosmic-nodes.json`. Each record may carry `name`, `numerology`, and an optional `lab` tag for emphasis.
 - Override numerology constants in `index.html` before calling `renderHelix` if alternate ratios are desired.
 - Compose new layers by duplicating the helper pattern in `js/helix-renderer.mjs`. Keep additions static and well-commented to preserve ND safety.
-- On `file://` origins the loader prefers JSON module imports to keep everything offline-first. If JSON modules are unavailable the fetch path takes over, and if that also fails the bundled palette and notice keep rendering safe.
-## Numerology grounding
-- Vertical placement maps the 144-step ladder so Malkuth rests at 144 units and pillar offsets use 33-unit shifts.
-- Supernal descent seats Chokmah/Binah 11 units below Kether (33 ÷ 3), Daath bridges the triads at 22 + 7, and the middle triad steps through 33 + 9 and 33 + 22.
-- Lower triad uses 99 − 3 for Netzach/Hod, 144 − 3 for Yesod, and closes at 144 for Malkuth.
-- Fibonacci sampling stops at 144 while helix rails step through 22 stations with a phase offset governed by 3 and 11.
-
-## Accessibility & ND-safe rationale
-- No animation, autoplay, or async redraw loops; rendering happens once per load.
-- Calm palette defaults with clear status messaging when fallbacks are active (header text plus optional canvas notice).
-- Layered drawing order preserves depth without flattening geometry into a single outline.
-- Pure functions, ASCII quotes, UTF-8, and LF newlines keep the module portable for offline review.
-
-## Palette override
-Update `data/palette.json` with your preferred colours:
-
-```json
-{
-  "bg": "#101018",
-  "ink": "#f0e6d2",
-  "layers": ["#6ca0ff", "#6cd7d8", "#9ce69a", "#ffd28c", "#f8a3ff", "#d7d7f0"]
-}
-```
-
-Missing or malformed palettes never stop rendering; the fallback palette maintains ND safety and emits a calm notice.

--- a/index.html
+++ b/index.html
@@ -6,257 +6,102 @@
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
   <meta name="color-scheme" content="light dark">
   <style>
-    /* ND-safe shell: calm contrast, no motion, maintain spacious margins */
+    /* ND-safe: calm contrast, no motion, layered geometry shell */
     :root {
       --bg:#0b0b12;
       --ink:#e8e8f0;
       --muted:#a6a6c1;
-      --edge:#1e2030;
+      --edge:#1d1d2a;
     }
     html, body {
       margin:0;
       padding:0;
       background:var(--bg);
       color:var(--ink);
-      font:14px/1.5 system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
+      font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
     }
     header {
-      padding:12px 16px 10px 16px;
+      padding:12px 16px;
       border-bottom:1px solid var(--edge);
     }
     .status {
-      margin-top:2px;
       color:var(--muted);
       font-size:12px;
+      margin-top:2px;
     }
     #stage {
       display:block;
-      margin:18px auto 12px auto;
+      margin:16px auto 12px auto;
       width:1440px;
       height:900px;
-      box-shadow:0 0 0 1px var(--edge),0 18px 48px rgba(0,0,0,0.45);
+      max-width:100%;
+      box-shadow:0 0 0 1px var(--edge);
       background-color:transparent;
     }
     .note {
-      max-width:920px;
+      max-width:900px;
       margin:0 auto 24px auto;
       padding:0 16px;
       color:var(--muted);
-    }
-    @media (max-width:1500px) {
-      #stage {
-        width:100%;
-        height:auto;
-        max-width:1440px;
-        aspect-ratio:1440/900;
-      }
     }
   </style>
 </head>
 <body>
   <header>
     <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
-
     <div class="status" id="status">Loading palette…</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">This static renderer paints four calm layers — vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice. Open directly; no network or build steps are required.</p>
-
-
-
-    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Loading palette...</div>
-  </header>
-
-  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-
-  <div id="chapel-ring" style="position:relative;width:min(80vmin,820px);aspect-ratio:1;margin:40px auto"></div>
-  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
-  <script type="module" src="./codex/inject.loader.js"></script>
-
-  <p class="note">Static, offline canvas tuned to the cathedral style reference: vesica grid foundation, Tree-of-Life vault, Fibonacci halo, and double-helix lattice. Palette loads locally with a safe fallback notice for ND assurance.</p>
-
-  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libraries. Open this file directly.</p>
-
+  <p class="note">This static renderer encodes the vesica grid, Tree-of-Life scaffold, Fibonacci curve, and a double-helix lattice. Open this file directly; no network calls beyond optional local JSON loads.</p>
 
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
 
-    const statusEl = document.getElementById("status");
+    const elStatus = document.getElementById("status");
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
 
-    const defaults = {
-      // Fallback palette + registry ensures offline resilience when JSON files are missing.
-    const DEFAULTS = {
-      palette: {
-        bg:"#0b0b12",
-        ink:"#e8e8f0",
-        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
-      }
-    };
-
-
-    async function importJSONModule(path) {
-
-      // Try modern import attributes first, then legacy import assertions.
+    async function loadJSON(path) {
       try {
-        // Modern
-        const m = await import(path, { with: { type: "json" } });
-        return m?.default ?? m;
-      } catch (e1) {
-        try {
-          // Legacy
-          const m = await import(path, { assert: { type: "json" } });
-          return m?.default ?? m;
-        } catch (e2) {
-          const err = new Error("JSON module import failed");
-          err.cause = e2;
-          throw err;
-
-      try {
-        const m = await import(path, { with: { type: "json" } });
-        if (m && m.default) return m.default;
-        throw new Error("JSON module missing default export");
-      } catch (e1) {
-        // Fallback for older Chromium builds that used `assert`
-        try {
-          const mOld = await import(path, { assert: { type: "json" } });
-          if (mOld && mOld.default) return mOld.default;
-          throw new Error("JSON module (assert) missing default export");
-        } catch (e2) {
-          throw e2;
-
-        }
-      }
-    }
-    async function fetchJSON(path) {
-      try {
-        const res = await fetch(path, { cache: "no-store" });
-        if (!res.ok) throw new Error(String(res.status));
-        return await res.json();
-    async function loadPalette(path) {
-      // Offline promise: only touches local paths. When browsers block file:// fetch we attempt a JSON module import first.
-      try {
-        if (window.location && window.location.protocol === "file:") {
-          try {
-            const module = await import(path, { assert: { type: "json" } });
-            return module.default;
-          } catch (importError) {
-            // Silent fallback: some engines reject JSON assertions when opened straight from disk.
-          }
-        }
         const response = await fetch(path, { cache: "no-store" });
-        if (!response.ok) throw new Error(String(response.status));
+        if (!response.ok) {
+          throw new Error(String(response.status));
+        }
         return await response.json();
-      } catch (err) {
+      } catch (error) {
         return null;
       }
     }
 
-
-    const defaults = {
-      palette: {
-        bg:"#0a0c16",
-        ink:"#f4e3c6",
-        layers:["#1f3f63","#265f7f","#c4974b","#f6d58b","#c987d6","#2c3b5d"]
-
-    async function resolvePalette() {
-      const isFileOrigin = typeof window !== "undefined" && window.location && window.location.protocol === "file:";
-
-      if (isFileOrigin) {
-        try {
-          const modulePalette = await importJSONModule("./data/palette.json");
-          elStatus.textContent = "Palette loaded via JSON module.";
-          return { palette: modulePalette, notice: null };
-        } catch (moduleError) {
-          // Fallback to fetch below; some browsers decline JSON module assertions.
-
-      }
-
-      const fetchedPalette = await fetchJSON("./data/palette.json");
-      if (fetchedPalette) {
-        elStatus.textContent = "Palette loaded.";
-        return { palette: fetchedPalette, notice: null };
-      }
-
-      elStatus.textContent = "Palette missing; using safe fallback.";
-      return { palette: defaults.palette, notice: "Palette fallback active" };
-    }
-
-    const { palette: activePalette, notice } = await resolvePalette();
-
-
-        bg: "#0b0b12",
-        ink: "#e8e8f0",
-        layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-
-      }
-
-      const fetchedPalette = await fetchJSON("./data/palette.json");
-      if (fetchedPalette) {
-        elStatus.textContent = "Palette loaded.";
-        return { palette: fetchedPalette, notice: null };
-
-        bg: "#0b0b12",
-        ink: "#e8e8f0",
-        layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-      }
-
-      elStatus.textContent = "Palette missing; using safe fallback.";
-      return { palette: defaults.palette, notice: "Palette fallback active" };
-    }
-
-    const { palette: activePalette, notice } = await resolvePalette();
-      },
-      registry: [
-        { "id": 0, "name": "The Fool", "type": "arcana", "numerology": 0, "lore": "Pure potential, leap into the abyss, Aleph breath of beginning", "lab": "respawn-meditation" },
-        { "id": 1, "name": "The Magician", "type": "arcana", "numerology": 1, "lore": "Will manifested, Mercury's messenger, tools of transformation", "lab": "beth-house-ritual" },
-        { "id": 2, "name": "High Priestess", "type": "arcana", "numerology": 2, "lore": "Veiled wisdom, lunar mysteries, guardian of thresholds", "lab": "gimel-camel-path" },
-        { "id": 3, "name": "The Empress", "type": "arcana", "numerology": 3, "lore": "Venus fertile, creative abundance, nature's sovereignty" },
-        { "id": 4, "name": "The Emperor", "type": "arcana", "numerology": 4, "lore": "Cubic throne, Mars authority, structure and order" },
-        { "id": 5, "name": "Hierophant", "type": "arcana", "numerology": 5, "lore": "Taurus teaching, bridge between worlds, sacred tradition" },
-        { "id": 6, "name": "The Lovers", "type": "arcana", "numerology": 6, "lore": "Zayin sword divides, conscious choice, sacred union" },
-        { "id": 7, "name": "The Chariot", "type": "arcana", "numerology": 7, "lore": "Cancer's shell, sphinx guardians, triumphant will" },
-        { "id": 8, "name": "Strength", "type": "arcana", "numerology": 8, "lore": "Serpent power, Leo's courage, infinite lemniscate" },
-        { "id": 9, "name": "Hermit", "type": "arcana", "numerology": 9, "lore": "Virgo's lamp, Yod hand of God, inner guidance" },
-        { "id": 10, "name": "Wheel of Fortune", "type": "arcana", "numerology": 10, "lore": "Jupiter's expansion, karma cycles, sphinx wisdom" },
-        { "id": 11, "name": "Justice", "type": "arcana", "numerology": 11, "lore": "Libra's balance, Lamed ox-goad, karmic adjustment" },
-        { "id": 12, "name": "Hanged Man", "type": "arcana", "numerology": 12, "lore": "Neptune's water, suspended mind, reversal wisdom" },
-        { "id": 13, "name": "Death", "type": "arcana", "numerology": 13, "lore": "Scorpio transformation, Nun fish, ego dissolution", "lab": "death-rebirth" },
-        { "id": 14, "name": "Temperance", "type": "arcana", "numerology": 14, "lore": "Sagittarius arrow, alchemical mixture, middle path" },
-        { "id": 15, "name": "Devil", "type": "arcana", "numerology": 15, "lore": "Capricorn matter, Ayin eye opens, shadow integration" },
-        { "id": 16, "name": "Tower", "type": "arcana", "numerology": 16, "lore": "Mars lightning, false crown falls, liberation shock", "lab": "tower-catalyst" },
-        { "id": 17, "name": "Star", "type": "arcana", "numerology": 17, "lore": "Aquarius pours, seven chakras, cosmic consciousness" },
-        { "id": 18, "name": "Moon", "type": "arcana", "numerology": 18, "lore": "Pisces dreams, Qoph back of head, astral journey", "lab": "moon-veil" },
-        { "id": 19, "name": "Sun", "type": "arcana", "numerology": 19, "lore": "Solar child, Resh head renewal, conscious joy" },
-        { "id": 20, "name": "Judgement", "type": "arcana", "numerology": 20, "lore": "Pluto rises, Shin tooth/fire, eternal calling" },
-        { "id": 21, "name": "World", "type": "arcana", "numerology": 21, "lore": "Saturn completes, Tau cross manifest, cosmic dance" },
-        { "id": 22, "name": "Kether", "type": "sephirah", "numerology": 1, "lore": "Crown unity, source point, pure will undifferentiated" },
-        { "id": 23, "name": "Chokmah", "type": "sephirah", "numerology": 2, "lore": "Wisdom force, Zodiac sphere, active principle" },
-        { "id": 24, "name": "Binah", "type": "sephirah", "numerology": 3, "lore": "Understanding form, Saturn's restriction, divine mother" },
-        { "id": 25, "name": "Chesed", "type": "sephirah", "numerology": 4, "lore": "Jupiter mercy, building power, benevolent king" },
-        { "id": 26, "name": "Geburah", "type": "sephirah", "numerology": 5, "lore": "Mars severity, destroying force, necessary restriction" },
-        { "id": 27, "name": "Tiphareth", "type": "sephirah", "numerology": 6, "lore": "Solar beauty, Christ center, harmonious balance" },
-        { "id": 28, "name": "Netzach", "type": "sephirah", "numerology": 7, "lore": "Venus victory, desire nature, creative force" },
-        { "id": 29, "name": "Hod", "type": "sephirah", "numerology": 8, "lore": "Mercury splendor, mental forms, magical image" },
-        { "id": 30, "name": "Yesod", "type": "sephirah", "numerology": 9, "lore": "Lunar foundation, astral light, subconscious machinery" },
-        { "id": 31, "name": "Malkuth", "type": "sephirah", "numerology": 10, "lore": "Kingdom manifest, four elements, physical completion" },
-        { "id": 32, "name": "Aleph Path", "type": "path", "numerology": 11, "lore": "Fool's breath, Kether to Chokmah, spirit descends" },
-        { "id": 33, "name": "Beth Path", "type": "path", "numerology": 12, "lore": "Magician's house, Kether to Binah, will directed" },
-        { "id": 34, "name": "Gimel Path", "type": "path", "numerology": 13, "lore": "Priestess veil, Kether to Tiphareth, unity to beauty" },
-        { "id": 35, "name": "Daleth Path", "type": "path", "numerology": 14, "lore": "Empress door, Chokmah to Binah, wisdom meets form" },
-        { "id": 36, "name": "Samekh Path", "type": "path", "numerology": 25, "lore": "Temperance arrow, Tiphareth to Yesod, testing ground" },
-        { "id": 37, "name": "Ayin Path", "type": "path", "numerology": 26, "lore": "Devil's eye, Tiphareth to Hod, material test" },
-        { "id": 38, "name": "Peh Path", "type": "path", "numerology": 27, "lore": "Tower's mouth, Netzach to Hod, force meets form" },
-        { "id": 39, "name": "Tzaddi Path", "type": "path", "numerology": 28, "lore": "Star's hook, Netzach to Yesod, desire crystallizes" },
-        { "id": 40, "name": "Qoph Path", "type": "path", "numerology": 29, "lore": "Moon's sleep, Netzach to Malkuth, dream manifest" },
-        { "id": 41, "name": "Shin Path", "type": "path", "numerology": 31, "lore": "Judgement fire, Hod to Malkuth, mind materializes" },
-        { "id": 42, "name": "Tau Path", "type": "path", "numerology": 32, "lore": "World's cross, Yesod to Malkuth, foundation complete" }
-      ]
+    const FALLBACK = {
+      bg:"#0b0b12",
+      ink:"#e8e8f0",
+      layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
     };
 
+    function applyShellPalette(palette) {
+      const root = document.documentElement;
+      root.style.setProperty("--bg", palette.bg);
+      root.style.setProperty("--ink", palette.ink);
+      root.style.setProperty("--muted", withAlpha(palette.ink, 0.6));
+    }
+
+    function withAlpha(hex, alpha) {
+      const normalised = String(hex || "").replace(/^#/, "");
+      if (normalised.length !== 6) {
+        return hex;
+      }
+      const r = parseInt(normalised.slice(0, 2), 16);
+      const g = parseInt(normalised.slice(2, 4), 16);
+      const b = parseInt(normalised.slice(4, 6), 16);
+      return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+    }
+
+    const palette = await loadJSON("./data/palette.json");
+    const active = palette || FALLBACK;
+    applyShellPalette(active);
+    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
 
     const NUM = {
       THREE:3,
@@ -269,173 +114,17 @@
       ONEFORTYFOUR:144
     };
 
-
-
-
-    const palette = await loadJSON("./data/palette.json");
-    const palette = await loadPalette("./data/palette.json");
-    const active = palette || defaults.palette;
-    const usingFallback = !palette;
-    const active = palette || defaults.palette;
-    const baseStatus = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
-
-
-    initialise();
-
-    async function initialise() {
-      const paletteData = await loadJSON("./data/palette.json");
-      const registryData = await loadJSON("./data/cosmic-nodes.json");
-
-      const activePalette = paletteData || defaults.palette;
-      const activeRegistry = registryData || defaults.registry;
-
-      applyChromePalette(activePalette);
-
-      const statusParts = [];
-      const notices = [];
-
-
-      applyChromePalette(active);
-      if (paletteData) {
-        statusParts.push("Palette loaded.");
-      } else {
-        statusParts.push("Palette missing; using safe fallback.");
-        notices.push("Palette fallback active");
-      }
-
-      if (registryData) {
-        statusParts.push("Registry loaded.");
-      } else {
-        statusParts.push("Registry missing; using sealed dataset.");
-        notices.push("Registry fallback active");
-      }
-
-      elStatus.textContent = statusParts.join(" ");
-      const paletteData = await loadPalette("./data/palette.json");
-      const usingFallback = !paletteData;
-      const palette = paletteData || DEFAULTS.palette;
-
-      applyChromePalette(palette);
-
-      if (!ctx) {
-        updateStatus(composeStatus(usingFallback, "Canvas 2D context unavailable; geometry skipped."));
-        return;
-      }
-
-      // ND-safe: renderer executes once with static geometry and optional notices when fallbacks are active.
-<
-      // Single-pass render keeps the scene static: no loops, no animation, ND-safe.
-      const outcome = renderHelix(ctx, {
+    if (ctx && typeof ctx.save === "function") {
+      renderHelix(ctx, {
         width:canvas.width,
         height:canvas.height,
-        palette,
-
-      // ND-safe: renderer executes once with static geometry and optional notice when fallbacks are active.
-      renderHelix(ctx, {
-
-
-    // ND-safe rationale: no motion, high readability, soft glow, preserved layer order
-    const result = renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM, notice: usingFallback ? "Palette fallback active" : null });
-    elStatus.textContent = result && result.summary ? `${baseStatus} ${result.summary}` : baseStatus;
-
-    // ND-safe rationale: no motion, high readability, soft colors, layered order
-    const renderConfig = {
-      width: canvas.width,
-      height: canvas.height,
-      palette: activePalette,
-      NUM,
-      notice
-    };
-
-    renderHelix(ctx, renderConfig);
-
-    // Sync CSS tokens with whichever palette resolved so the chrome mirrors the canvas.
-    document.documentElement.style.setProperty("--bg", active.bg);
-    document.documentElement.style.setProperty("--ink", active.ink);
-
-    elStatus.textContent = usingFallback ? "Palette missing; using safe fallback." : "Palette loaded.";
-
-    if (!ctx) {
-      elStatus.textContent += " Canvas 2D context unavailable.";
-    } else {
-      // Numerology constants used by geometry routines.
-      const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
-
-      // ND-safe rationale: no motion, high readability, soft colors, layered order.
-      renderHelix(ctx, {
-        width: canvas.width,
-        height: canvas.height,
-        palette: activePalette,
-        registry: activeRegistry,
-        palette: active,
-
+        palette:active,
         NUM,
-        notice: notices.length ? notices.join(" · ") : null
+        notice: palette ? null : "Palette fallback active"
       });
-
-      const summary = outcome && typeof outcome.summary === "string"
-        ? outcome.summary
-        : "Geometry rendered once.";
-      updateStatus(composeStatus(usingFallback, summary));
+    } else {
+      elStatus.textContent = "Canvas context unavailable; rendering skipped.";
     }
-
-    async function loadJSON(path) {
-      if (typeof path !== "string") return null;
-
-      // Offline-first: when opened via file:// prefer JSON modules to avoid fetch restrictions.
-      if (window.location && window.location.protocol === "file:") {
-        try {
-          const module = await import(path, { assert: { type: "json" } });
-          return module && typeof module.default !== "undefined" ? module.default : module;
-        } catch (err) {
-          return null;
-        }
-    async function loadPalette(path) {
-      if (typeof path !== "string") {
-        return null;
-      }
-      try {
-        const response = await fetch(path, { cache:"no-store" });
-        if (!response || !response.ok) {
-          return null;
-        }
-        return await response.json();
-      } catch (error) {
-        // Offline-first: browsers often block fetch for file:// origins; fallback keeps ND safety intact.
-        return null;
-      }
-    }
-
-    function applyChromePalette(palette) {
-      document.documentElement.style.setProperty("--bg", palette.bg);
-      document.documentElement.style.setProperty("--ink", palette.ink);
-      const muted = Array.isArray(palette.layers) && palette.layers.length > 0
-        ? palette.layers[palette.layers.length - 1]
-        : palette.ink;
-      // Muted tone mirrors the outer lattice layer so notes remain legible on both schemes.
-      document.documentElement.style.setProperty("--muted", muted);
-    }
-
-    function composeStatus(usingFallback, tail) {
-      const base = usingFallback
-        ? "Palette missing; using safe fallback."
-        : "Palette loaded.";
-      return `${base} ${tail}`;
-    }
-
-    function updateStatus(message) {
-      statusEl.textContent = message;
-    }
-
-  })();
-  </script>
-  <script>
-  window.addEventListener('cathedral:select', e => {
-    const tint = e.detail?.payload?.color || '#89a3ff';
-    document.documentElement.style.setProperty('--lattice', tint);
-  });
-    }
-
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- rebuild the offline index shell so it loads the palette with a safe fallback and seeds numerology constants before rendering
- rewrite the helix renderer module with small, well-commented helpers for the vesica field, tree scaffold, fibonacci curve, and helix lattice
- refresh the renderer readme to document the offline workflow, layer order, numerology anchors, and ND-safe rationale

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cdd251a93c8328b0d0f88a5809eced