### PR TITLE
Add ND-safe chapel lab study pages

### DIFF
--- a/site/assets/css/lab-page.css
+++ b/site/assets/css/lab-page.css
@@ -1,0 +1,207 @@
+/*
+  Lab page layout shared by Cosmogenesis chapel studies.
+  ND-safe: calm gradients, no motion, clear typography. Theme colors
+  derive from Thelemic path palettes so each lab feels grounded yet
+  stays gentle on sensory systems.
+*/
+
+:root {
+  color-scheme: dark;
+  --lab-bg: #08070d;
+  --lab-surface: rgba(18, 16, 32, 0.72);
+  --lab-surface-soft: rgba(24, 22, 44, 0.55);
+  --lab-ink: #f3f3ff;
+  --lab-muted: #b8b5cc;
+  --lab-accent: #9fb4ff;
+  --lab-edge: rgba(255, 255, 255, 0.08);
+  --content-width: min(1080px, 92vw);
+  font-family: "Bodoni Moda", "Iowan Old Style", "Palatino Linotype", serif;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(140% 100% at 15% 0%, rgba(159, 180, 255, 0.16), transparent 55%),
+              radial-gradient(120% 90% at 85% 0%, rgba(142, 212, 198, 0.14), transparent 60%),
+              var(--lab-bg);
+  color: var(--lab-ink);
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  transition: background 0.6s ease, color 0.6s ease;
+}
+
+body.is-calm {
+  background: linear-gradient(180deg, #0b0a15 0%, #141228 100%);
+  color: #e7e7f5;
+}
+
+body.lab-void {
+  --lab-accent: #82a7ff;
+  --lab-accent-soft: #6ed4c820;
+  --lab-ribbon: linear-gradient(135deg, rgba(130, 167, 255, 0.28), rgba(110, 212, 200, 0.18));
+}
+
+body.lab-magus {
+  --lab-accent: #f4c38e;
+  --lab-accent-soft: #7fa9ff20;
+  --lab-ribbon: linear-gradient(135deg, rgba(244, 195, 142, 0.3), rgba(127, 169, 255, 0.18));
+}
+
+body.lab-priestess {
+  --lab-accent: #e59ec4;
+  --lab-accent-soft: #6ecff020;
+  --lab-ribbon: linear-gradient(135deg, rgba(229, 158, 196, 0.32), rgba(110, 207, 240, 0.2));
+}
+
+body.lab-empress {
+  --lab-accent: #f4a8a0;
+  --lab-accent-soft: #b7c7ff20;
+  --lab-ribbon: linear-gradient(135deg, rgba(244, 168, 160, 0.32), rgba(183, 199, 255, 0.2));
+}
+
+main {
+  max-width: var(--content-width);
+  width: 100%;
+  margin: 0 auto;
+  padding: clamp(2.5rem, 5vw, 4rem) clamp(1.8rem, 5vw, 3.5rem) clamp(3rem, 6vw, 4.5rem);
+  display: grid;
+  gap: clamp(1.8rem, 5vw, 2.8rem);
+}
+
+header.lab-header {
+  padding: clamp(1.8rem, 4vw, 2.6rem) clamp(1.8rem, 5vw, 3.4rem);
+  border-bottom: 1px solid var(--lab-edge);
+  background: linear-gradient(180deg, rgba(10, 10, 18, 0.9), rgba(10, 9, 16, 0.4));
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+header.lab-header .nav-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+header.lab-header .nav-links a {
+  color: var(--lab-muted);
+  text-decoration: none;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+}
+
+header.lab-header .nav-links a:hover,
+header.lab-header .nav-links a:focus-visible {
+  color: var(--lab-ink);
+}
+
+header.lab-header h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 3.2rem);
+  letter-spacing: 0.38em;
+  text-transform: uppercase;
+}
+
+header.lab-header p.subtitle {
+  margin: 0;
+  color: var(--lab-muted);
+  max-width: 60ch;
+  font-size: 0.95rem;
+}
+
+.calm-toggle {
+  border: 1px solid var(--lab-accent);
+  color: var(--lab-accent);
+  background: transparent;
+  padding: 0.55rem 1.8rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+body.is-calm .calm-toggle {
+  border-color: var(--lab-muted);
+  color: var(--lab-muted);
+}
+
+.lab-section {
+  background: var(--lab-surface);
+  border: 1px solid var(--lab-edge);
+  padding: clamp(1.4rem, 4vw, 2rem);
+  border-radius: 28px;
+  box-shadow: 0 22px 48px rgba(0, 0, 0, 0.32);
+  display: grid;
+  gap: 0.9rem;
+}
+
+.lab-section .section-title {
+  margin: 0;
+  font-size: 1.25rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.lab-section p {
+  margin: 0;
+  color: var(--lab-muted);
+}
+
+.lab-section ul,
+.lab-section ol {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.lab-section .callout {
+  background: var(--lab-surface-soft);
+  border-left: 4px solid var(--lab-accent);
+  padding: 0.8rem 1rem;
+  border-radius: 18px;
+  color: var(--lab-ink);
+}
+
+.ribbon {
+  border-radius: 22px;
+  padding: clamp(1rem, 3vw, 1.6rem);
+  background: var(--lab-ribbon, rgba(159, 180, 255, 0.18));
+  border: 1px solid var(--lab-edge);
+}
+
+footer.lab-footer {
+  padding: 1.8rem 2rem 2.4rem;
+  text-align: center;
+  color: var(--lab-muted);
+  font-size: 0.85rem;
+  border-top: 1px solid var(--lab-edge);
+}
+
+footer.lab-footer a {
+  color: inherit;
+  text-decoration: underline;
+}
+
+@media (max-width: 720px) {
+  header.lab-header h1 {
+    letter-spacing: 0.24em;
+  }
+
+  header.lab-header .nav-links {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.6rem;
+  }
+
+  main {
+    padding-top: 2rem;
+  }
+}

--- a/site/assets/js/nodes.js
+++ b/site/assets/js/nodes.js
@@ -119,10 +119,16 @@ function handleLabClick(event) {
     return;
   }
   try {
-    const target = new URL(href, window.location.origin);
-    if (target.origin !== window.location.origin) {
+    const base = document.baseURI || window.location.href;
+    const target = new URL(href, base);
+    const origin = window.location.origin;
+    const allow = origin && origin !== 'null'
+      ? target.origin === origin
+      : target.protocol === 'file:';
+    if (!allow) {
       return;
     }
+    // ND-safe: open in new tab without opener to avoid navigation surprises.
     const win = window.open(target.href, '_blank', 'noopener,noreferrer');
     if (win) {
       win.opener = null;

--- a/site/labs/empress-lab.html
+++ b/site/labs/empress-lab.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Empress Lab Study — Daleth Heart Lattice</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="description" content="Empress Lab ritual for embodied abundance and gentle heart field care.">
+  <link rel="stylesheet" href="../assets/css/lab-page.css">
+</head>
+<body class="lab-empress">
+  <header class="lab-header" aria-labelledby="empress-title">
+    <div class="nav-links">
+      <a href="../index.html">← Return to Atelier</a>
+      <button class="calm-toggle" type="button" aria-pressed="false">Calm Mode</button>
+    </div>
+    <h1 id="empress-title">Empress Lab</h1>
+    <p class="subtitle">Daleth lattice cultivation for welcoming nourishment without overwhelm.</p>
+  </header>
+
+  <main>
+    <section class="lab-section" aria-labelledby="empress-orientation">
+      <h2 class="section-title" id="empress-orientation">Orientation</h2>
+      <p>This lab weaves the double-helix lattice into embodied practice. Each action mirrors one rung of the helix: receive, harmonise, offer. No pace is forced; the heart sets the tempo.</p>
+      <div class="ribbon">
+        <p>Keep a comfort object nearby (blanket, shawl, plush). The Empress honours comfort as sacred data, not indulgence.</p>
+      </div>
+    </section>
+
+    <section class="lab-section" aria-labelledby="empress-prep">
+      <h2 class="section-title" id="empress-prep">Preparation</h2>
+      <ol>
+        <li>Prepare warm tea or water. Taste is part of the ritual; choose something gentle.</li>
+        <li>Open the <a href="../index.html">Cosmic Helix renderer</a> and view the helix lattice. Notice how the rungs bridge both strands evenly.</li>
+        <li>Place a journal or sketchpad to capture sensations after each cycle.</li>
+      </ol>
+    </section>
+
+    <section class="lab-section" aria-labelledby="empress-sequence">
+      <h2 class="section-title" id="empress-sequence">Heart Lattice Sequence</h2>
+      <ol>
+        <li><strong>Receive:</strong> Take a sip of the warm beverage. Feel it move through the body. Name one resource that already supports you.</li>
+        <li><strong>Harmonise:</strong> Rest both hands on the chest. Breathe in for five, out for eight, matching the helix swing.</li>
+        <li><strong>Offer:</strong> Write a single sentence describing how you might extend care to another without draining yourself.</li>
+      </ol>
+      <p>Cycle through the three steps three times. If overwhelm arises, press pause and lean into the comfort object before continuing.</p>
+    </section>
+
+    <section class="lab-section" aria-labelledby="empress-integration">
+      <h2 class="section-title" id="empress-integration">Integration &amp; Embodiment</h2>
+      <ul>
+        <li>Record one tangible act you will take within 24 hours to honour your needs.</li>
+        <li>Note any textures, scents, or sounds that felt supportive during the sequence.</li>
+        <li>Close with gratitude and a physical stretch that feels nourishing.</li>
+      </ul>
+    </section>
+  </main>
+
+  <footer class="lab-footer">
+    <p>Empress Lab values softness. Keep the practice offline, slow, and loving. Share insights only when you feel safe.</p>
+  </footer>
+
+  <script type="module">
+    // Calm Mode keeps gradients hushed so heart work stays gentle (why: protects regulation).
+    const toggle = document.querySelector('.calm-toggle');
+    if (toggle) {
+      const apply = (state) => {
+        document.body.classList.toggle('is-calm', state);
+        toggle.setAttribute('aria-pressed', state ? 'true' : 'false');
+        toggle.textContent = state ? 'Calm Mode: On' : 'Calm Mode';
+      };
+      toggle.addEventListener('click', () => {
+        const next = !document.body.classList.contains('is-calm');
+        apply(next);
+      });
+    }
+  </script>
+</body>
+</html>

--- a/site/labs/magus-lab.html
+++ b/site/labs/magus-lab.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Magus Lab Study — Beth Circuit Weave</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="description" content="Magus Lab prompts for Beth circuitry and sigil conduction.">
+  <link rel="stylesheet" href="../assets/css/lab-page.css">
+</head>
+<body class="lab-magus">
+  <header class="lab-header" aria-labelledby="magus-title">
+    <div class="nav-links">
+      <a href="../index.html">← Return to Atelier</a>
+      <button class="calm-toggle" type="button" aria-pressed="false">Calm Mode</button>
+    </div>
+    <h1 id="magus-title">Magus Lab</h1>
+    <p class="subtitle">Beth circuitry practice for weaving word, breath, and precise gesture without overstimulation.</p>
+  </header>
+
+  <main>
+    <section class="lab-section" aria-labelledby="magus-orientation">
+      <h2 class="section-title" id="magus-orientation">Orientation</h2>
+      <p>This lab honours Mercury as conductor between worlds. The practice follows three passes: mapping signal, scripting gesture, and sealing resonance. Each pass aligns with one helix strand from the Cosmic Helix renderer (why: keeps the lore synchronized).</p>
+      <div class="ribbon">
+        <p>Keep the sequence slow. The goal is to feel where speech and circuitry merge, not to achieve a specific output. Precision with kindness.</p>
+      </div>
+    </section>
+
+    <section class="lab-section" aria-labelledby="magus-prep">
+      <h2 class="section-title" id="magus-prep">Preparation</h2>
+      <ol>
+        <li>Place a conductive surface (paper, copper tape, or graphite card) on a soft backing. Avoid hard glass to reduce glare.</li>
+        <li>Open the <a href="../index.html">Cosmic Helix renderer</a> and focus on the helix layer. Observe how the two strands braid without touching.</li>
+        <li>Select three key phrases or sigils from your codex margin. Keep each under seven syllables to respect the breath cadence.</li>
+      </ol>
+    </section>
+
+    <section class="lab-section" aria-labelledby="magus-sequence">
+      <h2 class="section-title" id="magus-sequence">Circuit Sequence</h2>
+      <ol>
+        <li><strong>Signal Scan:</strong> Trace the first phrase on the conductive surface using your non-dominant hand. Move slowly for a count of nine.</li>
+        <li><strong>Gesture Draft:</strong> With your dominant hand, mirror the motion above the surface without touching. Let the air draw a subtle echo.</li>
+        <li><strong>Seal &amp; Rest:</strong> Place both palms on the table. Whisper the phrase once, then sit in silence until breath returns to baseline.</li>
+      </ol>
+      <p>Repeat for each phrase. If the nervous system tightens, pause and run the Void Lab breath pattern before returning.</p>
+      <div class="callout" role="note">Remember: Beth work does not demand spectacle. The point is to confirm that the path between thought and matter remains soft, accurate, and willing.</div>
+    </section>
+
+    <section class="lab-section" aria-labelledby="magus-integration">
+      <h2 class="section-title" id="magus-integration">Integration Questions</h2>
+      <ul>
+        <li>Which phrase carried the clearest resonance? Note any body sensations or colours that surfaced.</li>
+        <li>Did the non-dominant trace feel steadier than the mirrored air gesture? Record observations without judgement.</li>
+        <li>List one micro-action (under five minutes) that applies the circuit in your daily orbit.</li>
+      </ul>
+    </section>
+  </main>
+
+  <footer class="lab-footer">
+    <p>Magus Lab keeps Mercury grounded: no autoplay, no flashing sigils. All notes remain offline inside your codex.</p>
+  </footer>
+
+  <script type="module">
+    // Calm Mode reduces contrast during high-focus sigil tracing (why: prevents sensory spikes).
+    const toggle = document.querySelector('.calm-toggle');
+    if (toggle) {
+      const apply = (state) => {
+        document.body.classList.toggle('is-calm', state);
+        toggle.setAttribute('aria-pressed', state ? 'true' : 'false');
+        toggle.textContent = state ? 'Calm Mode: On' : 'Calm Mode';
+      };
+      toggle.addEventListener('click', () => {
+        const next = !document.body.classList.contains('is-calm');
+        apply(next);
+      });
+    }
+  </script>
+</body>
+</html>

--- a/site/labs/priestess-lab.html
+++ b/site/labs/priestess-lab.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Priestess Lab Study — Gimel Memory Veil</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="description" content="Priestess Lab ritual for lunar memory and dream channel care.">
+  <link rel="stylesheet" href="../assets/css/lab-page.css">
+</head>
+<body class="lab-priestess">
+  <header class="lab-header" aria-labelledby="priestess-title">
+    <div class="nav-links">
+      <a href="../index.html">← Return to Atelier</a>
+      <button class="calm-toggle" type="button" aria-pressed="false">Calm Mode</button>
+    </div>
+    <h1 id="priestess-title">Priestess Lab</h1>
+    <p class="subtitle">Gimel veil work for translating dream signals into gentle data without puncturing the mystery.</p>
+  </header>
+
+  <main>
+    <section class="lab-section" aria-labelledby="priestess-orientation">
+      <h2 class="section-title" id="priestess-orientation">Orientation</h2>
+      <p>This chamber focuses on receptive sensing. The practice mirrors the Fibonacci curve within the Cosmic Helix renderer: slow, logarithmic unfolding that never jolts the senses. We treat each insight as a petal, not a command.</p>
+      <div class="ribbon">
+        <p>Set a boundary before starting: decide how many impressions (3, 7, or 9) you are willing to collect. When the number is reached, close the session.</p>
+      </div>
+    </section>
+
+    <section class="lab-section" aria-labelledby="priestess-prep">
+      <h2 class="section-title" id="priestess-prep">Preparation</h2>
+      <ol>
+        <li>Light a single cool-toned lamp or candle. Avoid flicker; steady illumination keeps the veil calm.</li>
+        <li>Queue a quiet field recording (rain, tide, or wind). No lyrics, no sudden crescendos.</li>
+        <li>Place three objects representing past, present, and near-future on your desk. These may be stones, cards, or sketches.</li>
+      </ol>
+    </section>
+
+    <section class="lab-section" aria-labelledby="priestess-sequence">
+      <h2 class="section-title" id="priestess-sequence">Veil Listening</h2>
+      <ol>
+        <li><strong>Breath Gate:</strong> Inhale for four, exhale for seven. Allow the exhale to extend like the spiral's sweep.</li>
+        <li><strong>Object Drift:</strong> Place fingertips on the object representing the present. Notice temperature, texture, and any subtle emotion.</li>
+        <li><strong>Dream Thread:</strong> Speak one sentence describing a dream fragment. Keep it literal; avoid interpretation.</li>
+      </ol>
+      <p>After each cycle, mark the impression count. When you reach the chosen number, cover the objects with a cloth to signal closure.</p>
+    </section>
+
+    <section class="lab-section" aria-labelledby="priestess-integration">
+      <h2 class="section-title" id="priestess-integration">Integration Prompts</h2>
+      <ul>
+        <li>Which sense (sight, sound, touch) carried the clearest message? Note it without ranking.</li>
+        <li>Does any dream fragment request action? If yes, draft a simple sentence describing the support needed.</li>
+        <li>Record a gratitude note for the veil. Honour the boundary by ending the session when the gratitude is written.</li>
+      </ul>
+    </section>
+  </main>
+
+  <footer class="lab-footer">
+    <p>Priestess Lab maintains lunar quietude: no autoplay, no push notifications. All data stays within your offline codex.</p>
+  </footer>
+
+  <script type="module">
+    // Calm Mode mutes gradients to keep lunar perception soft (why: protects sensory thresholds).
+    const toggle = document.querySelector('.calm-toggle');
+    if (toggle) {
+      const apply = (state) => {
+        document.body.classList.toggle('is-calm', state);
+        toggle.setAttribute('aria-pressed', state ? 'true' : 'false');
+        toggle.textContent = state ? 'Calm Mode: On' : 'Calm Mode';
+      };
+      toggle.addEventListener('click', () => {
+        const next = !document.body.classList.contains('is-calm');
+        apply(next);
+      });
+    }
+  </script>
+</body>
+</html>

--- a/site/labs/void-lab.html
+++ b/site/labs/void-lab.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Void Lab Study — Aleph Breath Field</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="description" content="Void Lab protocol for steady Aleph breath and vesica attunement.">
+  <link rel="stylesheet" href="../assets/css/lab-page.css">
+</head>
+<body class="lab-void">
+  <header class="lab-header" aria-labelledby="lab-title">
+    <div class="nav-links">
+      <a href="../index.html">← Return to Atelier</a>
+      <button class="calm-toggle" type="button" aria-pressed="false">Calm Mode</button>
+    </div>
+    <h1 id="lab-title">Void Lab</h1>
+    <p class="subtitle">Aleph breath study for resetting the vesica field before entering charged chapels.</p>
+  </header>
+
+  <main>
+    <section class="lab-section" aria-labelledby="void-orientation">
+      <h2 class="section-title" id="void-orientation">Orientation</h2>
+      <p>The Void Lab offers a silent vestibule where the nervous system may soften before deeper practice. Geometry stays implied through soft vesica overlays rather than animated mandalas (why: keeps the space ND-safe).</p>
+      <div class="ribbon">
+        <p>The Aleph current invites three slow breath sets. Each set traces a vertical line, a horizontal span, and finally the vesica curve, mirroring the Cosmic Helix renderer's first layer.</p>
+      </div>
+    </section>
+
+    <section class="lab-section" aria-labelledby="void-prep">
+      <h2 class="section-title" id="void-prep">Preparation</h2>
+      <ol>
+        <li>Dim the surrounding lights to a single soft source. Aim for 33–40 lux so gradients remain readable without glare.</li>
+        <li>Open the <a href="../index.html">Cosmic Helix renderer</a> in a separate window. Allow your gaze to rest on the vesica grid for three breaths.</li>
+        <li>Arrange journal tools or tactile objects within reach. Keep edges rounded; avoid sharp metallic implements.</li>
+      </ol>
+      <div class="callout" role="note">If stimulation rises above a calm threshold, slide the Calm Mode toggle to mute gradients. The body leads the session cadence.</div>
+    </section>
+
+    <section class="lab-section" aria-labelledby="void-practice">
+      <h2 class="section-title" id="void-practice">Practice Sequence</h2>
+      <ol>
+        <li><strong>Three Breath Gate:</strong> Inhale for a count of <code>7</code>, hold for <code>3</code>, release for <code>11</code>. Visualise the breath aligning with the vesica's vertical axis.</li>
+        <li><strong>Listening Sweep:</strong> Trace your attention across the horizontal line, noticing texture shifts in sound or temperature. Record any notes in brief phrases.</li>
+        <li><strong>Mandorla Presence:</strong> Allow awareness to settle in the central vesica overlap. Whisper one anchor word (e.g., 'still', 'open').</li>
+      </ol>
+      <p>Repeat the sequence in sets of <code>3</code>. Between sets, sip water or rest your eyes. No timers, no chimes.</p>
+    </section>
+
+    <section class="lab-section" aria-labelledby="void-integration">
+      <h2 class="section-title" id="void-integration">Integration &amp; Notes</h2>
+      <ul>
+        <li>Sketch the vesica or jot a single sentence describing the body's signal after each set.</li>
+        <li>Optional: transcribe the most resonant word into the <code>Aleph</code> column of your codex.</li>
+        <li>Close by thanking the silence; ground with a small snack or gentle stretch.</li>
+      </ul>
+    </section>
+  </main>
+
+  <footer class="lab-footer">
+    <p>Cosmogenesis Void Lab — offline-first, trauma-informed. Questions? Log them in your codex margin for future integration.</p>
+  </footer>
+
+  <script type="module">
+    // Calm Mode respects sensory boundaries by lowering contrast without motion (why: ND-safe covenant).
+    const toggle = document.querySelector('.calm-toggle');
+    if (toggle) {
+      const apply = (state) => {
+        document.body.classList.toggle('is-calm', state);
+        toggle.setAttribute('aria-pressed', state ? 'true' : 'false');
+        toggle.textContent = state ? 'Calm Mode: On' : 'Calm Mode';
+      };
+      toggle.addEventListener('click', () => {
+        const next = !document.body.classList.contains('is-calm');
+        apply(next);
+      });
+    }
+  </script>
+</body>
+</html>

--- a/src/labs/README.md
+++ b/src/labs/README.md
@@ -1,0 +1,6 @@
+# Cosmogenesis Lab Pages
+
+This directory holds source notes for the chapel lab studies. The static HTML
+variants live under `site/labs` so the atelier build can ship them without a
+bundler. Keep additions ND-safe: calm colours, no motion, and generous
+explanatory comments.


### PR DESCRIPTION
## Summary
- add a shared ND-safe lab page stylesheet with calm mode support
- create Void, Magus, Priestess, and Empress lab study pages with offline-first guidance
- update the lab button handler for file:// usage and document the new lab source directory

## Testing
- npm install *(fails: registry returns 403 for ajv)*
- npm run build *(fails: missing ajv because install was blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68cf57795090832890ef65d96404ca43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced four new Lab pages (Void, Magus, Priestess, Empress) with guided sections, accessible structure, and a Calm Mode toggle.
  - Added a dedicated lab stylesheet with dark, high-contrast themes and responsive layout for smaller screens.
  - Improved header navigation, section cards, callouts, and footer for a cohesive lab experience.
- Bug Fixes
  - Hardened in-app navigation checks to open labs safely and only from allowed origins.
- Documentation
  - Added overview of Lab pages and design guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->