### PR TITLE
feat: rebuild cosmic helix renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,94 +1,45 @@
 # Cosmic Helix Renderer
 
-Static, offline-first canvas capsule tuned to the luminous cathedral canon. The renderer paints four still layers (vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice) using numerology anchors {3, 7, 9, 11, 22, 33, 99, 144}. Comments in the module explain why each choice keeps ND safety intact (no motion, soft contrast, layered depth).
+Static, offline-first canvas capsule aligned with the luminous cosmology canon. Rendering happens once when `index.html` loads, painting four quiet layers (vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice). All geometry is parameterised by numerology anchors `{3, 7, 9, 11, 22, 33, 99, 144}` and every helper is a small, well-commented pure function so the composition stays ND-safe.
 
-## Files
+## Files delivered
+- `index.html` — Offline entry point. Loads the optional palette JSON, reports fallback status in the header, seeds the numerology constants, and invokes the renderer with a calm notice when data is missing.
+- `js/helix-renderer.mjs` — Pure ES module containing the layered drawing helpers. Each layer explains how the numerology keeps depth without motion.
+- `data/palette.json` — Optional colour override. When absent the renderer uses its sealed fallback and paints a footer notice for reassurance.
+- `README_RENDERER.md` — This guide.
 
-- `index.html` - offline entry point that loads the optional palette, seeds numerology constants, and invokes the renderer while reporting layer stats in the header.
-- `js/helix-renderer.mjs` - pure ES module of drawing helpers. Each function documents how the ND-safe order preserves depth.
-
-- `index.html` - offline entry point that loads the optional palette, syncs the resolved colours with the shell chrome, seeds numerology constants, gathers the render summary, and stays calm if a 2D context is denied.
-- `js/helix-renderer.mjs` - pure ES module of drawing helpers. Each function documents why the ND-safe order matters and references the covenant numbers.
-
-- `data/palette.json` - optional colour override. If missing the renderer applies its sealed fallback, posts a status message, and paints a canvas notice.
-- `data/cosmic-nodes.json` - optional registry of arcana, sephirot, and paths. Labels and helix markers draw from this list; when absent the defaults embedded in `index.html` keep the canvas layered and annotated.
-- `index.html` — offline entry point. Loads the optional palette JSON, applies chrome colours, seeds the numerology constants, and reports render status without animation.
-- `js/helix-renderer.mjs` — pure ES module of drawing helpers. Each function is small, well-commented, and preserves the layered order.
-- `data/palette.json` — optional override palette. If absent or blocked the renderer falls back to sealed colours and displays a calm notice.
-- `README_RENDERER.md` — this guide.
-
-## Usage
-1. Download or clone the repository.
-2. Double-click `index.html`. No build step or server is required; the module runs offline.
-3. If the palette JSON is blocked (common on hardened `file://` contexts) the fallback palette activates automatically, the header notes the change, and the canvas prints "Palette fallback active" near the base for reassurance.
+## How to use (offline)
+1. Download or clone this repository.
+2. Double-click `index.html` in any modern browser. No build steps, bundlers, or servers are required.
+3. If local JSON loading is blocked (common on hardened `file://` contexts) the fallback palette activates automatically, the header reports the change, and the canvas prints "Palette fallback active" near the base.
 
 ## Layer order (back to front)
-1. **Vesica field** — seven by three grid of intersecting vesica pairs with a mandorla halo and central axis. Soft alpha keeps the base calm while preserving depth.
-2. **Tree-of-Life scaffold** — sephirot nodes, 22 paths, vaulted arch, and central column. Positions rely on the covenant ladder so each descent honours {33, 99, 144} spans.
-3. **Fibonacci curve** — static logarithmic spiral built from Fibonacci numbers up to 144, rendered once with rounded joints and pearl markers.
-4. **Double-helix lattice** — two phase-shifted rails with alternating rungs, base walkway, and diamond anchors. Everything is static; no animation or flashing.
+1. **Vesica field** — Intersecting circle grid arranged by a `{3 × 7}` cadence. A central mandorla glow reinforces the vesica without motion.
+2. **Tree-of-Life scaffold** — Ten sephirot plus hidden Daath, linked by twenty-two calm paths. Pillar spacing and vertical placement derive from `{33, 99, 144}` ratios, forming a vaulted arch.
+3. **Fibonacci curve** — Logarithmic spiral seeded by the golden ratio. Quarter-turn markers align to the Fibonacci sequence up to `144` and receive pearl markers for clarity.
+4. **Double-helix lattice** — Two phase-shifted strands sampled at `22` stations, alternating rungs to imply twist. A quiet base walkway anchors the lattice without animation.
 
+## Numerology anchors
+- Vertical placement steps through the 144-unit ladder so Malkuth rests at `144` while the supernal triad seats `33 ÷ 3 = 11` units below the crown.
+- Daath bridges triads at `22 + 7`, Chesed/Geburah sit at `33 + 9`, Tiphareth at `33 + 22`, Netzach/Hod at `99 − 3`, Yesod at `144 − 3`.
+- The helix rails oscillate with a sine phase scaled by `{3, 11, 22}`, while rungs appear every other station to honour `33` anchors.
+- The Fibonacci spiral grows by `φ` so each quarter-turn multiplies the radius, matching the canonical progression up to `144`.
 
-## Layer order (back to front)
-1. **Vesica field** - seven by three grid of intersecting circles, softened alpha to avoid glare.
-2. **Tree-of-Life scaffold** - ten sephirot nodes tied by twenty-two calm paths. Horizontal pillar spacing and vertical placement both use combinations of {3, 7, 9, 11, 22, 33, 99, 144} so the descent honours the numerology covenant.
-3. If either JSON file is blocked by `file://` rules, the sealed fallbacks activate automatically, the page chrome updates to the safe defaults, and a notice appears on the canvas footer.
-
-## Layer order (back to front)
-1. **Vesica field** - seven by three grid of intersecting circles, softened alpha to avoid glare.
-2. **Tree-of-Life scaffold** - ten sephirot nodes tied by twenty-two calm paths. Vertical placement uses combinations of {3, 7, 9, 11, 22, 33, 99, 144} so the descent honours the numerology covenant, and each node receives a registry-driven label plus optional lab subtitle.
-3. **Fibonacci curve** - static logarithmic spiral sampled from Fibonacci numbers up to 144.
-4. **Double-helix lattice** - two phase-shifted strands with alternating rungs; entirely static. Arcana markers ride the rails, numbered by their numerology, with lab entries encircled for quick orientation.
-
-
-All routines stay parameterised by `{3, 7, 9, 11, 22, 33, 99, 144}` to honour the cosmology canon while keeping the numerology adjustable.
-
-### Numerology grounding cheatsheet
-- **Tree columns** shift by 33 of the 144 horizontal units so each pillar leans on the covenant pair (33, 144).
-- **Supernal triad** rests on 33 divided by 3, placing Chokmah and Binah 11 steps below Kether.
-- **Hidden gate** (Daath) descends by 22 + 7 units, bridging the upper triad with the ethical triad.
-- **Middle triad** aligns to 33 + 9 (Chesed/Geburah) and 33 + 22 (Tiphareth) to keep balance between mercy, strength, and heart.
-- **Lower triad** drops to 99 - 3 for Netzach/Hod and 144 - 3 for Yesod, keeping the emotional/intellectual pair and the foundation within the harmonic ladder.
-- **Malkuth** completes the run at 144, mirroring the full descent mapped across the canvas height.
-
-## Accessibility & ND-safe rationale
-- No animation, autoplay, or async loops. Rendering happens once per load.
-
-- Calm palette defaults with clear status messaging when fallbacks are in play.
-- Layered drawing order maintains geometric depth without flattening into a single outline, matching the reference architecture without motion.
-
-- Calm palette defaults with clear status messaging when fallbacks are in play, including an inline canvas caption for assurance.
-- Layered drawing order maintains geometric depth without flattening into a single outline.
-
-- ASCII quotes, UTF-8, LF newlines, and small pure functions keep the module portable offline.
-
-## Customisation
-- Adjust colours by editing `data/palette.json`. Provide `bg`, `ink`, and a six colour `layers` array.
-- Adjust labels and helix markers by editing `data/cosmic-nodes.json`. Each record may carry `name`, `numerology`, and an optional `lab` tag for emphasis.
-- Override numerology constants in `index.html` before calling `renderHelix` if alternate ratios are desired.
-- Compose new layers by duplicating the helper pattern in `js/helix-renderer.mjs`. Keep additions static and well-commented to preserve ND safety.
-- On `file://` origins the loader prefers JSON module imports to keep everything offline-first. If JSON modules are unavailable the fetch path takes over, and if that also fails the bundled palette and notice keep rendering safe.
-## Numerology grounding
-- Vertical placement maps the 144-step ladder so Malkuth rests at 144 units and pillar offsets use 33-unit shifts.
-- Supernal descent seats Chokmah/Binah 11 units below Kether (33 ÷ 3), Daath bridges the triads at 22 + 7, and the middle triad steps through 33 + 9 and 33 + 22.
-- Lower triad uses 99 − 3 for Netzach/Hod, 144 − 3 for Yesod, and closes at 144 for Malkuth.
-- Fibonacci sampling stops at 144 while helix rails step through 22 stations with a phase offset governed by 3 and 11.
-
-## Accessibility & ND-safe rationale
-- No animation, autoplay, or async redraw loops; rendering happens once per load.
-- Calm palette defaults with clear status messaging when fallbacks are active (header text plus optional canvas notice).
-- Layered drawing order preserves depth without flattening geometry into a single outline.
-- Pure functions, ASCII quotes, UTF-8, and LF newlines keep the module portable for offline review.
-
-## Palette override
-Update `data/palette.json` with your preferred colours:
+## Palette customisation
+Update `data/palette.json` with your preferred ND-safe palette:
 
 ```json
 {
-  "bg": "#101018",
-  "ink": "#f0e6d2",
-  "layers": ["#6ca0ff", "#6cd7d8", "#9ce69a", "#ffd28c", "#f8a3ff", "#d7d7f0"]
+  "bg": "#0a0c16",
+  "ink": "#f8e8ca",
+  "layers": ["#213963", "#2b5f7a", "#d8a159", "#f7d78e", "#cc8add", "#324766"]
 }
 ```
 
-Missing or malformed palettes never stop rendering; the fallback palette maintains ND safety and emits a calm notice.
+Missing or malformed palette data never stops rendering; the fallback palette keeps contrast calm and emits the inline notice.
+
+## ND-safe rationale
+- No animation loops or timers — everything renders once.
+- Layered drawing order avoids flattening geometry, preserving depth through overlaid transparencies.
+- Comments explain why each choice is present so future curators understand the trauma-informed guardrails.
+- ASCII quotes, UTF-8, and LF newlines keep the files portable and offline friendly.

--- a/index.html
+++ b/index.html
@@ -6,49 +6,49 @@
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
   <meta name="color-scheme" content="light dark">
   <style>
-    /* ND-safe shell: calm contrast, no motion, maintain spacious margins */
+    /* ND-safe shell: calm contrast, no motion, layered spacing */
     :root {
-      --bg:#0b0b12;
-      --ink:#e8e8f0;
-      --muted:#a6a6c1;
-      --edge:#1e2030;
+      --bg: #0b0b12;
+      --ink: #e8e8f0;
+      --muted: #a6a6c1;
+      --edge: #1e2030;
     }
     html, body {
-      margin:0;
-      padding:0;
-      background:var(--bg);
-      color:var(--ink);
-      font:14px/1.5 system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
+      margin: 0;
+      padding: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font: 14px/1.5 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
     }
     header {
-      padding:12px 16px 10px 16px;
-      border-bottom:1px solid var(--edge);
+      padding: 12px 16px 10px 16px;
+      border-bottom: 1px solid var(--edge);
     }
     .status {
-      margin-top:2px;
-      color:var(--muted);
-      font-size:12px;
+      margin-top: 4px;
+      color: var(--muted);
+      font-size: 12px;
     }
     #stage {
-      display:block;
-      margin:18px auto 12px auto;
-      width:1440px;
-      height:900px;
-      box-shadow:0 0 0 1px var(--edge),0 18px 48px rgba(0,0,0,0.45);
-      background-color:transparent;
+      display: block;
+      margin: 18px auto 16px auto;
+      width: 1440px;
+      height: 900px;
+      box-shadow: 0 0 0 1px var(--edge), 0 18px 48px rgba(0, 0, 0, 0.45);
+      background: transparent;
     }
     .note {
-      max-width:920px;
-      margin:0 auto 24px auto;
-      padding:0 16px;
-      color:var(--muted);
+      max-width: 920px;
+      margin: 0 auto 32px auto;
+      padding: 0 16px;
+      color: var(--muted);
     }
-    @media (max-width:1500px) {
+    @media (max-width: 1500px) {
       #stage {
-        width:100%;
-        height:auto;
-        max-width:1440px;
-        aspect-ratio:1440/900;
+        width: 100%;
+        height: auto;
+        max-width: 1440px;
+        aspect-ratio: 1440 / 900;
       }
     }
   </style>
@@ -56,29 +56,11 @@
 <body>
   <header>
     <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
-
     <div class="status" id="status">Loading palette…</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">This static renderer paints four calm layers — vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice. Open directly; no network or build steps are required.</p>
-
-
-
-    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Loading palette...</div>
-  </header>
-
-  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-
-  <div id="chapel-ring" style="position:relative;width:min(80vmin,820px);aspect-ratio:1;margin:40px auto"></div>
-  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
-  <script type="module" src="./codex/inject.loader.js"></script>
-
-  <p class="note">Static, offline canvas tuned to the cathedral style reference: vesica grid foundation, Tree-of-Life vault, Fibonacci halo, and double-helix lattice. Palette loads locally with a safe fallback notice for ND assurance.</p>
-
-  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libraries. Open this file directly.</p>
-
+  <p class="note">Static renderer with four calm layers: vesica field, Tree-of-Life scaffold, Fibonacci curve, and static double-helix lattice. Open directly; no network or build step is required.</p>
 
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
@@ -87,355 +69,81 @@
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
 
-    const defaults = {
-      // Fallback palette + registry ensures offline resilience when JSON files are missing.
-    const DEFAULTS = {
+    const NUM = {
+      THREE: 3,
+      SEVEN: 7,
+      NINE: 9,
+      ELEVEN: 11,
+      TWENTYTWO: 22,
+      THIRTYTHREE: 33,
+      NINETYNINE: 99,
+      ONEFORTYFOUR: 144
+    };
+
+    const FALLBACK = {
       palette: {
-        bg:"#0b0b12",
-        ink:"#e8e8f0",
-        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
+        bg: "#0b0b12",
+        ink: "#e8e8f0",
+        layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
       }
     };
 
-
-    async function importJSONModule(path) {
-
-      // Try modern import attributes first, then legacy import assertions.
-      try {
-        // Modern
-        const m = await import(path, { with: { type: "json" } });
-        return m?.default ?? m;
-      } catch (e1) {
+    async function loadPalette() {
+      const url = "./data/palette.json";
+      if (window.location.protocol === "file:") {
         try {
-          // Legacy
-          const m = await import(path, { assert: { type: "json" } });
-          return m?.default ?? m;
-        } catch (e2) {
-          const err = new Error("JSON module import failed");
-          err.cause = e2;
-          throw err;
-
-      try {
-        const m = await import(path, { with: { type: "json" } });
-        if (m && m.default) return m.default;
-        throw new Error("JSON module missing default export");
-      } catch (e1) {
-        // Fallback for older Chromium builds that used `assert`
-        try {
-          const mOld = await import(path, { assert: { type: "json" } });
-          if (mOld && mOld.default) return mOld.default;
-          throw new Error("JSON module (assert) missing default export");
-        } catch (e2) {
-          throw e2;
-
+          const module = await import(url, { with: { type: "json" } });
+          if (module && module.default) {
+            return module.default;
+          }
+        } catch (err) {
+          // Browsers that lack JSON module support will fall through to fetch below.
         }
       }
-    }
-    async function fetchJSON(path) {
       try {
-        const res = await fetch(path, { cache: "no-store" });
-        if (!res.ok) throw new Error(String(res.status));
-        return await res.json();
-    async function loadPalette(path) {
-      // Offline promise: only touches local paths. When browsers block file:// fetch we attempt a JSON module import first.
-      try {
-        if (window.location && window.location.protocol === "file:") {
-          try {
-            const module = await import(path, { assert: { type: "json" } });
-            return module.default;
-          } catch (importError) {
-            // Silent fallback: some engines reject JSON assertions when opened straight from disk.
-          }
+        const response = await fetch(url, { cache: "no-store" });
+        if (!response.ok) {
+          return null;
         }
-        const response = await fetch(path, { cache: "no-store" });
-        if (!response.ok) throw new Error(String(response.status));
         return await response.json();
       } catch (err) {
         return null;
       }
     }
 
-
-    const defaults = {
-      palette: {
-        bg:"#0a0c16",
-        ink:"#f4e3c6",
-        layers:["#1f3f63","#265f7f","#c4974b","#f6d58b","#c987d6","#2c3b5d"]
-
-    async function resolvePalette() {
-      const isFileOrigin = typeof window !== "undefined" && window.location && window.location.protocol === "file:";
-
-      if (isFileOrigin) {
-        try {
-          const modulePalette = await importJSONModule("./data/palette.json");
-          elStatus.textContent = "Palette loaded via JSON module.";
-          return { palette: modulePalette, notice: null };
-        } catch (moduleError) {
-          // Fallback to fetch below; some browsers decline JSON module assertions.
-
+    function applyChromeColours(palette) {
+      const root = document.documentElement;
+      if (palette.bg) root.style.setProperty("--bg", palette.bg);
+      if (palette.ink) root.style.setProperty("--ink", palette.ink);
+      if (Array.isArray(palette.layers) && palette.layers[0]) {
+        root.style.setProperty("--muted", palette.layers[0]);
       }
-
-      const fetchedPalette = await fetchJSON("./data/palette.json");
-      if (fetchedPalette) {
-        elStatus.textContent = "Palette loaded.";
-        return { palette: fetchedPalette, notice: null };
-      }
-
-      elStatus.textContent = "Palette missing; using safe fallback.";
-      return { palette: defaults.palette, notice: "Palette fallback active" };
     }
 
-    const { palette: activePalette, notice } = await resolvePalette();
+    const palette = await loadPalette();
+    const activePalette = palette || FALLBACK.palette;
+    const notice = palette ? null : "Palette fallback active (local data unavailable).";
 
+    applyChromeColours(activePalette);
 
-        bg: "#0b0b12",
-        ink: "#e8e8f0",
-        layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-
-      }
-
-      const fetchedPalette = await fetchJSON("./data/palette.json");
-      if (fetchedPalette) {
-        elStatus.textContent = "Palette loaded.";
-        return { palette: fetchedPalette, notice: null };
-
-        bg: "#0b0b12",
-        ink: "#e8e8f0",
-        layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-      }
-
-      elStatus.textContent = "Palette missing; using safe fallback.";
-      return { palette: defaults.palette, notice: "Palette fallback active" };
+    if (palette) {
+      statusEl.textContent = "Palette loaded from data/palette.json.";
+    } else {
+      statusEl.textContent = "Palette missing or blocked; using sealed fallback.";
     }
 
-    const { palette: activePalette, notice } = await resolvePalette();
-      },
-      registry: [
-        { "id": 0, "name": "The Fool", "type": "arcana", "numerology": 0, "lore": "Pure potential, leap into the abyss, Aleph breath of beginning", "lab": "respawn-meditation" },
-        { "id": 1, "name": "The Magician", "type": "arcana", "numerology": 1, "lore": "Will manifested, Mercury's messenger, tools of transformation", "lab": "beth-house-ritual" },
-        { "id": 2, "name": "High Priestess", "type": "arcana", "numerology": 2, "lore": "Veiled wisdom, lunar mysteries, guardian of thresholds", "lab": "gimel-camel-path" },
-        { "id": 3, "name": "The Empress", "type": "arcana", "numerology": 3, "lore": "Venus fertile, creative abundance, nature's sovereignty" },
-        { "id": 4, "name": "The Emperor", "type": "arcana", "numerology": 4, "lore": "Cubic throne, Mars authority, structure and order" },
-        { "id": 5, "name": "Hierophant", "type": "arcana", "numerology": 5, "lore": "Taurus teaching, bridge between worlds, sacred tradition" },
-        { "id": 6, "name": "The Lovers", "type": "arcana", "numerology": 6, "lore": "Zayin sword divides, conscious choice, sacred union" },
-        { "id": 7, "name": "The Chariot", "type": "arcana", "numerology": 7, "lore": "Cancer's shell, sphinx guardians, triumphant will" },
-        { "id": 8, "name": "Strength", "type": "arcana", "numerology": 8, "lore": "Serpent power, Leo's courage, infinite lemniscate" },
-        { "id": 9, "name": "Hermit", "type": "arcana", "numerology": 9, "lore": "Virgo's lamp, Yod hand of God, inner guidance" },
-        { "id": 10, "name": "Wheel of Fortune", "type": "arcana", "numerology": 10, "lore": "Jupiter's expansion, karma cycles, sphinx wisdom" },
-        { "id": 11, "name": "Justice", "type": "arcana", "numerology": 11, "lore": "Libra's balance, Lamed ox-goad, karmic adjustment" },
-        { "id": 12, "name": "Hanged Man", "type": "arcana", "numerology": 12, "lore": "Neptune's water, suspended mind, reversal wisdom" },
-        { "id": 13, "name": "Death", "type": "arcana", "numerology": 13, "lore": "Scorpio transformation, Nun fish, ego dissolution", "lab": "death-rebirth" },
-        { "id": 14, "name": "Temperance", "type": "arcana", "numerology": 14, "lore": "Sagittarius arrow, alchemical mixture, middle path" },
-        { "id": 15, "name": "Devil", "type": "arcana", "numerology": 15, "lore": "Capricorn matter, Ayin eye opens, shadow integration" },
-        { "id": 16, "name": "Tower", "type": "arcana", "numerology": 16, "lore": "Mars lightning, false crown falls, liberation shock", "lab": "tower-catalyst" },
-        { "id": 17, "name": "Star", "type": "arcana", "numerology": 17, "lore": "Aquarius pours, seven chakras, cosmic consciousness" },
-        { "id": 18, "name": "Moon", "type": "arcana", "numerology": 18, "lore": "Pisces dreams, Qoph back of head, astral journey", "lab": "moon-veil" },
-        { "id": 19, "name": "Sun", "type": "arcana", "numerology": 19, "lore": "Solar child, Resh head renewal, conscious joy" },
-        { "id": 20, "name": "Judgement", "type": "arcana", "numerology": 20, "lore": "Pluto rises, Shin tooth/fire, eternal calling" },
-        { "id": 21, "name": "World", "type": "arcana", "numerology": 21, "lore": "Saturn completes, Tau cross manifest, cosmic dance" },
-        { "id": 22, "name": "Kether", "type": "sephirah", "numerology": 1, "lore": "Crown unity, source point, pure will undifferentiated" },
-        { "id": 23, "name": "Chokmah", "type": "sephirah", "numerology": 2, "lore": "Wisdom force, Zodiac sphere, active principle" },
-        { "id": 24, "name": "Binah", "type": "sephirah", "numerology": 3, "lore": "Understanding form, Saturn's restriction, divine mother" },
-        { "id": 25, "name": "Chesed", "type": "sephirah", "numerology": 4, "lore": "Jupiter mercy, building power, benevolent king" },
-        { "id": 26, "name": "Geburah", "type": "sephirah", "numerology": 5, "lore": "Mars severity, destroying force, necessary restriction" },
-        { "id": 27, "name": "Tiphareth", "type": "sephirah", "numerology": 6, "lore": "Solar beauty, Christ center, harmonious balance" },
-        { "id": 28, "name": "Netzach", "type": "sephirah", "numerology": 7, "lore": "Venus victory, desire nature, creative force" },
-        { "id": 29, "name": "Hod", "type": "sephirah", "numerology": 8, "lore": "Mercury splendor, mental forms, magical image" },
-        { "id": 30, "name": "Yesod", "type": "sephirah", "numerology": 9, "lore": "Lunar foundation, astral light, subconscious machinery" },
-        { "id": 31, "name": "Malkuth", "type": "sephirah", "numerology": 10, "lore": "Kingdom manifest, four elements, physical completion" },
-        { "id": 32, "name": "Aleph Path", "type": "path", "numerology": 11, "lore": "Fool's breath, Kether to Chokmah, spirit descends" },
-        { "id": 33, "name": "Beth Path", "type": "path", "numerology": 12, "lore": "Magician's house, Kether to Binah, will directed" },
-        { "id": 34, "name": "Gimel Path", "type": "path", "numerology": 13, "lore": "Priestess veil, Kether to Tiphareth, unity to beauty" },
-        { "id": 35, "name": "Daleth Path", "type": "path", "numerology": 14, "lore": "Empress door, Chokmah to Binah, wisdom meets form" },
-        { "id": 36, "name": "Samekh Path", "type": "path", "numerology": 25, "lore": "Temperance arrow, Tiphareth to Yesod, testing ground" },
-        { "id": 37, "name": "Ayin Path", "type": "path", "numerology": 26, "lore": "Devil's eye, Tiphareth to Hod, material test" },
-        { "id": 38, "name": "Peh Path", "type": "path", "numerology": 27, "lore": "Tower's mouth, Netzach to Hod, force meets form" },
-        { "id": 39, "name": "Tzaddi Path", "type": "path", "numerology": 28, "lore": "Star's hook, Netzach to Yesod, desire crystallizes" },
-        { "id": 40, "name": "Qoph Path", "type": "path", "numerology": 29, "lore": "Moon's sleep, Netzach to Malkuth, dream manifest" },
-        { "id": 41, "name": "Shin Path", "type": "path", "numerology": 31, "lore": "Judgement fire, Hod to Malkuth, mind materializes" },
-        { "id": 42, "name": "Tau Path", "type": "path", "numerology": 32, "lore": "World's cross, Yesod to Malkuth, foundation complete" }
-      ]
-    };
-
-
-    const NUM = {
-      THREE:3,
-      SEVEN:7,
-      NINE:9,
-      ELEVEN:11,
-      TWENTYTWO:22,
-      THIRTYTHREE:33,
-      NINETYNINE:99,
-      ONEFORTYFOUR:144
-    };
-
-
-
-
-    const palette = await loadJSON("./data/palette.json");
-    const palette = await loadPalette("./data/palette.json");
-    const active = palette || defaults.palette;
-    const usingFallback = !palette;
-    const active = palette || defaults.palette;
-    const baseStatus = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
-
-
-    initialise();
-
-    async function initialise() {
-      const paletteData = await loadJSON("./data/palette.json");
-      const registryData = await loadJSON("./data/cosmic-nodes.json");
-
-      const activePalette = paletteData || defaults.palette;
-      const activeRegistry = registryData || defaults.registry;
-
-      applyChromePalette(activePalette);
-
-      const statusParts = [];
-      const notices = [];
-
-
-      applyChromePalette(active);
-      if (paletteData) {
-        statusParts.push("Palette loaded.");
-      } else {
-        statusParts.push("Palette missing; using safe fallback.");
-        notices.push("Palette fallback active");
-      }
-
-      if (registryData) {
-        statusParts.push("Registry loaded.");
-      } else {
-        statusParts.push("Registry missing; using sealed dataset.");
-        notices.push("Registry fallback active");
-      }
-
-      elStatus.textContent = statusParts.join(" ");
-      const paletteData = await loadPalette("./data/palette.json");
-      const usingFallback = !paletteData;
-      const palette = paletteData || DEFAULTS.palette;
-
-      applyChromePalette(palette);
-
-      if (!ctx) {
-        updateStatus(composeStatus(usingFallback, "Canvas 2D context unavailable; geometry skipped."));
-        return;
-      }
-
-      // ND-safe: renderer executes once with static geometry and optional notices when fallbacks are active.
-<
-      // Single-pass render keeps the scene static: no loops, no animation, ND-safe.
-      const outcome = renderHelix(ctx, {
-        width:canvas.width,
-        height:canvas.height,
-        palette,
-
-      // ND-safe: renderer executes once with static geometry and optional notice when fallbacks are active.
-      renderHelix(ctx, {
-
-
-    // ND-safe rationale: no motion, high readability, soft glow, preserved layer order
-    const result = renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM, notice: usingFallback ? "Palette fallback active" : null });
-    elStatus.textContent = result && result.summary ? `${baseStatus} ${result.summary}` : baseStatus;
-
-    // ND-safe rationale: no motion, high readability, soft colors, layered order
-    const renderConfig = {
+    // ND-safe rationale: no animation, soft contrast, layered order preserves depth.
+    const result = renderHelix(ctx, {
       width: canvas.width,
       height: canvas.height,
       palette: activePalette,
       NUM,
       notice
-    };
+    });
 
-    renderHelix(ctx, renderConfig);
-
-    // Sync CSS tokens with whichever palette resolved so the chrome mirrors the canvas.
-    document.documentElement.style.setProperty("--bg", active.bg);
-    document.documentElement.style.setProperty("--ink", active.ink);
-
-    elStatus.textContent = usingFallback ? "Palette missing; using safe fallback." : "Palette loaded.";
-
-    if (!ctx) {
-      elStatus.textContent += " Canvas 2D context unavailable.";
-    } else {
-      // Numerology constants used by geometry routines.
-      const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
-
-      // ND-safe rationale: no motion, high readability, soft colors, layered order.
-      renderHelix(ctx, {
-        width: canvas.width,
-        height: canvas.height,
-        palette: activePalette,
-        registry: activeRegistry,
-        palette: active,
-
-        NUM,
-        notice: notices.length ? notices.join(" · ") : null
-      });
-
-      const summary = outcome && typeof outcome.summary === "string"
-        ? outcome.summary
-        : "Geometry rendered once.";
-      updateStatus(composeStatus(usingFallback, summary));
+    if (result && result.summary) {
+      statusEl.textContent += ` | ${result.summary}`;
     }
-
-    async function loadJSON(path) {
-      if (typeof path !== "string") return null;
-
-      // Offline-first: when opened via file:// prefer JSON modules to avoid fetch restrictions.
-      if (window.location && window.location.protocol === "file:") {
-        try {
-          const module = await import(path, { assert: { type: "json" } });
-          return module && typeof module.default !== "undefined" ? module.default : module;
-        } catch (err) {
-          return null;
-        }
-    async function loadPalette(path) {
-      if (typeof path !== "string") {
-        return null;
-      }
-      try {
-        const response = await fetch(path, { cache:"no-store" });
-        if (!response || !response.ok) {
-          return null;
-        }
-        return await response.json();
-      } catch (error) {
-        // Offline-first: browsers often block fetch for file:// origins; fallback keeps ND safety intact.
-        return null;
-      }
-    }
-
-    function applyChromePalette(palette) {
-      document.documentElement.style.setProperty("--bg", palette.bg);
-      document.documentElement.style.setProperty("--ink", palette.ink);
-      const muted = Array.isArray(palette.layers) && palette.layers.length > 0
-        ? palette.layers[palette.layers.length - 1]
-        : palette.ink;
-      // Muted tone mirrors the outer lattice layer so notes remain legible on both schemes.
-      document.documentElement.style.setProperty("--muted", muted);
-    }
-
-    function composeStatus(usingFallback, tail) {
-      const base = usingFallback
-        ? "Palette missing; using safe fallback."
-        : "Palette loaded.";
-      return `${base} ${tail}`;
-    }
-
-    function updateStatus(message) {
-      statusEl.textContent = message;
-    }
-
-  })();
-  </script>
-  <script>
-  window.addEventListener('cathedral:select', e => {
-    const tint = e.detail?.payload?.color || '#89a3ff';
-    document.documentElement.style.setProperty('--lattice', tint);
-  });
-    }
-
   </script>
 </body>
 </html>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -1,15 +1,16 @@
 /*
   helix-renderer.mjs
-  ND-safe static renderer for layered sacred geometry tuned to the luminous cathedral style.
+  ND-safe static renderer for layered sacred geometry.
 
-  Layers:
-    1) Vesica field (intersecting circles and mandorla halos)
-    2) Tree-of-Life scaffold (10 sephirot + 22 paths + architectural vault)
-    3) Fibonacci curve (logarithmic halo traced with calm markers)
-    4) Double-helix lattice (two phase-shifted strands with static pedestals)
+  Layers (back to front):
+    1) Vesica field — intersecting circles arranged by {3, 7} grid.
+    2) Tree-of-Life scaffold — ten sephirot, hidden Daath, and twenty-two paths.
+    3) Fibonacci curve — calm logarithmic spiral grown by the golden ratio.
+    4) Double-helix lattice — two static strands with alternating rungs.
 
-  Why: encodes layered cosmology with calm colours, zero animation, and
-  comments explaining numerology-driven choices for offline review.
+  Why: encodes layered cosmology with soft contrast, zero motion, and explicit
+  numerology constants {3, 7, 9, 11, 22, 33, 99, 144}. All helpers stay small,
+  pure, and offline safe.
 */
 
 const DEFAULT_PALETTE = {
@@ -29,89 +30,45 @@ const DEFAULT_NUMBERS = {
   ONEFORTYFOUR: 144
 };
 
-/**
- * Render a static, four-layer sacred-geometry helix composition onto a 2D canvas.
- *
- * Draws, in sequence, a vesica field, a Tree of Life scaffold, a Fibonacci spiral, and a
- * double-helix lattice. The renderer saves/restores the canvas state, applies an optional
- * inline notice when fallbacks are active, and summarises the geometry counts for the
- * caller.
- *
- * @param {CanvasRenderingContext2D} ctx - Canvas 2D context to draw into.
- * @param {Object} [input={}] - Optional configuration overrides (palette, NUM values, dims, notice).
- * @returns {{summary: string}} A calm human-readable description of the rendered layers.
- */
-
- * Render a static four-layer helix composition onto a canvas.
- *
- * Draws, in sequence, a vesica field, a Tree of Life scaffold, a Fibonacci spiral, and a double-helix lattice,
- * then optionally renders an inline notice. If the provided canvas context is invalid or lacks `save()`,
- * the function returns immediately with a quiet summary object instead of throwing.
- *
- * @param {Object} [input={}] - Optional overrides for rendering (palette, numeric constants, notice text, explicit dimensions).
- * @return {{summary: string}} An object with a human-readable summary of which layers were rendered and basic counts.
-const DEFAULT_REGISTRY = {
-  arcana: [],
-  sephirot: [
-    { id: null, name: "Kether", type: "sephirah", numerology: 1, lore: "Crown unity", lab: null },
-    { id: null, name: "Chokmah", type: "sephirah", numerology: 2, lore: "Wisdom force", lab: null },
-    { id: null, name: "Binah", type: "sephirah", numerology: 3, lore: "Understanding form", lab: null },
-    { id: null, name: "Daath", type: "sephirah", numerology: null, lore: "Hidden knowledge", lab: null },
-    { id: null, name: "Chesed", type: "sephirah", numerology: 4, lore: "Mercy pillar", lab: null },
-    { id: null, name: "Geburah", type: "sephirah", numerology: 5, lore: "Severity pillar", lab: null },
-    { id: null, name: "Tiphareth", type: "sephirah", numerology: 6, lore: "Solar heart", lab: null },
-    { id: null, name: "Netzach", type: "sephirah", numerology: 7, lore: "Victory", lab: null },
-    { id: null, name: "Hod", type: "sephirah", numerology: 8, lore: "Splendour", lab: null },
-    { id: null, name: "Yesod", type: "sephirah", numerology: 9, lore: "Foundation", lab: null },
-    { id: null, name: "Malkuth", type: "sephirah", numerology: 10, lore: "Kingdom", lab: null }
-  ],
-  paths: []
-};
-
-export function renderHelix(ctx, input = {}) {
-  if (!ctx || typeof ctx.canvas === "undefined" || typeof ctx.save !== "function") {
-    // Calm skip keeps the offline shell quiet when contexts are denied (rare on hardened browsers).
+export function renderHelix(ctx, options = {}) {
+  if (!ctx || typeof ctx.save !== "function") {
     return { summary: "Canvas context unavailable; rendering skipped." };
   }
 
-  const config = normaliseConfig(ctx, input);
+  const config = prepareConfig(ctx, options);
   ctx.save();
-  clearStage(ctx, config.dims, config.palette, config.numbers);
+  clearStage(ctx, config);
 
-  const vesicaStats = drawVesicaField(ctx, config.dims, config.palette, config.numbers);
-  const treeStats = drawTreeOfLife(ctx, config.dims, config.palette, config.numbers, config.registry);
-  const fibonacciStats = drawFibonacciCurve(ctx, config.dims, config.palette, config.numbers);
-  const helixStats = drawHelixLattice(ctx, config.dims, config.palette, config.numbers, config.registry);
+  const vesica = drawVesicaField(ctx, config);
+  const tree = drawTreeOfLife(ctx, config);
+  const fib = drawFibonacciCurve(ctx, config);
+  const helix = drawHelixLattice(ctx, config);
 
   if (config.notice) {
-    // Inline notice reassures offline viewers that a safe fallback palette is active.
-    drawCanvasNotice(ctx, config.dims, config.palette.ink, config.notice);
+    drawCanvasNotice(ctx, config);
   }
 
   ctx.restore();
-
-  return {
-    summary: summariseLayers({ vesicaStats, treeStats, fibonacciStats, helixStats }, config.registry)
-  };
+  return { summary: summariseLayers(vesica, tree, fib, helix) };
 }
 
-function normaliseConfig(ctx, input) {
-  const width = typeof input.width === "number" ? input.width : ctx.canvas.width;
-  const height = typeof input.height === "number" ? input.height : ctx.canvas.height;
-  const dims = { width, height };
-  const palette = mergePalette(input.palette || {});
-  const numbers = mergeNumbers(input.NUM || {});
-  const notice = typeof input.notice === "string" ? input.notice : null;
-  const registry = normaliseRegistry(input.registry);
-  return { dims, palette, numbers, notice, registry };
+function prepareConfig(ctx, options) {
+  const width = typeof options.width === "number" ? options.width : ctx.canvas.width;
+  const height = typeof options.height === "number" ? options.height : ctx.canvas.height;
+  const palette = mergePalette(options.palette || {});
+  const numbers = mergeNumbers(options.NUM || {});
+  const notice = typeof options.notice === "string" ? options.notice : null;
+  return { dims: { width, height }, palette, numbers, notice };
 }
 
 function mergePalette(candidate) {
-  const layers = Array.isArray(candidate.layers) && candidate.layers.length > 0
-    ? candidate.layers.slice(0, DEFAULT_PALETTE.layers.length)
-    : DEFAULT_PALETTE.layers.slice();
-  while (layers.length < DEFAULT_PALETTE.layers.length) {
-    layers.push(DEFAULT_PALETTE.layers[layers.length]);
+  const layers = DEFAULT_PALETTE.layers.slice();
+  if (Array.isArray(candidate.layers)) {
+    for (let i = 0; i < candidate.layers.length && i < layers.length; i += 1) {
+      if (typeof candidate.layers[i] === "string") {
+        layers[i] = candidate.layers[i];
+      }
+    }
   }
   return {
     bg: typeof candidate.bg === "string" ? candidate.bg : DEFAULT_PALETTE.bg,
@@ -120,15 +77,6 @@ function mergePalette(candidate) {
   };
 }
 
-/**
- * Merge user-provided numeric overrides into the default numeric constants.
- *
- * Returns a shallow copy of DEFAULT_NUMBERS where any key present in the
- * input `candidate` that is a finite number replaces the corresponding default.
- *
- * @param {Object} candidate - Object whose numeric properties override defaults.
- * @return {Object} A new numbers object combining DEFAULT_NUMBERS with valid overrides.
- */
 function mergeNumbers(candidate) {
   const merged = { ...DEFAULT_NUMBERS };
   for (const key of Object.keys(DEFAULT_NUMBERS)) {
@@ -139,1097 +87,345 @@ function mergeNumbers(candidate) {
   return merged;
 }
 
-/**
- * Clear the canvas to the configured background and apply the layered background glow.
- *
- * Clears the entire drawing surface with palette.bg then delegates to applyBackgroundGlow
- * to paint the central radial halo and floor wash based on dims and numbers.
- * @param {CanvasRenderingContext2D} ctx - 2D canvas context to draw into.
- * @param {{width: number, height: number, cx?: number, cy?: number}} dims - Rendering dimensions and optional center coordinates.
- * @param {{bg: string, ink?: string, layers?: string[]}} palette - Palette object; bg is used as the fill color.
- * @param {Object} numbers - Numeric configuration (spacing/scales) used by the glow routine.
- */
-function clearStage(ctx, dims, palette, numbers) {
-  ctx.fillStyle = palette.bg;
-  ctx.fillRect(0, 0, dims.width, dims.height);
-  applyBackgroundGlow(ctx, dims, palette, numbers);
+function clearStage(ctx, config) {
+  const { width, height } = config.dims;
+  ctx.fillStyle = config.palette.bg;
+  ctx.fillRect(0, 0, width, height);
+  applyBackgroundGlow(ctx, config);
 }
 
-/**
- * Draws layered background glow: a central radial halo and a floor wash to add depth.
- *
- * Paints a radial halo near the top-center and a vertical floor gradient using colors
- * from the provided palette and sizing from the numeric constants. This mutates the
- * supplied 2D canvas context by filling the full canvas area.
- *
- * @param {Object} dims - Rendering dimensions; must include `width` and `height`.
- * @param {Object} palette - Color palette containing `bg`, `ink`, and a `layers` array used for gradients.
- * @param {Object} numbers - Numeric constants (e.g. THREE, NINE, SEVEN) that control radii and positions.
- */
-function applyBackgroundGlow(ctx, dims, palette, numbers) {
-  // Layered glow: central halo and floor wash keep depth without motion.
-  const centreX = dims.width / 2;
-  const crownY = dims.height / numbers.NINE;
-  const outerRadius = Math.max(dims.width, dims.height) / (numbers.THREE * 0.9);
-  const glow = ctx.createRadialGradient(centreX, crownY * 1.4, outerRadius / numbers.SEVEN, centreX, dims.height / 2, outerRadius);
-  glow.addColorStop(0, withAlpha(palette.ink, 0.22));
-  glow.addColorStop(0.45, withAlpha(palette.layers[3], 0.16));
-  glow.addColorStop(1, withAlpha(palette.bg, 0));
-  ctx.fillStyle = glow;
-  ctx.fillRect(0, 0, dims.width, dims.height);
-
-  const floorGradient = ctx.createLinearGradient(0, dims.height * 0.68, 0, dims.height);
-  floorGradient.addColorStop(0, withAlpha(palette.layers[5], 0.02));
-  floorGradient.addColorStop(0.4, withAlpha(palette.layers[2], 0.09));
-  floorGradient.addColorStop(1, withAlpha(palette.bg, 0.85));
-  ctx.fillStyle = floorGradient;
-function normaliseRegistry(candidate) {
-  const registry = cloneRegistry(DEFAULT_REGISTRY);
-  const partitions = partitionRegistry(candidate);
-
-  const arcana = partitions.arcana
-    .map(record => sanitiseRecord(record, "arcana"))
-    .filter(Boolean);
-  const paths = partitions.paths
-    .map(record => sanitiseRecord(record, "path"))
-    .filter(Boolean);
-  const sephirot = partitions.sephirot
-    .map(record => sanitiseRecord(record, "sephirah"))
-    .filter(Boolean);
-
-  if (arcana.length > 0) {
-    registry.arcana = arcana;
-  }
-
-  if (paths.length > 0) {
-    registry.paths = paths;
-  }
-
-  if (sephirot.length > 0) {
-    const index = new Map();
-    registry.sephirot.forEach(entry => {
-      index.set(canonicalKey(entry.name), entry);
-    });
-    sephirot.forEach(entry => {
-      const key = canonicalKey(entry.name);
-      if (!key) return;
-      if (index.has(key)) {
-        mergeSephirotEntry(index.get(key), entry);
-      } else {
-        registry.sephirot.push(entry);
-        index.set(key, entry);
-      }
-    });
-  }
-
-  ensureDaathEntry(registry.sephirot);
-  return registry;
-}
-
-function cloneRegistry(template) {
-  return {
-    arcana: Array.isArray(template.arcana) ? template.arcana.map(entry => ({ ...entry })) : [],
-    sephirot: Array.isArray(template.sephirot) ? template.sephirot.map(entry => ({ ...entry })) : [],
-    paths: Array.isArray(template.paths) ? template.paths.map(entry => ({ ...entry })) : []
-  };
-}
-
-function partitionRegistry(candidate) {
-  const result = { arcana: [], sephirot: [], paths: [] };
-  if (!candidate) return result;
-
-  if (Array.isArray(candidate)) {
-    candidate.forEach(item => distributeRecord(result, item));
-    return result;
-  }
-
-  if (typeof candidate === "object") {
-    distributeCollection(result.arcana, candidate.arcana, "arcana");
-    distributeCollection(result.sephirot, candidate.sephirot, "sephirah");
-    distributeCollection(result.paths, candidate.paths, "path");
-  }
-
-  return result;
-}
-
-function distributeRecord(result, item) {
-  if (!item || typeof item !== "object") return;
-  const type = typeof item.type === "string" ? item.type.toLowerCase() : "";
-  if (type === "arcana") {
-    result.arcana.push({ ...item });
-  } else if (type === "sephirah") {
-    result.sephirot.push({ ...item });
-  } else if (type === "path") {
-    result.paths.push({ ...item });
-  }
-}
-
-function distributeCollection(target, source, fallbackType) {
-  if (!Array.isArray(source)) return;
-  source.forEach(item => {
-    if (!item || typeof item !== "object") return;
-    const record = { ...item };
-    if (!record.type && fallbackType) {
-      record.type = fallbackType;
-    }
-    target.push(record);
-  });
-}
-
-function sanitiseRecord(record, forcedType) {
-  if (!record || typeof record !== "object") return null;
-  const name = typeof record.name === "string" ? record.name.trim() : "";
-  if (!name) return null;
-  const id = typeof record.id === "number" && Number.isFinite(record.id) ? record.id : null;
-  const type = forcedType || (typeof record.type === "string" ? record.type : "");
-  const numerology = typeof record.numerology === "number" && Number.isFinite(record.numerology)
-    ? record.numerology
-    : null;
-  const lore = typeof record.lore === "string" ? record.lore.trim() : "";
-  const labRaw = typeof record.lab === "string" ? record.lab.trim() : "";
-  const lab = labRaw.length > 0 ? labRaw : null;
-  return { id, name, type, numerology, lore, lab };
-}
-
-function mergeSephirotEntry(target, source) {
-  if (!target || !source) return;
-  target.id = source.id !== null ? source.id : target.id;
-  target.name = source.name || target.name;
-  if (source.numerology !== null) {
-    target.numerology = source.numerology;
-  }
-  if (source.lore) {
-    target.lore = source.lore;
-  }
-  if (source.lab) {
-    target.lab = source.lab;
-  }
-}
-
-function ensureDaathEntry(sephirot) {
-  if (!Array.isArray(sephirot)) return;
-  const hasDaath = sephirot.some(entry => canonicalKey(entry.name) === "daath");
-  if (!hasDaath) {
-    const insertIndex = Math.min(3, sephirot.length);
-    sephirot.splice(insertIndex, 0, { id: null, name: "Daath", type: "sephirah", numerology: null, lore: "Hidden knowledge", lab: null });
-  }
-}
-
-function canonicalKey(name) {
-  return String(name || "").toLowerCase().replace(/[^a-z0-9]/g, "");
-}
-
-function capitaliseKey(key) {
-  const text = String(key || "");
-  if (!text) return "";
-  return text.charAt(0).toUpperCase() + text.slice(1);
-}
-
-function clearStage(ctx, dims, bg) {
-  ctx.fillStyle = bg;
-  ctx.fillRect(0, 0, dims.width, dims.height);
-}
-
-/**
- * Render the Vesica field layer: a grid of paired vesica circles, a central halo, and a vertical axis.
- *
- * Renders positioned vesica pairs for each grid cell, a concentric halo near the canvas center,
- * and a dashed central axis. Returns lightweight statistics used by the caller to summarize the
- * rendered layer.
- *
- * @param {CanvasRenderingContext2D} ctx - 2D canvas drawing context to render into.
- * @param {{width: number, height: number}} dims - Canvas dimensions and derived layout bounds.
- * @param {{layers: string[]}} palette - Color palette object; uses palette.layers indices for strokes.
- * @param {{ONEFORTYFOUR: number, TWENTYTWO: number}} numbers - Numeric constants used for sizing and dashing.
- * @return {{circles: number, radius: number}} Statistics: total circle count (pairs + halo) and the grid radius.
- */
-function drawVesicaField(ctx, dims, palette, numbers) {
-  const grid = buildVesicaGrid(dims, numbers);
-
+function applyBackgroundGlow(ctx, config) {
+  const { width, height } = config.dims;
+  const { palette, numbers } = config;
   ctx.save();
-  ctx.globalAlpha = 0.66; // ND-safe softness keeps layer readable without glare.
-  ctx.strokeStyle = palette.layers[0];
-  ctx.lineWidth = Math.max(1.1, dims.width / (numbers.ONEFORTYFOUR * 1.6));
-  for (const cell of grid.cells) {
-    drawVesicaPair(ctx, cell);
-  }
+  const centreX = width / 2;
+  const crownY = height / numbers.NINE;
+  const outerRadius = Math.max(width, height) / (numbers.THREE * 0.9);
+  const halo = ctx.createRadialGradient(centreX, crownY * 1.4, outerRadius / numbers.SEVEN, centreX, height / 2, outerRadius);
+  halo.addColorStop(0, withAlpha(palette.ink, 0.18));
+  halo.addColorStop(0.4, withAlpha(palette.layers[3], 0.16));
+  halo.addColorStop(1, withAlpha(palette.bg, 0));
+  ctx.fillStyle = halo;
+  ctx.fillRect(0, 0, width, height);
 
-  ctx.globalAlpha = 0.82;
-  ctx.strokeStyle = palette.layers[5];
-  ctx.lineWidth = Math.max(1.2, dims.width / numbers.ONEFORTYFOUR);
-  drawVesicaHalo(ctx, dims, numbers);
-
-  ctx.globalAlpha = 0.5;
-  ctx.strokeStyle = palette.layers[2];
-  ctx.setLineDash([numbers.TWENTYTWO, numbers.TWENTYTWO]);
-  drawVesicaAxis(ctx, dims, numbers);
-  ctx.setLineDash([]);
-
+  const floor = ctx.createLinearGradient(0, height * 0.68, 0, height);
+  floor.addColorStop(0, withAlpha(palette.layers[5], 0.04));
+  floor.addColorStop(0.6, withAlpha(palette.layers[2], 0.1));
+  floor.addColorStop(1, withAlpha(palette.bg, 0.82));
+  ctx.fillStyle = floor;
+  ctx.fillRect(0, 0, width, height);
   ctx.restore();
-  return { circles: grid.cells.length * 2 + 2, radius: grid.radius };
 }
 
-/**
- * Build a rectangular grid of vesica cell descriptors for the canvas.
- *
- * Produces a rows x cols grid (rows and cols taken from `numbers`) of cell objects
- * positioned inside a uniform margin derived from `dims.width`. Each cell contains
- * the computed center coordinates and sizing used by vesica pair rendering.
- *
- * @param {Object} dims - Rendering dimensions; expects numeric `width` and `height`.
- * @param {Object} numbers - Numeric constants used for layout (expects `SEVEN`, `THREE`, `THIRTYTHREE`, `NINE`, `TWENTYTWO`, `ELEVEN`).
- * @return {{cells: Array<{cx:number, cy:number, radius:number, offset:number}>, radius: number}}
- *   An object with:
- *   - cells: Array of cell descriptors ({cx, cy, radius, offset}) for each grid position.
- *   - radius: the computed base radius applied to every cell.
- */
-function buildVesicaGrid(dims, numbers) {
+function drawVesicaField(ctx, config) {
+  const { width, height } = config.dims;
+  const { palette, numbers } = config;
+  const columns = numbers.THREE;
   const rows = numbers.SEVEN;
-  const cols = numbers.THREE;
-  const margin = dims.width / numbers.THIRTYTHREE;
-  const innerWidth = dims.width - margin * 2;
-  const innerHeight = dims.height - margin * 2;
-  const horizontalStep = cols > 1 ? innerWidth / (cols - 1) : 0;
-  const verticalStep = rows > 1 ? innerHeight / (rows - 1) : 0;
-  const radius = Math.min(horizontalStep, verticalStep) * (numbers.NINE / numbers.TWENTYTWO);
-  const offset = radius * (numbers.ELEVEN / numbers.TWENTYTWO);
-
-  const cells = [];
-  for (let row = 0; row < rows; row += 1) {
-    for (let col = 0; col < cols; col += 1) {
-      const cx = margin + col * horizontalStep;
-      const cy = margin + row * verticalStep;
-      cells.push({ cx, cy, radius, offset });
-    }
-  }
-  return { cells, radius };
-}
-
-/**
- * Draws a pair of stroked circles (a vesica pair) centered horizontally around a cell.
- *
- * The function issues two stroked arcs on the provided 2D canvas context: one centered at
- * (cell.cx - cell.offset, cell.cy) and the other at (cell.cx + cell.offset, cell.cy),
- * both using cell.radius.
- *
- * @param {Object} cell - Geometry describing the vesica pair.
- * @param {number} cell.cx - X coordinate of the cell center.
- * @param {number} cell.cy - Y coordinate of the cell center.
- * @param {number} cell.radius - Radius of each circle.
- * @param {number} cell.offset - Horizontal offset from the center to each circle.
- */
-function drawVesicaPair(ctx, cell) {
-  ctx.beginPath();
-  ctx.arc(cell.cx - cell.offset, cell.cy, cell.radius, 0, Math.PI * 2);
-  ctx.stroke();
-  ctx.beginPath();
-  ctx.arc(cell.cx + cell.offset, cell.cy, cell.radius, 0, Math.PI * 2);
-  ctx.stroke();
-}
-
-/**
- * Draws a two-ring vesica halo: an outer and a scaled inner circle centered above the canvas midpoint.
- *
- * The outer radius is computed from the smaller canvas dimension divided by (THREE * 0.82).
- * The inner radius is a scaled proportion of the outer radius using the numeric ratio SEVEN / ELEVEN.
- * Uses the current canvas stroke style and line width; does not modify canvas state stack.
- *
- * @param {{width:number,height:number}} dims - Canvas dimensions; used to compute the halo center and radii.
- * @param {{THREE:number,SEVEN:number,ELEVEN:number}} numbers - Numeric constants referenced to compute radii.
- */
-function drawVesicaHalo(ctx, dims, numbers) {
-  const centreX = dims.width / 2;
-  const centreY = dims.height / 2.2;
-  const outerRadius = Math.min(dims.width, dims.height) / (numbers.THREE * 0.82);
-  const innerRadius = outerRadius * (numbers.SEVEN / numbers.ELEVEN);
-
-  ctx.beginPath();
-  ctx.arc(centreX, centreY, outerRadius, 0, Math.PI * 2);
-  ctx.stroke();
-
-  ctx.beginPath();
-  ctx.arc(centreX, centreY, innerRadius, 0, Math.PI * 2);
-  ctx.stroke();
-}
-
-/**
- * Draws the central vertical axis and an elliptical base for the vesica field.
- *
- * The vertical axis runs from a top offset (1/NINE of the canvas height) down to 90% of the canvas height.
- * An elliptical "base" is drawn near the lower area to anchor the composition.
- *
- * @param {Object} dims - Rendering dimensions; expected to include `width` and `height` (pixels).
- * @param {Object} numbers - Numeric constants used for layout; must provide `NINE`, `THREE`, and `TWENTYTWO`.
- */
-function drawVesicaAxis(ctx, dims, numbers) {
-  const centreX = dims.width / 2;
-  const startY = dims.height / numbers.NINE;
-  const endY = dims.height * 0.9;
-  ctx.beginPath();
-  ctx.moveTo(centreX, startY);
-  ctx.lineTo(centreX, endY);
-  ctx.stroke();
-
-  const baseRadiusX = dims.width / numbers.THREE;
-  const baseRadiusY = dims.height / numbers.TWENTYTWO;
-  ctx.beginPath();
-  ctx.ellipse(centreX, dims.height * 0.87, baseRadiusX, baseRadiusY, 0, 0, Math.PI * 2);
-  ctx.stroke();
-}
-
-/**
- * Render the Tree of Life layer onto the provided 2D canvas context.
- *
- * Draws a vaulted arch and central column, renders canonical Tree of Life connections,
- * paints each sephirot as a filled circle with an outline, and adds a decorative star at
- * the kether position. Colors are taken from the provided palette; sizing uses numeric
- * constants.
- *
- * @param {Object} dims - Normalized drawing dimensions; must include at least { width, height, cx, cy }.
- * @param {Object} palette - Color palette (expects usable values at palette.layers[1], palette.layers[2], and palette.ink).
- * @param {Object} numbers - Numeric constants used for layout (e.g., NINETYNINE, ONEFORTYFOUR) that influence node radius and stroke widths.
- * @return {{nodes: number, paths: number}} Counts of sephirot nodes drawn and connecting paths stroked.
- */
-function drawTreeOfLife(ctx, dims, palette, numbers) {
-function drawTreeOfLife(ctx, dims, palette, numbers, registry) {
-  const nodes = buildTreeNodes(dims, numbers);
-  const paths = buildTreePaths();
-  const nodeRadius = Math.max(6, dims.width / numbers.NINETYNINE);
+  const centreX = width / 2;
+  const topMargin = height / numbers.NINE;
+  const rowSpacing = (height - topMargin * 1.8) / rows;
+  const columnSpacing = width / (columns + 1);
+  const radius = Math.min(columnSpacing, rowSpacing) / 1.6;
 
   ctx.save();
-  drawTreeVault(ctx, dims, palette, numbers, nodes);
-  drawTreeColumn(ctx, dims, palette, numbers, nodes);
+  ctx.strokeStyle = withAlpha(palette.layers[0], 0.52);
+  ctx.lineWidth = Math.max(radius / numbers.TWENTYTWO, 1.4);
+  for (let row = 0; row < rows; row += 1) {
+    const y = topMargin + rowSpacing * (row + 0.5);
+    for (let col = 0; col < columns; col += 1) {
+      const centreOffset = col - (columns - 1) / 2;
+      const x = centreX + centreOffset * columnSpacing;
+      ctx.beginPath();
+      ctx.arc(x, y, radius, 0, Math.PI * 2);
+      ctx.stroke();
+      ctx.beginPath();
+      ctx.arc(x + radius / numbers.THREE, y, radius, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+  }
 
-  ctx.globalAlpha = 0.9;
-  ctx.strokeStyle = palette.layers[1];
-  ctx.lineWidth = Math.max(1.4, dims.width / (numbers.ONEFORTYFOUR * 2));
-  ctx.lineJoin = "round";
-  for (const [fromKey, toKey] of paths) {
+  ctx.globalAlpha = 0.2;
+  ctx.fillStyle = palette.layers[1];
+  ctx.beginPath();
+  ctx.ellipse(centreX, height / numbers.THREE, radius * numbers.THREE, radius * 1.2, 0, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.globalAlpha = 1;
+  ctx.lineWidth = Math.max(radius / numbers.THIRTYTHREE, 1);
+  ctx.strokeStyle = withAlpha(palette.layers[0], 0.35);
+  ctx.beginPath();
+  ctx.moveTo(centreX, topMargin * 0.6);
+  ctx.lineTo(centreX, height - topMargin * 0.4);
+  ctx.stroke();
+  ctx.restore();
+
+  return { circles: columns * rows * 2 };
+}
+
+function drawTreeOfLife(ctx, config) {
+  const nodes = computeTreeNodes(config.dims, config.numbers);
+  const { palette, numbers } = config;
+  const edges = buildTreeEdges();
+  ctx.save();
+
+  ctx.strokeStyle = withAlpha(palette.layers[2], 0.75);
+  ctx.lineWidth = Math.max(config.dims.width / numbers.ONEFORTYFOUR * 1.6, 2);
+  ctx.lineCap = "round";
+  edges.forEach(([fromKey, toKey]) => {
     const from = nodes[fromKey];
     const to = nodes[toKey];
     ctx.beginPath();
     ctx.moveTo(from.x, from.y);
     ctx.lineTo(to.x, to.y);
     ctx.stroke();
-  }
+  });
 
-  ctx.fillStyle = palette.layers[2];
-  ctx.strokeStyle = palette.ink;
-  ctx.globalAlpha = 0.96;
-  ctx.lineWidth = 1;
-  for (const key of Object.keys(nodes)) {
-    const node = nodes[key];
+  // Vault arch connecting supernal triad, keeps layered depth without motion.
+  ctx.strokeStyle = withAlpha(palette.layers[2], 0.4);
+  ctx.lineWidth = Math.max(config.dims.width / numbers.ONEFORTYFOUR, 1.5);
+  ctx.beginPath();
+  const archRadius = Math.abs(nodes.binah.x - nodes.kether.x);
+  ctx.arc(nodes.kether.x, nodes.kether.y + archRadius * 0.6, archRadius * 1.12, Math.PI * 1.05, Math.PI * -0.05, true);
+  ctx.stroke();
+
+  const nodeRadius = Math.max(config.dims.width / numbers.THIRTYTHREE / 2.8, 8);
+  ctx.fillStyle = withAlpha(palette.layers[3], 0.85);
+  ctx.strokeStyle = withAlpha(palette.ink, 0.9);
+  Object.keys(nodes).forEach(key => {
+    const point = nodes[key];
+    const radius = key === "daath" ? nodeRadius * 0.6 : nodeRadius;
     ctx.beginPath();
-    ctx.arc(node.x, node.y, nodeRadius, 0, Math.PI * 2);
+    ctx.arc(point.x, point.y, radius, 0, Math.PI * 2);
     ctx.fill();
+    ctx.beginPath();
+    ctx.arc(point.x, point.y, radius, 0, Math.PI * 2);
     ctx.stroke();
-  }
+  });
 
-  drawTreeStar(ctx, dims, palette, numbers, nodes.kether);
   ctx.restore();
-  const sephirotRecords = registry && Array.isArray(registry.sephirot) ? registry.sephirot : [];
-  const labelStats = drawSephirahLabels(ctx, nodes, dims, palette, numbers, nodeRadius, sephirotRecords);
+  return { nodes: Object.keys(nodes).length, paths: edges.length };
+}
+
+function computeTreeNodes(dims, numbers) {
+  const marginY = dims.height / numbers.NINE;
+  const usableHeight = dims.height - marginY * 2;
+  const unitY = usableHeight / numbers.ONEFORTYFOUR;
+  const centreX = dims.width / 2;
+  const pillarShift = dims.width / numbers.THREE / 1.4;
   return {
-    nodes: Object.keys(nodes).length,
-    paths: paths.length,
-    labels: labelStats.labels,
-    labs: labelStats.labs
+    kether: { x: centreX, y: marginY + unitY * 0 },
+    chokmah: { x: centreX + pillarShift, y: marginY + unitY * numbers.ELEVEN },
+    binah: { x: centreX - pillarShift, y: marginY + unitY * numbers.ELEVEN },
+    daath: { x: centreX, y: marginY + unitY * (numbers.TWENTYTWO + numbers.SEVEN) },
+    chesed: { x: centreX + pillarShift, y: marginY + unitY * (numbers.THIRTYTHREE + numbers.NINE) },
+    geburah: { x: centreX - pillarShift, y: marginY + unitY * (numbers.THIRTYTHREE + numbers.NINE) },
+    tiphareth: { x: centreX, y: marginY + unitY * (numbers.THIRTYTHREE + numbers.TWENTYTWO) },
+    netzach: { x: centreX + pillarShift, y: marginY + unitY * (numbers.NINETYNINE - numbers.THREE) },
+    hod: { x: centreX - pillarShift, y: marginY + unitY * (numbers.NINETYNINE - numbers.THREE) },
+    yesod: { x: centreX, y: marginY + unitY * (numbers.ONEFORTYFOUR - numbers.THREE) },
+    malkuth: { x: centreX, y: marginY + unitY * numbers.ONEFORTYFOUR }
   };
 }
 
-/**
- * Compute pixel coordinates for the Tree-of-Life sephiroth using a covenant-ladder projection.
- *
- * Projects a 144-step vertical scale with a 33-step horizontal pillar offset to position
- * the 11 canonical sephiroth (including Daath as a centered, "hidden" node) across the canvas.
- * Positions are returned in pixels and are anchored so the two side pillars are offset from
- * center by 33 steps of a 144-step grid (keeps relative layout consistent across sizes).
- *
- * @param {{width:number,height:number}} dims - Canvas dimensions in pixels.
- * @param {Object<string,number>} numbers - Numeric constants (expects keys like ONEFORTYFOUR, THIRTYTHREE, THREE, etc.)
- * @return {Object<string,{x:number,y:number}>} Map of sephirah names to {x, y} pixel coordinates.
- */
-function buildTreeNodes(dims, numbers) {
-  const marginY = dims.height / numbers.THIRTYTHREE;
-  const innerHeight = dims.height - marginY * 2;
-  const verticalUnit = innerHeight / numbers.ONEFORTYFOUR; // 144-step descent honours the covenant ladder.
-  const centerX = dims.width / 2;
-
-  const horizontalUnit = dims.width / numbers.ONEFORTYFOUR;
-  const pillarShift = horizontalUnit * numbers.THIRTYTHREE; // 33-step shift keeps the side pillars tethered to 144.
-  const rightPillarX = centerX + pillarShift;
-  const leftPillarX = centerX - pillarShift;
-
-  const level = multiplier => marginY + verticalUnit * multiplier;
-
-  const levels = {
-    kether: 0,
-    chokmahBinah: numbers.THIRTYTHREE / numbers.THREE, // 33/3 = 11 -> supernal step anchored by 3 and 33.
-    daath: numbers.TWENTYTWO + numbers.SEVEN, // 22+7 = 29 holds the hidden gate between triads.
-    chesedGeburah: numbers.THIRTYTHREE + numbers.NINE, // 33+9 = 42 -> balanced mercy and strength.
-    tiphareth: numbers.THIRTYTHREE + numbers.TWENTYTWO, // 55 -> heart of the tree sits on 33 and 22 combined.
-    netzachHod: numbers.NINETYNINE - numbers.THREE, // 99-3 = 96 -> harmonics of 3 underpin the lower intellect/emotion pair.
-    yesod: numbers.ONEFORTYFOUR - numbers.THREE, // 144-3 = 141 anchors the foundation just above the base.
-    malkuth: numbers.ONEFORTYFOUR // full descent touches earth at 144.
-  };
-
-
-  return {
-    kether: { x: centerX, y: level(levels.kether) },
-    chokmah: { x: rightPillarX, y: level(levels.chokmahBinah) },
-    binah: { x: leftPillarX, y: level(levels.chokmahBinah) },
-    daath: { x: centerX, y: level(levels.daath) },
-    chesed: { x: rightPillarX, y: level(levels.chesedGeburah) },
-    geburah: { x: leftPillarX, y: level(levels.chesedGeburah) },
-    tiphareth: { x: centerX, y: level(levels.tiphareth) },
-    netzach: { x: rightPillarX, y: level(levels.netzachHod) },
-    hod: { x: leftPillarX, y: level(levels.netzachHod) },
-    yesod: { x: centerX, y: level(levels.yesod) },
-    malkuth: { x: centerX, y: level(levels.malkuth) }
-  };
-}
-
-/**
- * Returns the canonical Tree-of-Life connectivity as an array of node-pair paths.
- *
- * Each element is a 2-element array [from, to] of sephirot names describing a connection.
- * The list encodes the standard pathways between kether, chokmah, binah, chesed, geburah,
- * tiphareth, netzach, hod, yesod, malkuth and includes daath-related links where present.
- *
- * @return {string[][]} Array of 2-string arrays representing edges between named nodes.
- */
-function buildTreePaths() {
+function buildTreeEdges() {
   return [
     ["kether", "chokmah"],
     ["kether", "binah"],
+    ["kether", "daath"],
     ["chokmah", "binah"],
+    ["chokmah", "daath"],
     ["chokmah", "chesed"],
+    ["binah", "daath"],
     ["binah", "geburah"],
+    ["daath", "chesed"],
+    ["daath", "geburah"],
     ["chesed", "geburah"],
     ["chesed", "tiphareth"],
     ["geburah", "tiphareth"],
-    ["tiphareth", "netzach"],
-    ["tiphareth", "hod"],
+    ["chesed", "netzach"],
+    ["geburah", "hod"],
     ["netzach", "hod"],
     ["netzach", "yesod"],
     ["hod", "yesod"],
-    ["yesod", "malkuth"],
-    ["kether", "daath"],
-    ["daath", "tiphareth"],
-    ["daath", "chesed"],
-    ["daath", "geburah"],
-    ["chesed", "netzach"],
-    ["geburah", "hod"],
-    ["netzach", "malkuth"],
-    ["hod", "malkuth"]
+    ["tiphareth", "netzach"],
+    ["tiphareth", "hod"],
+    ["tiphareth", "yesod"],
+    ["yesod", "malkuth"]
   ];
 }
 
-/**
- * Draws an architectural vaulted arch and inner arc behind the Tree of Life.
- *
- * Renders a two-tiered vault (outer arch with base pillars and a smaller inner arch)
- * centered horizontally and positioned relative to the canvas height and the
- * `kether` node's y coordinate. The function temporarily adjusts canvas state,
- * stroke style, line width, and global alpha, then restores the context.
- *
- * @param {Object} dims - Rendering dimensions; must include numeric `width` and `height`.
- * @param {Object} nodes - Tree node coordinates; expects `nodes.kether.y` to position the arch vertically.
- */
-function drawTreeVault(ctx, dims, palette, numbers, nodes) {
-  ctx.save();
-  ctx.globalAlpha = 0.42;
-  ctx.strokeStyle = withAlpha(palette.layers[0], 0.7);
-  ctx.lineWidth = Math.max(1, dims.width / (numbers.ONEFORTYFOUR * 1.2));
+function drawFibonacciCurve(ctx, config) {
+  const { dims, palette, numbers } = config;
+  const fibSeq = buildFibonacci(numbers.ONEFORTYFOUR);
+  const phi = (1 + Math.sqrt(5)) / 2;
+  const centreX = dims.width * (numbers.TWENTYTWO / numbers.THIRTYTHREE);
+  const centreY = dims.height * (numbers.NINE / numbers.TWENTYTWO);
+  const targetRadius = Math.min(dims.width, dims.height) / numbers.THREE;
+  const growthPerQuarterTurn = Math.log(phi);
+  const baseRadius = targetRadius / Math.pow(phi, fibSeq.length - 1);
+  const growthPerRadian = growthPerQuarterTurn / (Math.PI / 2);
+  const thetaMax = (fibSeq.length - 1) * (Math.PI / 2);
+  const steps = numbers.THIRTYTHREE;
 
-  const baseY = dims.height * 0.88;
-  const innerBase = dims.height * 0.82;
-  const leftX = dims.width * 0.18;
-  const rightX = dims.width * 0.82;
-  const archRadius = (rightX - leftX) / 2;
-  const archCenterY = nodes.kether.y + archRadius * 0.65;
-
-  ctx.beginPath();
-  ctx.moveTo(leftX, baseY);
-  ctx.lineTo(leftX, archCenterY);
-  ctx.arc(dims.width / 2, archCenterY, archRadius, Math.PI, 0, false);
-  ctx.lineTo(rightX, baseY);
-  ctx.stroke();
-
-  ctx.beginPath();
-  ctx.moveTo(leftX + archRadius / numbers.SEVEN, innerBase);
-  ctx.lineTo(leftX + archRadius / numbers.SEVEN, archCenterY + archRadius / numbers.ELEVEN);
-  ctx.arc(dims.width / 2, archCenterY + archRadius / numbers.ELEVEN, archRadius * 0.78, Math.PI, 0, false);
-  ctx.lineTo(rightX - archRadius / numbers.SEVEN, innerBase);
-  ctx.stroke();
-  ctx.restore();
-}
-
-/**
- * Draws a vertical decorative column between the Tree-of-Life top (Kether) and bottom (Malkuth).
- *
- * Renders a filled column using a vertical gradient derived from the palette and paints a central stroked seam from `nodes.kether` down to `nodes.malkuth`.
- *
- * @param {Object} nodes - Coordinates used to position the column.
- * @param {{x: number, y: number}} nodes.kether - Top coordinate (Kether).
- * @param {{x: number, y: number}} nodes.malkuth - Bottom coordinate (Malkuth).
- */
-function drawTreeColumn(ctx, dims, palette, numbers, nodes) {
-  ctx.save();
-  const columnWidth = Math.max(dims.width / numbers.NINETYNINE, 6);
-  const gradient = ctx.createLinearGradient(nodes.kether.x, nodes.kether.y, nodes.malkuth.x, nodes.malkuth.y);
-  gradient.addColorStop(0, withAlpha(palette.layers[3], 0.36));
-  gradient.addColorStop(0.5, withAlpha(palette.layers[2], 0.18));
-  gradient.addColorStop(1, withAlpha(palette.layers[1], 0.05));
-  ctx.fillStyle = gradient;
-  ctx.fillRect(nodes.kether.x - columnWidth / 2, nodes.kether.y, columnWidth, nodes.malkuth.y - nodes.kether.y);
-
-  ctx.strokeStyle = withAlpha(palette.ink, 0.5);
-  ctx.lineWidth = Math.max(1, columnWidth / numbers.THREE);
-  ctx.beginPath();
-  ctx.moveTo(nodes.kether.x, nodes.kether.y);
-  ctx.lineTo(nodes.malkuth.x, nodes.malkuth.y);
-  ctx.stroke();
-  ctx.restore();
-}
-
-/**
- * Draws a decorative star motif centered on the provided `kether` coordinates and a vertical emphasis line.
- *
- * If `kether` is falsy the function returns without drawing.
- *
- * @param {CanvasRenderingContext2D} ctx - 2D canvas context to draw on.
- * @param {Object} dims - Canvas dimensions (expects a numeric `width`) used to scale the star.
- * @param {Object} palette - Color palette (expects `layers` array and `ink`) used for fill and stroke colors.
- * @param {Object} numbers - Numeric constants used for sizing (expects `ONEFORTYFOUR`, `THREE`, `NINE`).
- * @param {{x:number,y:number}} kether - Position where the star is centered.
- */
-function drawTreeStar(ctx, dims, palette, numbers, kether) {
-  if (!kether) {
-    return;
+  const points = [];
+  for (let i = 0; i <= steps; i += 1) {
+    const t = thetaMax * (i / steps);
+    const radius = baseRadius * Math.exp(growthPerRadian * t);
+    points.push({
+      x: centreX + Math.cos(t) * radius,
+      y: centreY + Math.sin(t) * radius
+    });
   }
+
   ctx.save();
-  const outer = Math.max(dims.width / numbers.ONEFORTYFOUR * numbers.THREE, 14);
-  const inner = outer / numbers.THREE;
-  const rays = numbers.NINE;
+  ctx.strokeStyle = withAlpha(palette.layers[4], 0.85);
+  ctx.lineWidth = Math.max(targetRadius / numbers.NINETYNINE, 2);
+  ctx.lineCap = "round";
+  ctx.lineJoin = "round";
   ctx.beginPath();
-  for (let i = 0; i < rays; i += 1) {
-    const angle = (Math.PI * 2 * i) / rays - Math.PI / 2;
-    const radius = i % 2 === 0 ? outer : inner;
-    const x = kether.x + Math.cos(angle) * radius;
-    const y = kether.y + Math.sin(angle) * radius;
-    if (i === 0) {
-      ctx.moveTo(x, y);
-    } else {
-      ctx.lineTo(x, y);
+  if (points.length > 0) {
+    ctx.moveTo(points[0].x, points[0].y);
+    for (let i = 1; i < points.length; i += 1) {
+      const prev = points[i - 1];
+      const current = points[i];
+      const midX = (prev.x + current.x) / 2;
+      const midY = (prev.y + current.y) / 2;
+      ctx.quadraticCurveTo(prev.x, prev.y, midX, midY);
     }
   }
-  ctx.closePath();
-  ctx.fillStyle = withAlpha(palette.layers[3], 0.32);
-  ctx.strokeStyle = palette.ink;
-  ctx.lineWidth = 1;
-  ctx.fill();
   ctx.stroke();
 
-  ctx.strokeStyle = withAlpha(palette.layers[4], 0.7);
-  ctx.beginPath();
-  ctx.moveTo(kether.x, kether.y - outer * 1.5);
-  ctx.lineTo(kether.x, kether.y + outer * numbers.THREE);
-  ctx.stroke();
-  ctx.restore();
-}
-
-/**
- * Draws a smooth Fibonacci-based spiral on the provided 2D canvas context and renders periodic markers along it.
- *
- * The function generates a Fibonacci sequence, maps it to 2D spiral coordinates, renders a smoothed path
- * through those points using quadratic segments, and then draws small markers along the spiral. Stroke
- * thickness and opacity are scaled relative to the canvas dimensions and numeric constants.
- *
- * @param {CanvasRenderingContext2D} ctx - 2D drawing context (canvas rendering surface).
- * @param {Object} dims - Rendering dimensions and derived layout values (expects at least width/height).
- * @param {Object} palette - Palette object providing layer colors; the spiral uses palette.layers[3].
- * @param {Object} numbers - Numeric constants used for sizing and limits (e.g., ONEFORTYFOUR, NINETYNINE).
- * @returns {{points: number}} An object containing the number of spiral points rendered (property `points`).
- */
-function drawSephirahLabels(ctx, nodes, dims, palette, numbers, nodeRadius, sephirotRecords) {
-  if (!nodes || typeof nodes !== "object") {
-    return { labels: 0, labs: 0 };
-  }
-
-  const records = Array.isArray(sephirotRecords) ? sephirotRecords : [];
-  if (records.length === 0) {
-    return { labels: 0, labs: 0 };
-  }
-
-  const map = new Map();
-  records.forEach(record => {
-    const key = canonicalKey(record.name);
-    if (key) {
-      map.set(key, record);
-    }
+  ctx.fillStyle = withAlpha(palette.layers[5], 0.9);
+  const markerRadius = Math.max(targetRadius / numbers.THIRTYTHREE, 3);
+  fibSeq.forEach((_, index) => {
+    const angle = index * (Math.PI / 2);
+    const radius = baseRadius * Math.exp(growthPerRadian * angle);
+    const px = centreX + Math.cos(angle) * radius;
+    const py = centreY + Math.sin(angle) * radius;
+    ctx.beginPath();
+    ctx.arc(px, py, markerRadius, 0, Math.PI * 2);
+    ctx.fill();
   });
 
-  const centerX = dims.width / 2;
-  const fontSize = Math.max(16, dims.width / (numbers.ONEFORTYFOUR * 0.85));
-  const labSize = Math.max(11, fontSize * 0.68);
-  const offset = nodeRadius * (numbers.THIRTYTHREE / numbers.TWENTYTWO);
-  let labels = 0;
-  let labs = 0;
-
-  ctx.save();
-  ctx.textBaseline = "middle";
-
-  for (const key of Object.keys(nodes)) {
-    const node = nodes[key];
-    if (!node) continue;
-    const canonical = canonicalKey(key);
-    const record = map.get(canonical);
-    const baseName = record ? record.name : capitaliseKey(key);
-    const numeral = record && record.numerology !== null ? ` · ${record.numerology}` : "";
-    const labelText = `${baseName}${numeral}`;
-    const align = node.x >= centerX ? "left" : "right";
-    const labelX = align === "left" ? node.x + nodeRadius + offset : node.x - nodeRadius - offset;
-    const labelY = node.y;
-
-    ctx.font = `${fontSize}px system-ui, -apple-system, Segoe UI, sans-serif`;
-    ctx.textAlign = align;
-    ctx.fillStyle = palette.ink;
-    ctx.fillText(labelText, labelX, labelY);
-    labels += 1;
-
-    if (record && record.lab) {
-      ctx.font = `${labSize}px system-ui, -apple-system, Segoe UI, sans-serif`;
-      ctx.textBaseline = "top";
-      ctx.fillStyle = palette.layers[5] || palette.ink;
-      const labLabel = record.lab.replace(/[-_]/g, " ");
-      ctx.fillText(labLabel, labelX, labelY + fontSize * 0.55);
-      ctx.textBaseline = "middle";
-      labs += 1;
-    }
-  }
-
   ctx.restore();
-  return { labels, labs };
+  return { fibonacci: fibSeq.length };
 }
 
-unction drawFibonacciCurve(ctx, dims, palette, numbers) {
-  const sequence = buildFibonacciSequence(numbers.ONEFORTYFOUR);
-  const points = buildSpiralPoints(sequence, dims, numbers);
-
-  ctx.save();
-  ctx.globalAlpha = 0.92;
-  ctx.strokeStyle = palette.layers[3];
-  ctx.lineWidth = Math.max(1.4, dims.width / numbers.NINETYNINE);
-  ctx.lineJoin = "round";
-  ctx.lineCap = "round";
-  ctx.beginPath();
-  ctx.moveTo(points[0].x, points[0].y);
-  for (let i = 1; i < points.length; i += 1) {
-    const prev = points[i - 1];
-    const current = points[i];
-    const midX = (prev.x + current.x) / 2;
-    const midY = (prev.y + current.y) / 2;
-    ctx.quadraticCurveTo(prev.x, prev.y, midX, midY);
-  }
-  ctx.stroke();
-
-  drawSpiralMarkers(ctx, points, palette, numbers);
-  ctx.restore();
-
-  return { points: points.length };
-}
-
-/**
- * Build a Fibonacci sequence starting with [1, 1], including values up to and including the largest value that does not exceed `limit`.
- * @param {number} limit - Maximum allowed value in the sequence (inclusive). Should be a finite number.
- * @returns {number[]} Fibonacci sequence beginning with [1, 1] where each element is <= `limit`.
- * If `limit` is less than 1 the function still returns the initial [1, 1].
- */
-function buildFibonacciSequence(limit) {
+function buildFibonacci(limit) {
   const seq = [1, 1];
-  while (true) {
+  while (seq[seq.length - 1] < limit) {
     const next = seq[seq.length - 1] + seq[seq.length - 2];
-    if (next > limit) {
+    seq.push(next);
+    if (next === limit) {
       break;
     }
-    seq.push(next);
+    if (next > limit) {
+      seq.pop();
+      break;
+    }
   }
   return seq;
 }
 
-/**
- * Convert a numeric sequence into 2D spiral coordinates centered on the canvas.
- *
- * Maps each value in `sequence` to a point by using a radius proportional to the square root
- * of the value and an angular progression based on a golden-angle-like step. The spiral is
- * centered horizontally at canvas midpoint and vertically at one-third from the top.
- *
- * @param {number[]} sequence - Ordered numeric sequence (e.g., Fibonacci numbers); should be non-empty and increasing so scale computation is meaningful.
- * @param {{width: number, height: number}} dims - Canvas dimensions; used to compute center and scaling.
- * @param {Object} numbers - Numeric constants object (expects properties like THREE, SEVEN, NINE, ELEVEN, TWENTYTWO) used to control scaling and angular increments.
- * @return {{x: number, y: number}[]} Array of 2D points for the spiral; the first element is the computed spiral center followed by points for each sequence value.
- */
-function buildSpiralPoints(sequence, dims, numbers) {
-  const centerX = dims.width / 2;
-  const centerY = dims.height / numbers.THREE;
-  const maxValue = sequence[sequence.length - 1];
-  const scale = Math.min(dims.width, dims.height) / (Math.sqrt(maxValue) * numbers.TWENTYTWO / numbers.ELEVEN);
-  const goldenAngle = Math.PI * 2 * (numbers.SEVEN / numbers.TWENTYTWO);
-  const rotation = Math.PI / numbers.NINE;
-
-  const points = sequence.map((value, index) => {
-    const angle = rotation + goldenAngle * index;
-    const radius = Math.sqrt(value) * scale;
-    return {
-      x: centerX + radius * Math.cos(angle),
-      y: centerY + radius * Math.sin(angle)
-    };
-  });
-
-  return [{ x: centerX, y: centerY }, ...points];
-}
-
-</**
- * Draws small filled markers at regular intervals along a list of spiral points.
- *
- * The function samples the provided points array using a step of
- * `max(1, floor(points.length / numbers.TWENTYTWO))`, draws filled circles
- * at those sampled coordinates using `palette.ink`, and sizes each marker
- * with a canvas-width–relative radius of `max(2, ctx.canvas.width / numbers.ONEFORTYFOUR / 1.8)`.
- *
- * @param {Array<{x: number, y: number}>} points - Ordered 2D points defining the spiral; markers are placed at sampled indices.
- */
-function drawSpiralMarkers(ctx, points, palette, numbers) {
-  ctx.save();
-  ctx.fillStyle = palette.ink;
-  const step = Math.max(1, Math.floor(points.length / numbers.TWENTYTWO));
-  const dotRadius = Math.max(2, ctx.canvas.width / numbers.ONEFORTYFOUR / 1.8);
-  for (let i = 0; i < points.length; i += step) {
-    const point = points[i];
-    ctx.beginPath();
-    ctx.arc(point.x, point.y, dotRadius, 0, Math.PI * 2);
-    ctx.fill();
-  }
-  ctx.restore();
-}
-
-/**
- * Render the double-helix lattice (two sinusoidal rails, connecting rungs, and endpoint anchors).
- *
- * Draws both helix rails with distinct layer colors, strokes the rung connections using the ink color,
- * renders a subtle guide and decorative anchors, and returns simple statistics about the lattice.
- *
- * @param {CanvasRenderingContext2D} ctx - 2D drawing context to render into.
- * @param {{width:number,height:number}} dims - Canvas dimensions used to scale line widths and geometry.
- * @param {{ink:string,layers:string[]}} palette - Color palette; expects `layers[4]` and `layers[5]` for the two rails and `ink` for rungs.
- * @param {Object} numbers - Numeric constants used for layout and stroke scaling (e.g., ONEFORTYFOUR).
- * @return {{rungs:number}} Object with the number of rung segments drawn.
- */
-function drawHelixLattice(ctx, dims, palette, numbers) {
->>>>>>>+main
-====
-funfunction drawHelixLattice(ctx, dims, palette, numbers, registry) {
->>>>>>>+origin/codex/ad
-onst rails = buildHelixRails(dims, numbers);
-
-  ctx.save();
-  drawHelixGuide(ctx, dims, palette, numbers);
-
-  ctx.strokeStyle = palette.layers[4];
-  ctx.lineWidth = Math.max(1.4, dims.width / numbers.ONEFORTYFOUR);
-  ctx.lineJoin = "round";
-  ctx.beginPath();
-  rails.a.forEach((point, index) => {
-    if (index === 0) {
-      ctx.moveTo(point.x, point.y);
-    } else {
-      ctx.lineTo(point.x, point.y);
-    }
-  });
-  ctx.stroke();
-
-  ctx.strokeStyle = palette.layers[5];
-  ctx.beginPath();
-  rails.b.forEach((point, index) => {
-    if (index === 0) {
-      ctx.moveTo(point.x, point.y);
-    } else {
-      ctx.lineTo(point.x, point.y);
-    }
-  });
-  ctx.stroke();
-
-  ctx.strokeStyle = palette.ink;
-  ctx.lineWidth = Math.max(1, dims.width / numbers.ONEFORTYFOUR);
-  rails.rungs.forEach(rung => {
-    ctx.beginPath();
-    ctx.moveTo(rung.a.x, rung.a.y);
-    ctx.lineTo(rung.b.x, rung.b.y);
-    ctx.stroke();
-  });
-
-<<<  drawHelixAnchors(ctx, rails, palette, numbers);
->>>>>>>+main
-====
-  c  const arcanaRecords = registry && Array.isArray(registry.arcana) ? registry.arcana : [];
-  const markerStats = drawArcanaMarkers(ctx, rails, dims, palette, numbers, arcanaRecords);
-
->>>>>>>+origin/codex/ad
-tx.restore();
-  return {
-    rungs: rails.rungs.length,
-    markers: markerStats.markers,
-    labs: markerStats.labs
-  };
-}
-
-function drawArcanaMarkers(ctx, rails, dims, palette, numbers, arcanaRecords) {
-  const records = Array.isArray(arcanaRecords) ? arcanaRecords : [];
-  if (records.length === 0) {
-    return { markers: 0, labs: 0 };
-  }
-
-  const radius = Math.max(8, dims.width / (numbers.ONEFORTYFOUR * 1.1));
-  const fontSize = Math.max(11, radius * 1.35);
-  let markers = 0;
-  let labs = 0;
-
-  ctx.save();
-  ctx.textAlign = "center";
-  ctx.textBaseline = "middle";
-  ctx.font = `${fontSize}px system-ui, -apple-system, Segoe UI, sans-serif`;
-
-  const limit = Math.min(records.length, rails.a.length);
-  for (let i = 0; i < limit; i += 1) {
-    const record = records[i];
-    if (!record || typeof record !== "object") continue;
-    const rail = i % 2 === 0 ? rails.a : rails.b;
-    const point = rail[i];
-    if (!point) continue;
-
-    const fill = i % 2 === 0 ? palette.layers[4] : palette.layers[5];
-    ctx.beginPath();
-    ctx.arc(point.x, point.y, radius, 0, Math.PI * 2);
-    ctx.fillStyle = fill;
-    ctx.fill();
-    ctx.strokeStyle = palette.ink;
-    ctx.lineWidth = Math.max(0.8, radius / 3);
-    ctx.stroke();
-
-    const numeral = typeof record.numerology === "number" && Number.isFinite(record.numerology)
-      ? record.numerology
-      : i;
-    ctx.fillStyle = palette.ink;
-    ctx.fillText(String(numeral), point.x, point.y);
-
-    if (record.lab) {
-      ctx.beginPath();
-      ctx.arc(point.x, point.y, radius * 1.35, 0, Math.PI * 2);
-      ctx.strokeStyle = palette.layers[2];
-      ctx.lineWidth = Math.max(0.6, radius / 4);
-      ctx.stroke();
-      labs += 1;
-    }
-
-    markers += 1;
-  }
-
-  ctx.restore();
-  return { markers, labs };
-}
-
-/**
- * Build two sinusoidal helix rails across the horizontal span and a list of evenly spaced rungs connecting them.
- *
- * @param {Object} dims - Rendering dimensions; must include numeric `width` and `height`.
- * @param {Object} numbers - Numeric constants used for layout; this function reads `TWENTYTWO`, `SEVEN`, `THREE`, and `ELEVEN`.
- * @return {{a: Array<{x:number,y:number}>, b: Array<{x:number,y:number}>, rungs: Array<{a:{x:number,y:number}, b:{x:number,y:number}}>} }
- * An object containing:
- * - `a`: points for rail A (array of {x,y}).
- * - `b`: points for rail B (array of {x,y}, phase-shifted from A).
- * - `rungs`: array of connections (every second index) each with `{a, b}` referencing the corresponding rail points.
- */
-function buildHelixRails(dims, numbers) {
-  const length = numbers.TWENTYTWO;
-  const startX = dims.width * 0.18;
-  const endX = dims.width * 0.82;
-  const amplitude = dims.height / numbers.SEVEN;
-  const centreY = dims.height * 0.72;
-  const phaseShift = Math.PI / numbers.THREE;
-  const step = (endX - startX) / (length - 1);
-
-  const a = [];
-  const b = [];
-  const rungs = [];
-  for (let i = 0; i < length; i += 1) {
-    const x = startX + step * i;
-    const angle = (Math.PI * 2 * i) / numbers.ELEVEN;
-    const yA = centreY + Math.sin(angle) * amplitude;
-    const yB = centreY + Math.sin(angle + phaseShift) * amplitude;
-    const pointA = { x, y: yA };
-    const pointB = { x, y: yB };
-    a.push(pointA);
-    b.push(pointB);
-    if (i % 2 === 0) {
-      rungs.push({ a: pointA, b: pointB });
-    }
-  }
-  return { a, b, rungs };
-}
-
-/**
- * Draws a subtle guide ellipse and an inner "walkway" band near the bottom-center to suggest the helix region.
- *
- * Renders a faint filled ellipse with an outline and a narrow rectangular walkway inside it. Uses
- * colors from palette.layers and sizing from numbers to compute the ellipse radii, stroke widths,
- * and walkway dimensions. Saves and restores the canvas state so calling code's context transforms
- * and styles are preserved.
- *
- * @param {CanvasRenderingContext2D} ctx - 2D canvas context to draw into.
- * @param {{width:number,height:number}} dims - Rendering dimensions; used to position and scale the guide.
- * @param {object} palette - Palette object; expects a layers array where specific indices provide fill/ink colors.
- * @param {object} numbers - Numeric constants (e.g. THREE, TWENTYTWO, ELEVEN, ONEFORTYFOUR) used for layout math.
- */
-function drawHelixGuide(ctx, dims, palette, numbers) {
-  ctx.save();
+function drawHelixLattice(ctx, config) {
+  const { dims, palette, numbers } = config;
   const centreX = dims.width / 2;
-  const baseY = dims.height * 0.86;
-  const radiusX = dims.width / numbers.THREE;
-  const radiusY = dims.height / numbers.TWENTYTWO;
+  const top = dims.height / numbers.NINE;
+  const bottom = dims.height - dims.height / numbers.NINE;
+  const railSpread = dims.width / numbers.SEVEN;
+  const amplitude = railSpread / numbers.ELEVEN;
+  const steps = numbers.TWENTYTWO;
 
-  ctx.fillStyle = withAlpha(palette.layers[1], 0.08);
-  ctx.beginPath();
-  ctx.ellipse(centreX, baseY, radiusX, radiusY, 0, 0, Math.PI * 2);
-  ctx.fill();
+  const leftPoints = [];
+  const rightPoints = [];
+  for (let i = 0; i <= steps; i += 1) {
+    const t = i / steps;
+    const y = top + (bottom - top) * t;
+    const angle = Math.PI * numbers.THREE * t;
+    const offset = Math.sin(angle) * amplitude;
+    leftPoints.push({ x: centreX - railSpread / 2 + offset, y });
+    rightPoints.push({ x: centreX + railSpread / 2 - offset, y });
+  }
 
-  ctx.strokeStyle = withAlpha(palette.layers[0], 0.5);
-  ctx.lineWidth = Math.max(1, dims.width / numbers.ONEFORTYFOUR);
+  ctx.save();
+  ctx.strokeStyle = withAlpha(palette.layers[0], 0.65);
+  ctx.lineWidth = Math.max(dims.width / numbers.ONEFORTYFOUR, 2);
+  ctx.lineCap = "round";
+  tracePolyline(ctx, leftPoints);
+  tracePolyline(ctx, rightPoints);
+
+  ctx.strokeStyle = withAlpha(palette.layers[3], 0.55);
+  ctx.lineWidth = Math.max(dims.width / numbers.ONEFORTYFOUR, 1.5);
+  for (let i = 0; i <= steps; i += 1) {
+    if (i % 2 === 0) {
+      const left = leftPoints[i];
+      const right = rightPoints[i];
+      ctx.beginPath();
+      ctx.moveTo(left.x, left.y);
+      ctx.lineTo(right.x, right.y);
+      ctx.stroke();
+    }
+  }
+
+  ctx.fillStyle = withAlpha(palette.layers[5], 0.8);
+  const nodeRadius = Math.max(dims.width / numbers.NINETYNINE, 4);
+  for (let i = 0; i <= steps; i += 1) {
+    const target = i % 2 === 0 ? leftPoints[i] : rightPoints[i];
+    ctx.beginPath();
+    ctx.arc(target.x, target.y, nodeRadius, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  ctx.strokeStyle = withAlpha(palette.ink, 0.35);
+  ctx.lineWidth = Math.max(dims.width / numbers.ONEFORTYFOUR, 1.2);
   ctx.beginPath();
-  ctx.ellipse(centreX, baseY, radiusX, radiusY, 0, 0, Math.PI * 2);
+  ctx.moveTo(centreX - railSpread / 1.8, bottom + nodeRadius * 1.8);
+  ctx.lineTo(centreX + railSpread / 1.8, bottom + nodeRadius * 1.8);
   ctx.stroke();
 
-  const walkwayWidth = radiusX * (numbers.TWENTYTWO / numbers.ELEVEN);
-  const walkwayHeight = dims.height / numbers.TWENTYTWO;
-  ctx.fillStyle = withAlpha(palette.layers[4], 0.08);
-  ctx.fillRect(centreX - walkwayWidth / 2, baseY - walkwayHeight, walkwayWidth, walkwayHeight);
-  ctx.strokeStyle = withAlpha(palette.layers[0], 0.35);
-  ctx.lineWidth = Math.max(1, dims.width / numbers.ONEFORTYFOUR);
-  ctx.strokeRect(centreX - walkwayWidth / 2, baseY - walkwayHeight, walkwayWidth, walkwayHeight);
   ctx.restore();
+  return { strands: 2, rungs: Math.floor(steps / 2) + 1 };
 }
 
-/**
- * Draws decorative diamond anchors at the start and end points of the two helix rails.
- *
- * Uses the first and last points of rails.a and rails.b (if present) to render small
- * filled-and-stroked diamond markers. Marker size scales with canvas width and
- * falls back to a minimum radius. Stroke uses `palette.ink` at 70% alpha; fill uses
- * the helix layer color (palette.layers[3]) at 18% alpha.
- *
- * @param {{a: Array<{x:number,y:number}>, b: Array<{x:number,y:number}>}} rails - Rail point arrays; anchors are taken from the first and last elements of each array.
- * @param {{ink:string, layers:string[]}} palette - Colour palette; expects an `ink` string and a `layers` array containing the helix layer at index 3.
- * @param {{ONEFORTYFOUR:number}} numbers - Numeric constants object; used to compute a responsive marker radius.
- */
-function drawHelixAnchors(ctx, rails, palette, numbers) {
-  ctx.save();
-  const anchors = [rails.a[0], rails.a[rails.a.length - 1], rails.b[0], rails.b[rails.b.length - 1]];
-  const radius = Math.max(4, ctx.canvas.width / numbers.ONEFORTYFOUR);
-  ctx.strokeStyle = withAlpha(palette.ink, 0.7);
-  ctx.fillStyle = withAlpha(palette.layers[3], 0.18);
-  anchors.forEach(point => {
-    if (!point) {
-      return;
-    }
-    ctx.beginPath();
-    ctx.moveTo(point.x, point.y - radius);
-    ctx.lineTo(point.x + radius, point.y);
-    ctx.lineTo(point.x, point.y + radius);
-    ctx.lineTo(point.x - radius, point.y);
-    ctx.closePath();
-    ctx.fill();
-    ctx.stroke();
-  });
-  ctx.restore();
+function tracePolyline(ctx, points) {
+  if (points.length === 0) {
+    return;
+  }
+  ctx.beginPath();
+  ctx.moveTo(points[0].x, points[0].y);
+  for (let i = 1; i < points.length; i += 1) {
+    ctx.lineTo(points[i].x, points[i].y);
+  }
+  ctx.stroke();
 }
 
-/**
- * Draws a centered notice line near the bottom of the canvas.
- *
- * Renders `message` horizontally centered and positioned just above the bottom edge using a responsive font size derived from `dims.width`. The function saves and restores the canvas context so it does not leave side effects on drawing state.
- *
- * @param {{width: number, height: number}} dims - Canvas dimensions used to compute position and font size.
- * @param {string} color - CSS color string for the text fill.
- * @param {string} message - The text to render.
- */
-function drawCanvasNotice(ctx, dims, color, message) {
+function drawCanvasNotice(ctx, config) {
+  const { width, height } = config.dims;
   ctx.save();
-  ctx.fillStyle = color;
-  ctx.font = `${Math.max(14, dims.width / 72)}px system-ui, -apple-system, Segoe UI, sans-serif`;
+  ctx.fillStyle = withAlpha(config.palette.ink, 0.72);
+  ctx.font = `${Math.max(width / config.numbers.ONEFORTYFOUR * 3.2, 12)}px/1.2 "Georgia", serif`;
   ctx.textAlign = "center";
-  ctx.fillText(message, dims.width / 2, dims.height - dims.height / 40);
+  ctx.fillText(config.notice, width / 2, height - height / config.numbers.ELEVEN);
   ctx.restore();
 }
 
-<<</**
- * Create a human-readable summary of rendered layer statistics.
- *
- * Builds a single-line summary describing counts returned by each layer renderer:
- * vesica circle count, tree paths/nodes, fibonacci spiral points, and helix rungs.
- *
- * @param {Object} stats - Aggregated layer statistics.
- * @param {Object} stats.vesicaStats - Vesica layer stats.
- * @param {number} stats.vesicaStats.circles - Number of vesica circles drawn.
- * @param {Object} stats.treeStats - Tree-of-life layer stats.
- * @param {number} stats.treeStats.paths - Number of tree paths drawn.
- * @param {number} stats.treeStats.nodes - Number of tree nodes drawn.
- * @param {Object} stats.fibonacciStats - Fibonacci/spiral layer stats.
- * @param {number} stats.fibonacciStats.points - Number of spiral points drawn.
- * @param {Object} stats.helixStats - Helix layer stats.
- * @param {number} stats.helixStats.rungs - Number of helix rungs drawn.
- * @return {string} A single-line summary suitable for logs or UI.
- */
-function summariseLayers(stats) {
->>>>>>>+main
-====
-function summariseLayers(stats, registry) {
->>>>>>> origin/codex/add-arcana-and-sephirah-lore-data
-  const vesica = `${stats.vesicaStats.circles} vesica circles`;
-  const treeBase = `${stats.treeStats.paths} paths / ${stats.treeStats.nodes} nodes`;
-  const treeLabels = stats.treeStats.labels > 0 ? ` / ${stats.treeStats.labels} labels` : "";
-  const treeLabs = stats.treeStats.labs > 0 ? ` (${stats.treeStats.labs} labs)` : "";
-  const tree = `${treeBase}${treeLabels}${treeLabs}`;
-  const fibonacci = `${stats.fibonacciStats.points} spiral points`;
-  let helix = `${stats.helixStats.rungs} helix rungs`;
-  if (stats.helixStats.markers > 0) {
-    helix += ` / ${stats.helixStats.markers} arcana markers`;
-  }
-  if (stats.helixStats.labs > 0) {
-    helix += ` (${stats.helixStats.labs} lab rings)`;
-  }
-  const arcanaCount = registry && Array.isArray(registry.arcana) ? registry.arcana.length : 0;
-  const sephirotCount = registry && Array.isArray(registry.sephirot) ? registry.sephirot.length : 0;
-  const registryNote = `registry ${arcanaCount} arcana, ${sephirotCount} sephirot`;
-  return `Layers rendered - ${vesica}; ${tree}; ${fibonacci}; ${helix}; ${registryNote}.`;
+function summariseLayers(vesica, tree, fib, helix) {
+  return [
+    `vesica ${vesica.circles} arcs`,
+    `tree ${tree.nodes} nodes/${tree.paths} paths`,
+    `fibonacci ${fib.fibonacci} markers`,
+    `helix ${helix.rungs} rungs`
+  ].join(" · ");
 }
 
-/**
- * Convert a 6-digit hex color to an `rgba(...)` string with the given alpha.
- *
- * Accepts a hex string with or without a leading `#`. If `hex` is not a valid
- * 6-character hex code the function returns `rgba(0,0,0,alpha)`.
- *
- * @param {string} hex - A 6-digit hex color (e.g. `"#ffddaa"` or `"ffddaa"`).
- * @param {number} alpha - Alpha transparency between 0 and 1.
- * @return {string} An `rgba(r,g,b,a)` CSS color string.
- */
 function withAlpha(hex, alpha) {
-  const normalized = typeof hex === "string" ? hex.replace(/^#/, "") : "";
-  if (normalized.length !== 6) {
-    return `rgba(0,0,0,${alpha})`;
+  if (!/^#?[0-9a-fA-F]{6}$/.test(hex)) {
+    return hex;
   }
-  const r = parseInt(normalized.slice(0, 2), 16);
-  const g = parseInt(normalized.slice(2, 4), 16);
-  const b = parseInt(normalized.slice(4, 6), 16);
-  return `rgba(${r},${g},${b},${alpha})`;
+  const value = hex.replace("#", "");
+  const r = parseInt(value.slice(0, 2), 16);
+  const g = parseInt(value.slice(2, 4), 16);
+  const b = parseInt(value.slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }


### PR DESCRIPTION
## Summary
- rebuild the offline index shell with palette fallbacks, numerology constants, and render summary messaging
- replace the helix renderer module with layered vesica, tree-of-life, fibonacci, and helix helpers that stay ND-safe
- refresh the renderer README to document usage, numerology anchors, and palette overrides

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cde6636f2c83289f0cec1b967ce365

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Offline-first palette loading with automatic fallback.
  - Palette customization support with clear defaults.
- Improvements
  - Single static render on load; simplified four-layer renderer.
  - Cleaner UI: consolidated header, canvas, and streamlined status messages.
  - Standardized spacing, typography, and color tokens for consistency.
- Documentation
  - Overhauled README: offline usage guide, “Files delivered,” and clearer failure/fallback behavior.
  - Added “Numerology anchors” and “Palette customization” sections with examples.
  - Expanded ND-safety rationale and accessibility guidance.
- Bug Fixes
  - Removed duplicate elements and dead paths that could cause confusion during loading and rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->