### PR TITLE
Refine offline cosmic helix renderer

### DIFF
--- a/cosmic-helix/README_RENDERER.md
+++ b/cosmic-helix/README_RENDERER.md
@@ -1,102 +1,31 @@
 # Cosmic Helix Renderer (Offline, ND-safe)
 
-
-Static HTML + Canvas capsule that renders the layered cosmology once on load. Double-clicking `index.html` paints a 1440×900 canvas with four calm layers: Vesica field, Tree-of-Life scaffold, Fibonacci curve, and a double-helix lattice. Everything runs offline with no build tools or external libraries.
-
-## Files
-- `index.html` — offline entry point that loads the optional palette, seeds numerology constants, and invokes the renderer.
-- `js/helix-renderer.mjs` — ES module of pure drawing helpers. Each helper documents why the ND-safe order matters.
-- `data/palette.json` — optional palette override. If missing, the renderer keeps a safe fallback and posts a gentle notice on the canvas.
-
-## Usage (offline)
-1. Open `cosmic-helix/index.html` directly in any modern browser. No server or network connection is required.
-2. The header status reports whether `data/palette.json` loaded successfully. Missing data keeps the fallback colours and prints the notice.
-3. The canvas renders the four layers once using the numerology constants (3, 7, 9, 11, 22, 33, 99, 144) baked into the helper functions.
-
-## Layer order (back to front)
-1. **Vesica field** — intersecting circle lattice spaced with 9×11 divisions to honour the womb-of-forms geometry.
-2. **Tree-of-Life scaffold** — ten sephirot nodes joined by twenty-two steady paths, scaled by the numerology denominators for clarity.
-3. **Fibonacci curve** — static logarithmic spiral sampled over 144 points with golden ratio pacing.
-4. **Double-helix lattice** — two phase-shifted strands with thirty-three cross ties and no motion.
-
-Static HTML + Canvas renderer that paints the requested four-layer cosmology on a fixed 1440x900 stage. Open `index.html` directly in any modern browser and the canvas renders once without motion.
+Static HTML + Canvas capsule that paints the layered cosmology exactly once when `index.html` is opened. The module honours the covenant: ND-safe colours, no motion, and sacred geometry rendered in four calm passes.
 
 ## Files
-- `index.html` - offline entry that loads the optional palette and geometry files, applies sealed fallbacks, and calls the renderer.
-- `js/helix-renderer.mjs` - ES module of small pure helpers. Each helper documents the ND-safe layer order.
-- `data/palette.json` - optional colour overrides. Missing data triggers the sealed palette, a status note, and a canvas notice.
-- `data/geometry.json` - optional geometry overrides for spacing, node layout, and helix pacing.
+- `index.html` — offline entry point that applies the palette (or sealed fallback) and calls the renderer.
+- `js/helix-renderer.mjs` — ES module of pure drawing helpers sequenced in the ND-safe layer order.
+- `data/palette.json` — optional palette override. Missing data triggers the sealed palette and a gentle inline notice.
+- `README_RENDERER.md` — this guide.
 
 ## Usage (offline)
-1. Double-click `cosmic-helix/index.html`. No server, build step, or network connection is required.
-2. The header status confirms whether the palette and geometry files loaded. Missing files fall back gracefully and keep the canvas ND-safe.
-3. The renderer draws the vesica field, Tree-of-Life scaffold, Fibonacci curve, and double-helix lattice exactly once.
+1. Double-click `cosmic-helix/index.html` in any modern browser. No server or build step required.
+2. The header status reports whether `data/palette.json` loaded. If browsers block the fetch on the `file://` protocol, the sealed palette activates automatically.
+3. The canvas renders the vesica field, Tree-of-Life scaffold, Fibonacci curve, and static double-helix lattice once. There is no animation, autoplay, or timers.
 
 ## Layer order (back to front)
-1. **Vesica field** - intersecting circle lattice spaced with 3/7/9/11 ratios to seed the womb-of-forms grid.
-2. **Tree-of-Life scaffold** - ten sephirot nodes joined by twenty-two calm paths derived from numerology constants.
-3. **Fibonacci curve** - logarithmic spiral polyline sampled over 144 points for gentle golden-ratio growth.
-4. **Double-helix lattice** - two still strands with thirty-three cross ties and no motion.
-
+1. **Vesica field** — a 9×11 lattice of intersecting circles (3, 9, 11 ratios) plus a central vesica pair for womb-of-forms depth.
+2. **Tree-of-Life scaffold** — ten sephirot positioned by calm 33-based margins with twenty-two steady connective paths.
+3. **Fibonacci curve** — a logarithmic spiral sampled over 144 golden-ratio steps to evoke organic growth without motion.
+4. **Double-helix lattice** — two phase-shifted strands with thirty-three rungs, rendered as still polylines to preserve layered geometry.
 
 ## ND-safe and trauma-informed choices
-- No animation, autoplay, or timers. Rendering completes in a single pass.
-- Calm palette defaults with explicit status messaging so fallbacks never surprise viewers.
-- Layered geometry keeps sacred forms three-dimensional instead of flattening them into a single outline.
-- ASCII quotes, UTF-8, and LF newlines preserve portability for offline review.
+- Pure functions render once; there are no timers, autoplay, or strobe effects.
+- Palette fallbacks and status messaging keep surprises minimal and explain why fallbacks appear.
+- Calm hex colours meet WCAG-friendly contrast against the #0b0b12 background.
+- Layer separation keeps the sacred geometry volumetric instead of flattening it into a single outline.
 
 ## Customising safely
-
-- Adjust `data/palette.json` to change colours. Keys remain `bg`, `ink`, `muted`, and `layers` (array of six hex strings).
-- Pass a custom geometry object when calling `renderHelix` if deeper tuning is required; the function validates numbers and keeps the ND-safe structure intact.
-
-- Adjust `data/palette.json` to supply custom colours. Provide `bg`, `ink`, `muted`, and a six colour `layers` array.
-- Tune spacing by editing `data/geometry.json` or by passing a `geometry` object to `renderHelix`. The module validates every override to keep ND-safe bounds.
-- Compose new layers by following the pure helper pattern inside `js/helix-renderer.mjs`. Keep additions static and well-commented to honour the covenant.
-
-
-Static HTML + Canvas capsule that renders the layered cosmology with no motion. Double-clicking `index.html` paints a
-1440x900 canvas in four calm passes: vesica field, Tree-of-Life scaffold, Fibonacci curve, and the static double helix.
-Everything runs offline with zero dependencies so the lore remains portable.
-
-## Files
-- `index.html` - offline entry point. Loads the optional palette, seeds numerology constants, and invokes the renderer.
-- `js/helix-renderer.mjs` - ES module of pure drawing helpers. Comments explain why each layer order stays ND-safe.
-- `data/palette.json` - optional palette override. Missing or invalid data keeps the sealed fallback and shows a gentle
-  notice in the canvas corner.
-
-## Usage (offline)
-1. Open `cosmic-helix/index.html` directly in any modern browser (no server required).
-2. The header status reports whether `data/palette.json` loaded. If file:// security blocks the fetch, the fallback palette
-   activates and the canvas prints a calm notice.
-3. Rendering happens once per load using the numerology constants (3, 7, 9, 11, 22, 33, 99, 144) baked into the geometry.
-
-## Layer order (back to front)
-1. **Vesica field** - intersecting circle lattice spaced with 9x11 divisions (why: honours womb-of-forms geometry).
-2. **Tree-of-Life scaffold** - ten sephirot joined by twenty-two paths, scaled by 33/99 ratios so lines stay readable.
-3. **Fibonacci curve** - logarithmic spiral sampled over 144 points with golden ratio pacing.
-4. **Double-helix lattice** - two phase-shifted strands with thirty-three cross ties and no animation.
-
-## ND-safe and trauma-informed choices
-- No timers or autoplay; the canvas draws once to avoid sensory spikes.
-- Calm palette defaults with clear status messaging so fallbacks never surprise the viewer.
-- Layered depth is preserved by drawing in ordered passes rather than flattening forms.
-- All code sticks to ASCII quotes, UTF-8, LF newlines, and small pure helpers for ease of stewardship.
-
-## Customising safely
-Update `data/palette.json` to supply new colours:
-
-```json
-{
-  "bg": "#0b0b12",
-  "ink": "#e8e8f0",
-  "muted": "#a6a6c1",
-  "layers": ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-}
-```
-
-If the file is absent or malformed, the renderer keeps the sealed palette, updates the header status, and prints the gentle
-notice in the canvas so nothing fails silently. Geometry overrides can be passed to `renderHelix` when embedding the module,
-but keep the covenant: static rendering, ND-safe palettes, and comments explaining every change.
-
-
+- Update `data/palette.json` with `bg`, `ink`, `muted`, and a six-colour `layers` array to tune hues. Invalid or missing values fall back silently to the sealed palette.
+- Pass a `geometry` object into `renderHelix` (when embedding the module elsewhere) to adjust counts or spacing. Every override is validated to keep ratios positive and ND-safe.
+- Keep additions static, well-commented, and grounded in the numerology constants (3, 7, 9, 11, 22, 33, 99, 144).

--- a/cosmic-helix/index.html
+++ b/cosmic-helix/index.html
@@ -6,12 +6,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
   <meta name="color-scheme" content="light dark">
   <style>
-
     /* ND-safe chrome: calm contrast, no motion, layered depth preserved (why: reduces sensory load). */
-
-
-    /* ND-safe chrome: calm contrast, no motion, layered geometry preserved. */
-
     :root {
       --bg: #0b0b12;
       --ink: #e8e8f0;
@@ -31,22 +26,10 @@
     header {
       padding: 12px 16px;
       border-bottom: 1px solid var(--outline);
-      background: linear-gradient(180deg, rgba(17,17,26,0.9), rgba(11,11,18,0.2));
     }
 
     header strong {
-
-      letter-spacing: 0.05em;
-
-
-      letter-spacing: 0.05em;
-
-
-      letter-spacing: 0.05em;
-
-      font-weight: 600;
       letter-spacing: 0.06em;
-
     }
 
     .status {
@@ -57,39 +40,13 @@
 
     #stage {
       display: block;
-      width: 1440px;
-      height: 900px;
       margin: 16px auto;
-
       width: 1440px;
       height: 900px;
-      max-width: calc(100vw - 32px);
-      max-height: calc(100vh - 160px);
-
-
+      max-width: min(1440px, 100vw - 32px);
+      max-height: min(900px, 100vh - 160px);
       background: var(--bg);
       box-shadow: 0 0 0 1px var(--outline);
-
-    
-      background: var(--bg);
-      box-shadow: 0 0 0 1px var(--outline);
-
-      background: var(--bg);
-      box-shadow: 0 0 0 1px var(--outline);
-
-
-      box-shadow: 0 0 0 1px var(--outline);
-      background: var(--bg);
-      max-width: calc(100vw - 32px);
-      max-height: calc(100vh - 160px);
-
-
-    }
-
-    canvas {
-      width: 100%;
-      height: 100%;
-      display: block;
     }
 
     canvas {
@@ -114,103 +71,18 @@
 </head>
 <body>
   <header>
-
     <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
     <div class="status" id="status">Loading palette…</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">Static renderer for Vesica field, Tree-of-Life scaffold, Fibonacci curve, and a double-helix lattice. Open this file directly (no server, no animation, ND-safe palette).</p>
-
-    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Loading palette...</div>
-  </header>
-
-  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-
-  <p class="note">Static renderer encoding the vesica field, Tree-of-Life scaffold, Fibonacci curve, and a double-helix lattice. Open this file directly; no build tools, no animation, ND-safe palette only.</p>
-
-
-  <p class="note">Static renderer encoding the vesica field, Tree-of-Life scaffold, Fibonacci curve, and a double-helix lattice. Open this file directly; no build tools, no animation, ND-safe palette only.</p>
-
-  <p class="note">Static renderer encoding the vesica field, Tree-of-Life scaffold, Fibonacci curve, and a double-helix lattice. Open this file directly; no build tools, no animation, ND-safe palette only.</p>
-
-  <p class="note">This static renderer encodes the vesica field, Tree-of-Life scaffold, Fibonacci curve, and static double helix. Open
-
-    this file directly - no build tools, no animation, ND-safe palette.</p>
-
+  <p class="note">Static renderer encoding the vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice. Open this file directly; no build tools, no animation, ND-safe palette only.</p>
 
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
 
-
     const statusEl = document.getElementById("status");
     const canvas = document.getElementById("stage");
-
-    const ctx = canvas.getContext("2d");
-
-
-    const DEFAULTS = {
-      palette: {
-        bg: "#0b0b12",
-        ink: "#e8e8f0",
-        muted: "#a6a6c1",
-        layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-      }
-    };
-
-    const NUM = { THREE: 3, SEVEN: 7, NINE: 9, ELEVEN: 11, TWENTYTWO: 22, THIRTYTHREE: 33, NINETYNINE: 99, ONEFORTYFOUR: 144 };
-
-
-
-
-    const DEFAULTS = {
-      palette: {
-        bg: "#0b0b12",
-        ink: "#e8e8f0",
-        muted: "#a6a6c1",
-        layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-      }
-    };
-
-    const NUM = { THREE: 3, SEVEN: 7, NINE: 9, ELEVEN: 11, TWENTYTWO: 22, THIRTYTHREE: 33, NINETYNINE: 99, ONEFORTYFOUR: 144 };
-
-
-
-    async function loadJSON(path) {
-      try {
-        const response = await fetch(path, { cache: "no-store" });
-        if (!response.ok) {
-          throw new Error(String(response.status));
-        }
-        return await response.json();
-      } catch (error) {
-        return null;
-      }
-    }
-
-    function applyTheme(palette) {
-      const root = document.documentElement;
-      root.style.setProperty("--bg", palette.bg);
-      root.style.setProperty("--ink", palette.ink);
-      root.style.setProperty("--muted", palette.muted || palette.ink);
-    }
-
-
-    const ctx = canvas.getContext("2d");
-
-    const DEFAULTS = {
-      palette: {
-        bg: "#0b0b12",
-        ink: "#e8e8f0",
-        muted: "#a6a6c1",
-        layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-      }
-    };
-
-    const NUM = { THREE: 3, SEVEN: 7, NINE: 9, ELEVEN: 11, TWENTYTWO: 22, THIRTYTHREE: 33, NINETYNINE: 99, ONEFORTYFOUR: 144 };
-
-
     const context = canvas.getContext("2d");
 
     const NUM = Object.freeze({
@@ -224,15 +96,6 @@
       ONEFORTYFOUR: 144
     });
 
-    (async () => {
-      const palette = await loadJSON("./data/palette.json");
-      const activePalette = palette || defaults.palette;
-      const notice = palette ? "" : "Palette missing; ND-safe fallback active.";
-
-      if (!ctx) {
-        statusEl.textContent = "Canvas unavailable in this browser.";
-        return;
-
     const FALLBACK = Object.freeze({
       palette: {
         bg: "#0b0b12",
@@ -242,12 +105,7 @@
       }
     });
 
-    function updateStatus(message) {
-      statusEl.textContent = message;
-    }
-
-
-    async function loadJSON(path) {
+    async function loadPalette(path) {
       try {
         const response = await fetch(path, { cache: "no-store" });
         if (!response.ok) {
@@ -256,11 +114,9 @@
         return await response.json();
       } catch (error) {
         return null;
-
       }
     }
 
-]
     function applyTheme(palette) {
       const root = document.documentElement;
       root.style.setProperty("--bg", palette.bg);
@@ -268,83 +124,37 @@
       root.style.setProperty("--muted", palette.muted || palette.ink);
     }
 
-
-
-    if (!ctx) {
-      statusEl.textContent = "Canvas unavailable in this browser.";
-    } else {
-      const paletteData = await loadJSON("./data/palette.json");
-      const geometryData = await loadJSON("./data/geometry.json");
-      const palette = paletteData || DEFAULTS.palette;
-      applyTheme(palette);
-
-
-      const notice = paletteData ? "" : "Palette fallback active.";
-      const result = renderHelix(ctx, {
-
-
-
-      const notice = paletteData ? "" : "Palette fallback active.";
-      const result = renderHelix(ctx, {
-
-
-      const notice = paletteData ? "" : "Palette fallback active.";
-      const result = renderHelix(ctx, {
-
-    if (!context) {
-      updateStatus("Canvas context unavailable in this browser.");
-    } else {
-      const palette = await loadJSON("./data/palette.json");
-      const activePalette = palette || FALLBACK.palette;
-      const notice = palette ? "" : "Palette missing; using sealed fallback.";
-
-      // Draw once: calm sequencing keeps ND-safe pacing.
-      const result = renderHelix(context, {
-
-
-
-      statusEl.textContent = palette ? "Palette loaded." : "Palette missing; fallback in use.";
-
-      renderHelix(ctx, {
-
-        width: canvas.width,
-        height: canvas.height,
-        palette,
-        geometry: geometryData || undefined,
-        NUM,
-        notice
-      });
-
-    })();
-
-
-
-      if (result.ok) {
-
-
-
-      if (result.ok) {
-
-      if (result.ok) {
-
-
-
-        const paletteMessage = paletteData ? "Palette loaded." : "Palette missing; using sealed fallback.";
-        const geometryMessage = geometryData ? " Geometry loaded." : " Geometry fallback in use.";
-        statusEl.textContent = paletteMessage + geometryMessage;
-      } else {
-        statusEl.textContent = "Renderer error: " + (result.reason || "unknown");
-
-
-        updateStatus(palette ? "Palette loaded." : "Palette missing; fallback active.");
-      } else {
-        updateStatus(`Render failed: ${result.reason}`);
-
-
-
-      }
+    function updateStatus(message) {
+      statusEl.textContent = message;
     }
 
+    (async () => {
+      if (!context) {
+        updateStatus("Canvas unavailable in this browser.");
+        return;
+      }
+
+      const paletteData = await loadPalette("./data/palette.json");
+      const activePalette = paletteData ? paletteData : FALLBACK.palette;
+      applyTheme(activePalette);
+
+      const result = renderHelix(context, {
+        width: canvas.width,
+        height: canvas.height,
+        palette: activePalette,
+        NUM,
+        notice: paletteData ? null : "Palette missing; sealed fallback active."
+      });
+
+      if (result.ok) {
+        const parts = [];
+        parts.push(paletteData ? "Palette loaded." : "Palette missing; fallback palette in use.");
+        parts.push(result.notice ? "Fallback notice rendered." : "Render complete.");
+        updateStatus(parts.join(" "));
+      } else {
+        updateStatus("Renderer error: " + (result.reason || "unknown"));
+      }
+    })();
   </script>
 </body>
 </html>

--- a/cosmic-helix/js/helix-renderer.mjs
+++ b/cosmic-helix/js/helix-renderer.mjs
@@ -1,70 +1,19 @@
 /*
   helix-renderer.mjs
 
-  Static ND-safe renderer for the Cosmic Helix canvas. Draws four calm layers:
-    1) Vesica field (foundation grid)
-    2) Tree-of-Life scaffold (nodes and paths)
-    3) Fibonacci curve (golden spiral polyline)
-    4) Double-helix lattice (phase-shifted strands)
-
-  All helpers are pure so a single invocation paints the scene without motion.
-  Numerology constants (3, 7, 9, 11, 22, 33, 99, 144) guide proportions.
-
-
-  Offline ND-safe renderer for the Cosmic Helix canvas.
-
-  Layer order (back to front):
-    1) Vesica field - intersecting circles grounding the vesica piscis grid.
-    2) Tree-of-Life scaffold - ten sephirot nodes with twenty-two calm paths.
-    3) Fibonacci curve - static logarithmic spiral sampled from the Fibonacci family.
-    4) Double-helix lattice - two phase-shifted strands tied by gentle rungs.
-
-  Why this structure:
-    - Zero animation: everything renders in one pass to preserve ND-safe pacing.
-    - Layer separation keeps sacred geometry three-dimensional instead of flattened.
-    - Numerology constants (3, 7, 9, 11, 22, 33, 99, 144) shape spacing and sampling.
-    - Pure helper functions keep the module portable for offline review.
-
-*/
-
-const DEFAULT_PALETTE = {
-  bg: "#0b0b12",
-  ink: "#e8e8f0",
-  muted: "#a6a6c1",
-  layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"],
-};
-
-const DEFAULT_NUMBERS = {
-
-
-*/
-
-const DEFAULT_PALETTE = {
-  bg: "#0b0b12",
-  ink: "#e8e8f0",
-  muted: "#a6a6c1",
-  layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"],
-};
-
-const DEFAULT_NUMBERS = {
-
-
-
-  ND-safe static renderer for the four-layer cosmic helix.
+  ND-safe static renderer for the four-layer Cosmic Helix canvas.
   The helpers are pure and sequenced so the canvas paints once without motion.
   Layer order (back to front):
-    1) Vesica field - intersecting circles establish the womb-of-forms grid.
-    2) Tree-of-Life scaffold - ten sephirot and twenty-two paths anchor lineage.
-    3) Fibonacci curve - logarithmic spiral sampling the golden ratio for growth.
-    4) Double-helix lattice - static sine strands with calm cross ties.
+    1) Vesica field — intersecting circles to ground the vesica piscis grid.
+    2) Tree-of-Life scaffold — ten sephirot nodes with twenty-two calm paths.
+    3) Fibonacci curve — logarithmic spiral sampled with 144 golden-ratio steps.
+    4) Double-helix lattice — two still strands with thirty-three cross ties.
 
   Numerology constants (3, 7, 9, 11, 22, 33, 99, 144) parameterise spacing so
-  sacred ratios remain readable without animation (why: respects covenant).
+  sacred ratios remain readable without animation (why: honours ND-safe pacing).
 */
 
-const DEFAULT_N
-
-
+const DEFAULT_NUM = Object.freeze({
   THREE: 3,
   SEVEN: 7,
   NINE: 9,
@@ -72,90 +21,53 @@ const DEFAULT_N
   TWENTYTWO: 22,
   THIRTYTHREE: 33,
   NINETYNINE: 99,
-
-  ONEFORTYFOUR: 144,
-};
-
-const FALLBACK_GEOMETRY = {
-
-const DEFAULT_GEOMETRY = {
-
-  vesica: {
-    rows: 9,
-    columns: 11,
-    paddingDivisor: 11,
-    radiusFactor: 1.5,
-    strokeDivisor: 99,
-    alpha: 0.6,
-
-
-
   ONEFORTYFOUR: 144
 });
+
+const FALLBACK_LAYERS = Object.freeze([
+  "#b1c7ff",
+  "#89f7fe",
+  "#a0ffa1",
+  "#ffd27f",
+  "#f5a3ff",
+  "#d0d0e6"
+]);
 
 const FALLBACK_PALETTE = Object.freeze({
   bg: "#0b0b12",
   ink: "#e8e8f0",
   muted: "#a6a6c1",
-  layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
+  layers: FALLBACK_LAYERS
 });
 
-const FALLBACK_GEOMETRY = {
-  vesica: {
+const DEFAULT_GEOMETRY = Object.freeze({
+  vesica: Object.freeze({
     rows: DEFAULT_NUM.NINE,
     columns: DEFAULT_NUM.ELEVEN,
-    paddingDivisor: DEFAULT_NUM.ELEVEN,
+    paddingFactor: DEFAULT_NUM.ELEVEN,
     radiusFactor: DEFAULT_NUM.SEVEN / DEFAULT_NUM.THREE,
     strokeDivisor: DEFAULT_NUM.NINETYNINE,
     alpha: 0.55
-
-
-  },
-  treeOfLife: {
-    marginDivisor: DEFAULT_NUM.ELEVEN,
+  }),
+  treeOfLife: Object.freeze({
+    marginFactor: DEFAULT_NUM.ELEVEN,
     radiusDivisor: DEFAULT_NUM.THIRTYTHREE,
-    labelOffset: -DEFAULT_NUM.TWENTYTWO,
-    labelLineHeight: 14,
+    pathWidthDivisor: DEFAULT_NUM.THIRTYTHREE,
+    labelOffset: DEFAULT_NUM.ELEVEN,
     labelFont: "12px system-ui, -apple-system, Segoe UI, sans-serif",
-    nodes: [
-      { id: "kether", title: "Kether", level: 0, xFactor: 0.5 },
-      { id: "chokmah", title: "Chokmah", level: 1, xFactor: 0.7 },
-      { id: "binah", title: "Binah", level: 1, xFactor: 0.3 },
-      { id: "chesed", title: "Chesed", level: 2, xFactor: 0.68 },
-      { id: "geburah", title: "Geburah", level: 2, xFactor: 0.32 },
-      { id: "tiphareth", title: "Tiphareth", level: 3, xFactor: 0.5 },
-      { id: "netzach", title: "Netzach", level: 4, xFactor: 0.66 },
-      { id: "hod", title: "Hod", level: 4, xFactor: 0.34 },
-      { id: "yesod", title: "Yesod", level: 5, xFactor: 0.5 },
-      { id: "malkuth", title: "Malkuth", level: 6, xFactor: 0.5 },
-
-
+    nodes: Object.freeze([
       { id: "kether", title: "Kether", meaning: "Crown", level: 0, xFactor: 0.5 },
-
-      { id: "chokmah", title: "Chokmah", meaning: "Wisdom", level: 1, xFactor: 0.68 },
-      { id: "binah", title: "Binah", meaning: "Understanding", level: 1, xFactor: 0.32 },
-      { id: "chesed", title: "Chesed", meaning: "Mercy", level: 2, xFactor: 0.66 },
-      { id: "geburah", title: "Geburah", meaning: "Severity", level: 2, xFactor: 0.34 },
-      { id: "tiphareth", title: "Tiphareth", meaning: "Beauty", level: 3, xFactor: 0.5 },
-      { id: "netzach", title: "Netzach", meaning: "Victory", level: 4, xFactor: 0.64 },
-      { id: "hod", title: "Hod", meaning: "Glory", level: 4, xFactor: 0.36 },
-
       { id: "chokmah", title: "Chokmah", meaning: "Wisdom", level: 1, xFactor: 0.72 },
       { id: "binah", title: "Binah", meaning: "Understanding", level: 1, xFactor: 0.28 },
       { id: "chesed", title: "Chesed", meaning: "Mercy", level: 2, xFactor: 0.68 },
       { id: "geburah", title: "Geburah", meaning: "Severity", level: 2, xFactor: 0.32 },
       { id: "tiphareth", title: "Tiphareth", meaning: "Beauty", level: 3, xFactor: 0.5 },
-      { id: "netzach", title: "Netzach", meaning: "Victory", level: 4, xFactor: 0.7 },
-      { id: "hod", title: "Hod", meaning: "Glory", level: 4, xFactor: 0.3 },
-
+      { id: "netzach", title: "Netzach", meaning: "Victory", level: 4, xFactor: 0.64 },
+      { id: "hod", title: "Hod", meaning: "Glory", level: 4, xFactor: 0.36 },
       { id: "yesod", title: "Yesod", meaning: "Foundation", level: 5, xFactor: 0.5 },
       { id: "malkuth", title: "Malkuth", meaning: "Kingdom", level: 6, xFactor: 0.5 }
-
-
-
-    ],
-    edges: [
-
+    ]),
+    edges: Object.freeze([
       ["kether", "chokmah"], ["kether", "binah"], ["kether", "tiphareth"],
       ["chokmah", "binah"], ["chokmah", "tiphareth"], ["chokmah", "chesed"],
       ["chokmah", "netzach"], ["binah", "tiphareth"], ["binah", "geburah"],
@@ -163,2379 +75,256 @@ const FALLBACK_GEOMETRY = {
       ["chesed", "netzach"], ["geburah", "tiphareth"], ["geburah", "hod"],
       ["tiphareth", "netzach"], ["tiphareth", "hod"], ["tiphareth", "yesod"],
       ["netzach", "hod"], ["netzach", "yesod"], ["hod", "yesod"], ["yesod", "malkuth"]
-    ]
-
-      ["kether", "chokmah"],
-      ["kether", "binah"],
-      ["kether", "tiphareth"],
-      ["chokmah", "binah"],
-      ["chokmah", "tiphareth"],
-      ["chokmah", "chesed"],
-      ["chokmah", "netzach"],
-      ["binah", "tiphareth"],
-      ["binah", "geburah"],
-      ["binah", "hod"],
-      ["chesed", "geburah"],
-      ["chesed", "tiphareth"],
-      ["chesed", "netzach"],
-      ["geburah", "tiphareth"],
-      ["geburah", "hod"],
-      ["tiphareth", "netzach"],
-      ["tiphareth", "hod"],
-      ["tiphareth", "yesod"],
-      ["netzach", "hod"],
-      ["netzach", "yesod"],
-      ["hod", "yesod"],
-      ["yesod", "malkuth"],
-    ],
-
-  },
-  fibonacci: {
+    ])
+  }),
+  fibonacci: Object.freeze({
     sampleCount: DEFAULT_NUM.ONEFORTYFOUR,
     turns: DEFAULT_NUM.THREE,
-    baseRadiusDivisor: DEFAULT_NUM.THREE,
+    baseRadiusDivisor: DEFAULT_NUM.NINE,
     phi: 1.618033988749895,
-
     alpha: 0.85,
-
-
-    alpha: 0.85,
-
-
-    alpha: 0.85,
-
-    alpha: 0.88
-
-
-
-  },
-  helix: {
-    sampleCount: DEFAULT_NUM.ONEFORTYFOUR,
-    cycles: DEFAULT_NUM.THREE,
-    amplitudeDivisor: DEFAULT_NUM.THREE,
-    phaseOffset: 180,
-
-    crossTieCount: 33,
-    strandAlpha: 0.85,
+    thickness: 2.5,
+    centerOffsetX: 0.62,
+    centerOffsetY: 0.58
+  }),
+  helix: Object.freeze({
+    strandPoints: DEFAULT_NUM.NINETYNINE,
+    rungCount: DEFAULT_NUM.THIRTYTHREE,
+    sideMarginDivisor: DEFAULT_NUM.ELEVEN,
+    amplitudeDivisor: DEFAULT_NUM.NINE,
+    frequencyTurns: DEFAULT_NUM.SEVEN / DEFAULT_NUM.THREE,
+    strandThickness: 2.5,
     rungAlpha: 0.6,
-  },
+    verticalCenterOffset: 0
+  })
+});
 
-
-    crossTieCount: DEFAULT_NUM.THIRTYTHREE,
-    strandAlpha: 0.82,
-    rungAlpha: 0.65
-  }
-
-
-};
-
-
-};
-
-/**
- * Render a static, layered sacred-geometry scene onto a 2D canvas context.
- *
- * Draws four composited layers in fixed order — vesica field, Tree of Life scaffold,
- * Fibonacci curve, and double-helix lattice — then optionally renders a short notice.
- *
- * @param {CanvasRenderingContext2D} ctx - A 2D canvas rendering context (must have a valid `canvas`).
- * @param {Object} [options] - Rendering options.
- * @param {number} [options.width] - Canvas width to use for rendering; falls back to `ctx.canvas.width`.
- * @param {number} [options.height] - Canvas height to use for rendering; falls back to `ctx.canvas.height`.
- * @param {Object} [options.palette] - Optional palette overrides (bg, ink, muted, layers[]). Invalid/missing fields fall back to defaults.
- * @param {Object} [options.NUM] - Optional numerology constants to override numeric defaults used for layout/scaling.
- * @param {Object} [options.geometry] - Optional geometry overrides for vesica, treeOfLife, fibonacci, and helix components.
- * @param {string} [options.notice] - Optional short message rendered near the bottom-left when provided.
- *
- * @return {{ok: boolean, reason?: string, constants?: Object}} Result object.
- *   - On success: { ok: true, constants } where `constants` is the numerology object used.
- *   - On failure: { ok: false, reason } where `reason` is "missing-context" (invalid ctx) or "invalid-dimensions" (non-finite or non-positive width/height).
-
- * Render a static, layered helix composition onto a 2D canvas context.
- *
- * Produces an offline (non-animated) rendering of four layered elements — vesica piscis field,
- * Tree of Life scaffold, Fibonacci spiral, and double-helix lattice — using configurable
- * palette, numeric constants, and geometry. The function clears the canvas, draws each layer
- * in sequence, optionally renders a centered notice, and returns a small summary of rendered
- * layer statistics.
- *
- * @param {CanvasRenderingContext2D} ctx - The 2D drawing context of the target canvas. Must be a valid context with a `.canvas` property.
- * @param {Object} [options] - Rendering options.
- * @param {Object} [options.palette] - Palette overrides (bg, ink, muted, layers array). Missing values are merged with defaults.
- * @param {Object} [options.NUM] - Numeric constants overrides (e.g., THREE, SEVEN, etc.). Non-finite or non-positive values fall back to defaults.
- * @param {Object} [options.geometry] - Geometry overrides for the four layers (vesica, treeOfLife, fibonacci, helix). Each subsection is merged with safe defaults.
- * @param {string} [options.notice] - Optional short message to render centered near the bottom of the canvas; ignored if empty or non-string.
- *
- * @return {{ok: boolean, reason?: string, summary?: string}} If the context is missing or invalid, returns { ok: false, reason: "missing-context" }. On success returns { ok: true, summary } where `summary` is a human-readable summary of per-layer stats.
-=======
-
- * Render a four-layer static "cosmic helix" onto a 2D canvas context.
- *
- * Validates the provided drawing context and dimensions, normalizes palette,
- * numerology, and geometry options, then paints four layers (vesica field,
- * Tree-of-Life scaffold, Fibonacci curve, and double-helix lattice) in back-to-front
- * order. Optionally renders a short notice string. The function does not mutate
- * the provided canvas transform or state (it saves/restores the context).
- *
- * @param {CanvasRenderingContext2D} ctx - A 2D canvas rendering context (must have a `.canvas`).
- * @param {Object} [options] - Rendering options.
- * @param {number} [options.width] - Width to render; defaults to `ctx.canvas.width`.
- * @param {number} [options.height] - Height to render; defaults to `ctx.canvas.height`.
- * @param {Object} [options.palette] - Optional palette object (normalized internally).
- * @param {Object} [options.NUM] - Optional numerology constants (normalized internally).
- * @param {Object} [options.geometry] - Optional geometry overrides (normalized internally).
- * @param {string} [options.notice] - Optional short notice string to draw near the bottom-left.
- * @return {{ok: true, numerology: Object}|{ok: false, reason: string}} Returns `{ ok: true, numerology }` on success.
- * On failure returns `{ ok: false, reason }` where `reason` is `"missing-context"` when `ctx` is invalid
- * or `"invalid-dimensions"` when width/height are not positive finite numbers.
-
- * Render the Cosmic Helix composition onto a Canvas 2D context in a single offline pass.
- *
- * Validates the provided drawing context, normalizes dimensions and configuration by
- * merging supplied palettes, numeric constants, and geometry with safe defaults, then
- * renders four layered visuals (vesica field, Tree of Life, Fibonacci curve, helix lattice)
- * back-to-front. Optionally draws a bottom-centered notice string. Returns a short
- * summary of what was rendered.
- *
- * Note: this function draws directly to the provided canvas context.
- *
- * @param {Object} [options] - Optional overrides and metadata.
- * @param {Object} [options.palette] - Partial palette to merge with defaults (bg, ink, muted, layers).
- * @param {Object} [options.NUM] - Numeric overrides merged against default numbers.
- * @param {Object} [options.geometry] - Per-layer geometry overrides (vesica, treeOfLife, fibonacci, helix).
- * @param {string} [options.notice] - Optional notice text to render at the bottom of the canvas.
- * @return {{ok: false, reason: string}|{ok: true, summary: string}} If the drawing context is missing returns
- *         { ok: false, reason: "missing-context" }. On success returns { ok: true, summary } where
- *         summary is a human-readable synopsis of rendered layer statistics.
- * Render a four-layer static "cosmic helix" onto a 2D canvas context.
- *
- * Validates the provided drawing context and dimensions, normalizes palette,
- * numerology, and geometry options, then paints four layers (vesica field,
- * Tree-of-Life scaffold, Fibonacci curve, and double-helix lattice) in back-to-front
- * order. Optionally renders a short notice string. The function does not mutate
- * the provided canvas transform or state (it saves/restores the context).
- *
- * @param {CanvasRenderingContext2D} ctx - A 2D canvas rendering context (must have a `.canvas`).
- * @param {Object} [options] - Rendering options.
- * @param {number} [options.width] - Width to render; defaults to `ctx.canvas.width`.
- * @param {number} [options.height] - Height to render; defaults to `ctx.canvas.height`.
- * @param {Object} [options.palette] - Optional palette object (normalized internally).
- * @param {Object} [options.NUM] - Optional numerology constants (normalized internally).
- * @param {Object} [options.geometry] - Optional geometry overrides (normalized internally).
- * @param {string} [options.notice] - Optional short notice string to draw near the bottom-left.
- * @return {{ok: true, numerology: Object}|{ok: false, reason: string}} Returns `{ ok: true, numerology }` on success.
- * On failure returns `{ ok: false, reason }` where `reason` is `"missing-context"` when `ctx` is invalid
- * or `"invalid-dimensions"` when width/height are not positive finite numbers.
-
-
- */
 export function renderHelix(ctx, options = {}) {
   if (!ctx || typeof ctx.canvas === "undefined") {
-    return { ok: false, reason: "missing-context" };
+    return { ok: false, reason: "Invalid 2D context" };
   }
 
-  const dims = normaliseDimensions(ctx, options);
-  const palette = mergePalette(options.palette);
-  const numbers = mergeNumbers(options.NUM);
-  const geometry = mergeGeometry(options.geometry);
-  const notice =
-    typeof options.notice === "string" && options.notice.trim()
-      ? options.notice.trim()
-      : "";
-
-  ctx.save();
-
-  clearStage(ctx, dims, palette.bg);
-
-  const vesicaStats = drawVesicaField(
-    ctx,
-    dims,
-    palette.layers[0],
-    numbers,
-    geometry.vesica,
-  );
-  const treeStats = drawTreeOfLife(
-    ctx,
-    dims,
-    palette,
-    numbers,
-    geometry.treeOfLife,
-  );
-  const fibonacciStats = drawFibonacciCurve(
-    ctx,
-    dims,
-    palette.layers[3],
-    numbers,
-    geometry.fibonacci,
-  );
-  const helixStats = drawHelixLattice(
-    ctx,
-    dims,
-    palette,
-    numbers,
-    geometry.helix,
-  );
-
-  ctx.setTransform(1, 0, 0, 1, 0, 0);
-  fillBackground(ctx, width, height, palette.bg);
-
-
-  // Layer order preserves depth without motion (why: layered sacred geometry, ND-safe pacing).
-
-  // Layered sequencing preserves depth without motion (why: ND-safe covenant).
-
-  drawVesicaField(ctx, width, height, palette.layers[0], numerology, geometry.vesica);
-  drawTreeOfLife(ctx, width, height, palette.layers[1], palette.layers[2], palette.ink, numerology, geometry.treeOfLife);
-  drawFibonacciCurve(ctx, width, height, palette.layers[3], numerology, geometry.fibonacci);
-  drawHelixLattice(ctx, width, height, palette.layers[4], palette.layers[5], numerology, geometry.helix);
-
-
-
-  if (notice) {
-    drawCanvasNotice(ctx, dims, palette.ink, notice);
-  }
-
-  ctx.restore();
-
-
-  return {
-
-
-  return {
-
-  return { ok: true, numerology };
-}
-
-  return {
-    
-
-/**
- * Normalize a candidate palette into a safe palette object suitable for rendering.
- *
- * If `input` is not an object, returns a shallow clone of FALLBACK_PALETTE.
- * Otherwise returns an object with string properties `bg`, `ink`, `muted`
- * and a `layers` array whose length matches FALLBACK_PALETTE.layers. For each
- * layer index, a string value from `input.layers` is used when valid; otherwise
- * the corresponding fallback layer color is substituted.
- *
- * @param {Object} [input] - Candidate palette (may contain `bg`, `ink`, `muted`, `layers`).
- * @return {{bg: string, ink: string, muted: string, layers: string[]}} Normalized palette.
- */
-function normalisePalette(input) {
-  if (!input || typeof input !== "object") {
-    return clonePalette(FALLBACK_PALETTE);
-  }
-
-  return {
-    
-
-
-
-    ok: true,
-    summary: summariseLayers({
-      vesicaStats,
-      treeStats,
-      fibonacciStats,
-      helixStats,
-    }),
-  };
-}
-
-
-
-/**
- * Normalize canvas drawing dimensions, using provided overrides or falling back to the canvas size.
- *
- * Options.width and options.height are converted to positive numbers when valid; otherwise the
- * corresponding ctx.canvas dimension is used.
- *
- * @param {CanvasRenderingContext2D} ctx - Rendering context whose canvas provides fallback dimensions.
- * @param {Object} options - Optional dimension overrides.
- * @param {number} [options.width] - Desired width (finite positive number).
- * @param {number} [options.height] - Desired height (finite positive number).
- * @returns {{width: number, height: number}} Normalized positive width and height.
- */
-
-
-/**
- * Return safe, positive drawing dimensions for the canvas.
- *
- * Uses options.width and options.height when they are finite positive numbers;
- * otherwise falls back to ctx.canvas.width and ctx.canvas.height.
- *
- * @param {Object} options - Optional overrides for dimensions.
- * @param {number} [options.width] - Preferred width; ignored if not a finite positive number.
- * @param {number} [options.height] - Preferred height; ignored if not a finite positive number.
- * @return {{width: number, height: number}} Normalized positive width and height suitable for drawing.
- */
-
-
-
-function normaliseDimensions(ctx, options) {
   const width = toPositiveNumber(options.width, ctx.canvas.width);
   const height = toPositiveNumber(options.height, ctx.canvas.height);
-  return { width, height };
-
-}
-
-function mergePalette(candidate = {}) {
-  const layers = Array.isArray(candidate.layers)
-    ? candidate.layers.slice(0, DEFAULT_PALETTE.layers.length)
-    : [];
-  while (layers.length < DEFAULT_PALETTE.layers.length) {
-    layers.push(DEFAULT_PALETTE.layers[layers.length]);
-  }
-  return {
-    bg: typeof candidate.bg === "string" ? candidate.bg : DEFAULT_PALETTE.bg,
-    ink:
-      typeof candidate.ink === "string" ? candidate.ink : DEFAULT_PALETTE.ink,
-    muted:
-      typeof candidate.muted === "string"
-        ? candidate.muted
-        : DEFAULT_PALETTE.muted,
-    layers,
-  };
-}
-
-
-
-}
-
-
-/**
- * Merge a partial palette with the default palette, returning a complete palette object.
- *
- * Missing or invalid color fields fall back to defaults. The returned `layers` array
- * is trimmed to the default layer count if the candidate provides too many entries,
- * and is padded with default layer colors if too few are provided.
- *
- * @param {object} [candidate={}] - Partial palette overrides.
- * @param {string} [candidate.bg] - Background color (hex or CSS color string). Used only if a string.
- * @param {string} [candidate.ink] - Primary ink color. Used only if a string.
- * @param {string} [candidate.muted] - Muted color. Used only if a string.
- * @param {string[]} [candidate.layers] - Array of layer colors; entries must be strings. Excess entries are discarded; missing entries are filled from defaults.
- * @returns {{bg: string, ink: string, muted: string, layers: string[]}} A palette object with guaranteed keys and a layers array matching the default layer count.
- */
-
-
-/**
- * Create a shallow clone of a palette object, copying the layers array.
- *
- * Returns a new object with the same bg, ink, and muted values and a new
- * layers array (shallow copy) so the returned palette can be modified
- * without mutating the original's layers array.
- *
- * @param {Object} palette - Source palette with properties `bg`, `ink`, `muted`, and `layers`.
- * @return {{bg: string, ink: string, muted: string, layers: Array<string>}} The cloned palette.
- */
-function clonePalette(palette) {
-
-
-/**
- * Merge a partial palette with DEFAULT_PALETTE, producing a complete palette object.
- *
- * If the candidate provides string values for `bg`, `ink`, or `muted`, those are used;
- * otherwise the corresponding DEFAULT_PALETTE values are returned. The `layers` array
- * is cloned up to the default length; missing entries are filled from DEFAULT_PALETTE.
- *
- * @param {Object} [candidate={}] - Partial palette to merge.
- * @param {string} [candidate.bg] - Background color (hex or CSS color string).
- * @param {string} [candidate.ink] - Primary ink color.
- * @param {string} [candidate.muted] - Muted/secondary color.
- * @param {string[]} [candidate.layers] - Array of layer colors; values beyond the default length are ignored.
- * @return {{bg: string, ink: string, muted: string, layers: string[]}} A complete palette object suitable for rendering.
- */
-
-
-function mergePalette(candidate = {}) {
-  const layers = Array.isArray(candidate.layers)
-    ? candidate.layers.slice(0, DEFAULT_PALETTE.layers.length)
-    : [];
-  while (layers.length < DEFAULT_PALETTE.layers.length) {
-    layers.push(DEFAULT_PALETTE.layers[layers.length]);
-  }
-/**
- * Create a shallow clone of a palette object, copying the layers array.
- *
- * Returns a new object with the same bg, ink, and muted values and a new
- * layers array (shallow copy) so the returned palette can be modified
- * without mutating the original's layers array.
- *
- * @param {Object} palette - Source palette with properties `bg`, `ink`, `muted`, and `layers`.
- * @return {{bg: string, ink: string, muted: string, layers: Array<string>}} The cloned palette.
- */
-function clonePalette(palette) {
-
-  return {
-
-    bg: typeof candidate.bg === "string" ? candidate.bg : DEFAULT_PALETTE.bg,
-    ink:
-      typeof candidate.ink === "string" ? candidate.ink : DEFAULT_PALETTE.ink,
-    muted:
-      typeof candidate.muted === "string"
-        ? candidate.muted
-        : DEFAULT_PALETTE.muted,
-    layers,
-
-  };
-}
-
-/**
- * Merge a partial numbers config into the default numeric settings.
- *
- * Produces a new object based on DEFAULT_NUMBERS where any keys present in
- * `candidate` replace the defaults only if the provided value is a finite
- * number greater than zero. Non-numeric, non-finite, zero or negative values
- * in `candidate` are ignored and the default is preserved.
- *
- * @param {Object<string, number>} [candidate={}] - Partial numeric overrides.
- * @returns {Object<string, number>} A new numbers object with validated overrides applied.
- */
-
-
-    bg: palette.bg,
-    ink: palette.ink,
-    muted: palette.muted,
-    layers: palette.layers.slice()
-
-  };
-}
-
-
-/**
- * Merge a candidate numeric map into the default numeric constants.
- *
- * Accepts an object of numeric overrides and returns a new object containing
- * all keys from DEFAULT_NUMBERS where any provided value is used only if it is
- * a finite number greater than 0. Non-numeric, non-finite, or non-positive
- * values in the candidate are ignored and the default for that key is kept.
- *
- * @param {Object<string, number>} [candidate={}] - Partial mapping of numeric overrides keyed by the same names as DEFAULT_NUMBERS.
- * @return {Object<string, number>} A new object containing the merged numeric constants.
- */
-
-function mergeNumbers(candidate = {}) {
-  const merged = { ...DEFAULT_NUMBERS };
-  for (const key of Object.keys(DEFAULT_NUMBERS)) {
-    const value = candidate[key];
-    if (typeof value === "number" && Number.isFinite(value) && value > 0) {
-      merged[key] = value;
-    }
-  }
-  return merged;
-}
-
-
-/**
- * Merge user-provided geometry overrides into the renderer's default geometry.
- *
- * Accepts a partial geometry object and returns a fully merged, validated geometry
- * set with the four sections used by the renderer: `vesica`, `treeOfLife`,
- * `fibonacci`, and `helix`. Each section is produced by its respective merge helper
- * (which applies defaults and clamps/validates values).
- *
- * @param {Object} [candidate={}] - Partial geometry overrides; may include any of `vesica`, `treeOfLife`, `fibonacci`, and `helix`.
- * @return {{vesica: Object, treeOfLife: Object, fibonacci: Object, helix: Object}} Normalized geometry ready for rendering.
- */
-
-
-
-/**
- * Merge a partial geometry configuration with defaults for all render layers.
- *
- * Accepts an optional partial `candidate` object and returns a fully populated
- * geometry spec containing the four layer configurations: `vesica`, `treeOfLife`,
- * `fibonacci`, and `helix`. Each sub-object is validated and merged by its
- * respective helper (e.g., `mergeVesica`, `mergeTree`, `mergeFibonacci`,
- * `mergeHelix`) so callers receive safe, ready-to-use geometry settings.
- *
- * @param {Object} [candidate={}] - Partial geometry overrides; may include any subset of
- *   `vesica`, `treeOfLife`, `fibonacci`, and `helix` objects. Missing sections are filled
- *   with defaults.
- * @return {Object} A merged geometry object with keys: `vesica`, `treeOfLife`, `fibonacci`, and `helix`.
- */
-
-
-
-function mergeGeometry(candidate = {}) {
-  return {
-    vesica: mergeVesica(candidate.vesica),
-    treeOfLife: mergeTree(candidate.treeOfLife),
-    fibonacci: mergeFibonacci(candidate.fibonacci),
-    helix: mergeHelix(candidate.helix),
-  };
-}
-
-
-/**
- * Merge and validate a vesica-field configuration, falling back to DEFAULT_GEOMETRY.vesica.
- *
- * Accepts a partial config and returns a fully populated, validated vesica settings object
- * with positive integer/number coercion and alpha clamping.
- *
- * @param {Object} [config] - Partial vesica configuration overrides.
- * @param {number} [config.rows] - Number of grid rows.
- * @param {number} [config.columns] - Number of grid columns.
- * @param {number} [config.paddingDivisor] - Divisor controlling padding relative to canvas size.
- * @param {number} [config.radiusFactor] - Factor that determines circle radius from cell size.
- * @param {number} [config.strokeDivisor] - Divisor controlling stroke width relative to radius.
- * @param {number} [config.alpha] - Opacity for vesica elements (0–1).
- * @return {{rows:number,columns:number,paddingDivisor:number,radiusFactor:number,strokeDivisor:number,alpha:number}}
- *   A normalized vesica configuration with defaults applied and values coerced/clamped.
- */
-
-
-/**
- * Merge and sanitize vesica geometry settings with defaults.
- *
- * Accepts a partial vesica config and returns a fully populated, validated
- * settings object where numeric fields are coerced to positive numbers/integers
- * and alpha is clamped to a valid opacity value.
- *
- * @param {Object} [config={}] - Partial vesica configuration.
- * @param {number} [config.rows] - Number of grid rows (coerced to a positive integer).
- * @param {number} [config.columns] - Number of grid columns (coerced to a positive integer).
- * @param {number} [config.paddingDivisor] - Divisor controlling padding around the grid (positive number).
- * @param {number} [config.radiusFactor] - Multiplier applied to compute vesica circle radius (positive number).
- * @param {number} [config.strokeDivisor] - Divisor used to derive stroke width from radius (positive number).
- * @param {number} [config.alpha] - Opacity for vesica strokes (clamped to [0,1]; 0 preserved).
- * @returns {Object} A sanitized vesica geometry object with keys:
- *  - rows {number}
- *  - columns {number}
- *  - paddingDivisor {number}
- *  - radiusFactor {number}
- *  - strokeDivisor {number}
- *  - alpha {number}
- */
-
-
-
-function mergeVesica(config = {}) {
-  const base = DEFAULT_GEOMETRY.vesica;
-  return {
-    rows: toPositiveInteger(config.rows, base.rows),
-    columns: toPositiveInteger(config.columns, base.columns),
-    paddingDivisor: toPositiveNumber(
-      config.paddingDivisor,
-      base.paddingDivisor,
-    ),
-    radiusFactor: toPositiveNumber(config.radiusFactor, base.radiusFactor),
-    strokeDivisor: toPositiveNumber(config.strokeDivisor, base.strokeDivisor),
-    alpha: clampAlpha(config.alpha, base.alpha),
-  };
-}
-
-/**
- * Merge and sanitize a Tree-of-Life configuration, filling defaults and validating node/edge data.
- *
- * Accepts a partial config and returns a normalized tree configuration suitable for rendering.
- * - Nodes provided in config.nodes are normalized: missing fields fall back to the corresponding
- *   default node (cycled if there are more provided nodes than defaults). Each node is ensured to
- *   have an `id` (string), `title` (string), `level` (number), and `xFactor` (clamped to [0,1]).
- * - Edges provided in config.edges are normalized to 2-element arrays and filtered so both endpoints
- *   reference existing node ids; invalid or out-of-range edges are dropped.
- * - Numeric layout parameters fall back to defaults when missing or invalid.
- *
- * @param {Object} [config={}] - Partial Tree-of-Life configuration to merge.
- * @param {Array<Object>} [config.nodes] - Optional list of node objects; each may include `{ id, title, level, xFactor }`.
- * @param {Array<Array<string>>} [config.edges] - Optional list of edges as 2-item id pairs.
- * @param {number} [config.marginDivisor] - Optional margin divisor for layout; must be positive.
- * @param {number} [config.radiusDivisor] - Optional divisor controlling node radius; must be positive.
- * @param {number} [config.labelOffset] - Optional label offset in canvas units.
- * @param {string} [config.labelFont] - Optional CSS-like font string for node labels.
- * @returns {Object} Normalized tree configuration with properties:
- *   - {number} marginDivisor
- *   - {number} radiusDivisor
- *   - {number} labelOffset
- *   - {string} labelFont
- *   - {Array<Object>} nodes — each node has `{ id, title, level, xFactor }`
- *   - {Array<Array<string>>} edges — validated 2-item id pairs
- */
-
-
-/**
- * Normalize and sanitize a Tree-of-Life geometry object for rendering.
- *
- * Accepts a possibly partial or invalid `data` object and returns a safe, well-typed
- * tree configuration using FALLBACK_GEOMETRY.treeOfLife values where inputs are missing
- * or invalid. Node templates are merged with fallback templates (preserving node order),
- * numeric fields are coerced/validated (levels -> finiteNumber, xFactor -> clamped [0,1]),
- * and edges are filtered to include only two-item pairs that reference existing node IDs.
- *
- * @param {Object} data - Candidate tree configuration (may be partial or malformed).
- * @return {Object} A normalized tree object with properties:
- *   - marginDivisor {number}
- *   - radiusDivisor {number}
- *   - labelOffset {number}
- *   - labelLineHeight {number}
- *   - labelFont {string}
- *   - nodes {Array<Object>} Array of sanitized node objects { id, title, meaning, level, xFactor }
- *   - edges {Array<[string,string]>} Array of valid edges referencing node ids
- */
-
-
-/**
- * Merge and sanitize Tree-of-Life geometry configuration, returning a complete, safe structure.
- *
- * Produces a validated tree-of-life geometry object by applying defaults for missing values,
- * sanitizing node entries (ensuring each node has a stable id, title, numeric level, and an
- * xFactor clamped to [0,1]), and filtering edges so they reference existing node ids. If no
- * nodes or edges are supplied, the defaults are used. Other numeric layout values are coerced
- * to positive numbers or fall back to defaults.
- *
- * @param {Object} [config={}] - Partial geometry overrides.
- * @param {Array<Object>} [config.nodes] - Optional array of node overrides; each node may provide
- *   {id, title, level, xFactor}. Missing or invalid fields are replaced from defaults.
- * @param {Array<Array<string>>} [config.edges] - Optional array of edges as two-element id pairs.
- *   Edges referencing unknown node ids are dropped.
- * @param {number} [config.marginDivisor] - Optional positive number to override margin divisor.
- * @param {number} [config.radiusDivisor] - Optional positive number to override node radius divisor.
- * @param {number} [config.labelOffset] - Optional numeric label offset.
- * @param {string} [config.labelFont] - Optional font string for labels.
- * @return {Object} Sanitized tree geometry with keys:
- *   - marginDivisor {number}
- *   - radiusDivisor {number}
- *   - labelOffset {number}
- *   - labelFont {string}
- *   - nodes {Array<Object>} (each node: {id, title, level, xFactor})
- *   - edges {Array<Array<string>>} (filtered valid id pairs)
- */
-
-
-
-function mergeTree(config = {}) {
-  const base = DEFAULT_GEOMETRY.treeOfLife;
-  const nodes =
-    Array.isArray(config.nodes) && config.nodes.length > 0
-      ? config.nodes
-      : base.nodes;
-  const safeNodes = nodes.map((node, index) => {
-    const reference = base.nodes[index % base.nodes.length];
-    const data = typeof node === "object" && node !== null ? node : {};
-
-    return {
-      id: typeof data.id === "string" && data.id ? data.id : reference.id,
-      title:
-        typeof data.title === "string" && data.title
-          ? data.title
-          : reference.title,
-      level: Number.isFinite(data.level) ? data.level : reference.level,
-      xFactor: clamp01(
-        Number.isFinite(data.xFactor) ? data.xFactor : reference.xFactor,
-      ),
-
-
-    return {
-      id: typeof data.id === "string" && data.id ? data.id : reference.id,
-      title:
-        typeof data.title === "string" && data.title
-          ? data.title
-          : reference.title,
-      level: Number.isFinite(data.level) ? data.level : reference.level,
-      xFactor: clamp01(
-        Number.isFinite(data.xFactor) ? data.xFactor : reference.xFactor,
-      ),
-
-    return {
-      id: typeof data.id === "string" && data.id ? data.id : reference.id,
-      title:
-        typeof data.title === "string" && data.title
-          ? data.title
-          : reference.title,
-      level: Number.isFinite(data.level) ? data.level : reference.level,
-      xFactor: clamp01(
-        Number.isFinite(data.xFactor) ? data.xFactor : reference.xFactor,
-      ),
-
- * Normalize and sanitize a Tree-of-Life geometry object for rendering.
- *
- * Accepts a possibly partial or invalid `data` object and returns a safe, well-typed
- * tree configuration using FALLBACK_GEOMETRY.treeOfLife values where inputs are missing
- * or invalid. Node templates are merged with fallback templates (preserving node order),
- * numeric fields are coerced/validated (levels -> finiteNumber, xFactor -> clamped [0,1]),
- * and edges are filtered to include only two-item pairs that reference existing node IDs.
- *
- * @param {Object} data - Candidate tree configuration (may be partial or malformed).
- * @return {Object} A normalized tree object with properties:
- *   - marginDivisor {number}
- *   - radiusDivisor {number}
- *   - labelOffset {number}
- *   - labelLineHeight {number}
- *   - labelFont {string}
- *   - nodes {Array<Object>} Array of sanitized node objects { id, title, meaning, level, xFactor }
- *   - edges {Array<[string,string]>} Array of valid edges referencing node ids
- */
-
-function normaliseTree(data) {
-  const fallback = FALLBACK_GEOMETRY.treeOfLife;
-  const safe = data && typeof data === "object" ? data : {};
-  const fallbackNodes = fallback.nodes;
-  const providedNodes = Array.isArray(safe.nodes) && safe.nodes.length > 0 ? safe.nodes : fallbackNodes;
-  const nodes = fallbackNodes.map((template, index) => {
-    const candidate = typeof providedNodes[index] === "object" && providedNodes[index] !== null ? providedNodes[index] : {};
-    const base = fallbackNodes[index % fallbackNodes.length];
-    return {
-      id: typeof candidate.id === "string" && candidate.id ? candidate.id : base.id,
-      title: typeof candidate.title === "string" && candidate.title ? candidate.title : base.title,
-      meaning: typeof candidate.meaning === "string" ? candidate.meaning : base.meaning,
-      level: finiteNumber(candidate.level, base.level),
-      xFactor: clamp01(finiteNumber(candidate.xFactor, base.xFactor))
-
-
-    };
-  });
-
-  const nodeIds = new Set(safeNodes.map((node) => node.id));
-  const edges =
-    Array.isArray(config.edges) && config.edges.length > 0
-      ? config.edges
-      : base.edges;
-  const safeEdges = edges
-    .map((edge) => (Array.isArray(edge) ? edge.slice(0, 2) : []))
-    .filter(
-      (edge) =>
-        edge.length === 2 && nodeIds.has(edge[0]) && nodeIds.has(edge[1]),
-    );
-
-  return {
-
-    marginDivisor: toPositiveNumber(config.marginDivisor, base.marginDivisor),
-    radiusDivisor: toPositiveNumber(config.radiusDivisor, base.radiusDivisor),
-    labelOffset: Number.isFinite(config.labelOffset)
-      ? config.labelOffset
-      : base.labelOffset,
-    labelFont:
-      typeof config.labelFont === "string" && config.labelFont
-        ? config.labelFont
-        : base.labelFont,
-    nodes: safeNodes,
-    edges: safeEdges,
-
-  };
-}
-
-
-
-  };
-}
-
-/**
- * Merge and validate Fibonacci-curve geometry settings, filling missing values from DEFAULT_GEOMETRY.fibonacci.
- *
- * Accepts a partial config object and returns a fully populated, sanitized geometry object used to draw
- * the static Fibonacci/logarithmic spiral.
- *
- * @param {Object} [config] - Partial geometry overrides.
- * @param {number} [config.sampleCount] - Number of sample points along the curve; coerced to a positive integer.
- * @param {number} [config.turns] - Number of turns of the spiral; coerced to a positive number.
- * @param {number} [config.baseRadiusDivisor] - Divisor controlling the spiral's base radius; coerced to a positive number.
- * @param {number} [config.phi] - Growth constant (phi) for the logarithmic spiral; coerced to a positive number.
- * @param {number} [config.alpha] - Stroke alpha for the spiral; clamped to [0, 1] (zero preserved).
- * @return {{sampleCount: number, turns: number, baseRadiusDivisor: number, phi: number, alpha: number}} Sanitized Fibonacci geometry.
- */
-
-    marginDivisor: positiveNumber(safe.marginDivisor, fallback.marginDivisor),
-    radiusDivisor: positiveNumber(safe.radiusDivisor, fallback.radiusDivisor),
-    labelOffset: finiteNumber(safe.labelOffset, fallback.labelOffset),
-    labelLineHeight: positiveNumber(safe.labelLineHeight, fallback.labelLineHeight),
-    labelFont: typeof safe.labelFont === "string" && safe.labelFont ? safe.labelFont : fallback.labelFont,
-    nodes,
-    edges
-
-  };
-}
-
-
-/**
- * Merge and validate a Fibonacci-curve configuration with defaults.
- *
- * Returns a safe configuration object for the Fibonacci (logarithmic spiral) layer by
- * taking user-supplied values from `config`, validating/clamping them, and substituting
- * defaults from DEFAULT_GEOMETRY.fibonacci when values are missing or invalid.
- *
- * @param {Object} [config={}] - Partial Fibonacci configuration.
- * @param {number} [config.sampleCount] - Number of sample points along the spiral (positive integer).
- * @param {number} [config.turns] - Number of spiral turns (positive number).
- * @param {number} [config.baseRadiusDivisor] - Divisor controlling the spiral's base radius (positive number).
- * @param {number} [config.phi] - Growth factor (phi) used in the logarithmic spiral (positive number).
- * @param {number} [config.alpha] - Stroke alpha/transparency for the curve (0–1).
- * @return {{sampleCount:number, turns:number, baseRadiusDivisor:number, phi:number, alpha:number}} A normalized, validated Fibonacci configuration.
- */
-
-function mergeFibonacci(config = {}) {
-  const base = DEFAULT_GEOMETRY.fibonacci;
-  return {
-    sampleCount: toPositiveInteger(config.sampleCount, base.sampleCount),
-    turns: toPositiveNumber(config.turns, base.turns),
-    baseRadiusDivisor: toPositiveNumber(
-      config.baseRadiusDivisor,
-      base.baseRadiusDivisor,
-    ),
-    phi: toPositiveNumber(config.phi, base.phi),
-    alpha: clampAlpha(config.alpha, base.alpha),
-  };
-}
-
-/**
- * Merge and validate helix geometry settings with defaults.
- *
- * Returns a fully populated helix configuration where each numeric property is validated/coerced and clamped as needed.
- * Fields in the returned object:
- * - sampleCount: positive integer number of sample points along each strand
- * - cycles: positive number of helical cycles
- * - amplitudeDivisor: positive number controlling strand amplitude relative to canvas
- * - phaseOffset: numeric phase offset (radians)
- * - crossTieCount: positive integer number of cross-rungs between strands
- * - strandAlpha: alpha value in [0,1] used for strand rendering
- * - rungAlpha: alpha value in [0,1] used for rung rendering
- *
- * @param {Object} [config] - Partial helix configuration to merge.
- * @return {Object} Normalized helix configuration with validated numeric fields.
- */
-
-
-
-/**
- * Merge user-supplied helix geometry settings with defaults, validating and clamping values.
- *
- * Produces a fully-populated helix geometry object suitable for rendering by applying
- * numeric validation and fallbacks to DEFAULT_GEOMETRY.helix.
- *
- * @param {Object} [config] - Partial helix configuration overrides.
- * @param {number} [config.sampleCount] - Number of samples per strand; coerced to a positive integer.
- * @param {number} [config.cycles] - Number of helix cycles; coerced to a positive number.
- * @param {number} [config.amplitudeDivisor] - Divisor controlling helix amplitude; coerced to a positive number.
- * @param {number} [config.phaseOffset] - Phase offset (radians); used only if finite, otherwise default is kept.
- * @param {number} [config.crossTieCount] - Number of cross-ties (rungs) between strands; coerced to a positive integer.
- * @param {number} [config.strandAlpha] - Alpha for strand strokes; clamped to [0,1] (0 preserved) with a default fallback.
- * @param {number} [config.rungAlpha] - Alpha for rung strokes; clamped to [0,1] (0 preserved) with a default fallback.
- * @return {Object} Merged helix geometry with keys: sampleCount, cycles, amplitudeDivisor, phaseOffset, crossTieCount, strandAlpha, rungAlpha.
- */
-
-
-
-function mergeHelix(config = {}) {
-  const base = DEFAULT_GEOMETRY.helix;
-  return {
-    sampleCount: toPositiveInteger(config.sampleCount, base.sampleCount),
-    cycles: toPositiveNumber(config.cycles, base.cycles),
-    amplitudeDivisor: toPositiveNumber(
-      config.amplitudeDivisor,
-      base.amplitudeDivisor,
-    ),
-    phaseOffset: Number.isFinite(config.phaseOffset)
-      ? config.phaseOffset
-      : base.phaseOffset,
-    crossTieCount: toPositiveInteger(config.crossTieCount, base.crossTieCount),
-    strandAlpha: clampAlpha(config.strandAlpha, base.strandAlpha),
-    rungAlpha: clampAlpha(config.rungAlpha, base.rungAlpha),
-  };
-}
-
-
-/**
- * Fill the entire drawing area with the given color.
- *
- * Clears the canvas by filling a rectangle from (0,0) to (dims.width, dims.height).
- *
- * @param {{width: number, height: number}} dims - Canvas dimensions to clear.
- * @param {string} color - CSS color string used to fill the background.
- */
-
-
-
-/**
- * Fill the canvas drawing area with a solid color.
- *
- * Uses the provided CanvasRenderingContext2D to fill a rectangle from (0,0)
- * to (dims.width, dims.height) with the given CSS color.
- *
- * @param {Object} dims - Object with numeric `width` and `height` (drawing area size).
- * @param {string} color - CSS color string to use as the fill style (e.g. '#000', 'rgba(0,0,0,0.5)').
- */
-
-
-function clearStage(ctx, dims, color) {
-  ctx.fillStyle = color;
-  ctx.fillRect(0, 0, dims.width, dims.height);
-}
-
-/**
- * Draws a rectangular grid of vesica-like circular strokes onto the canvas.
- *
- * The grid is inset by a padding computed from the smaller canvas dimension and
- * settings.paddingDivisor. Circles are arranged in `rows` × `columns`, with
- * alternating-row horizontal offsets (checker-like lattice). Circle radius and
- * stroke width are derived from the grid step sizes and numerology constants;
- * stroke color is the provided `color` combined with `settings.alpha`.
- *
- * @param {number} width - Canvas drawing width in pixels.
- * @param {number} height - Canvas drawing height in pixels.
- * @param {string} color - Hex color string used for circle strokes.
- * @param {Object} N - Numerology constants object (keys like NINE, ELEVEN, THREE, THIRTYTHREE, NINETYNINE) used to scale radii and stroke widths.
- * @param {Object} settings - Vesica geometry controls:
- *   - rows {number}: number of rows (minimum 2).
- *   - columns {number}: number of columns (minimum 2).
- *   - paddingDivisor {number}: divisor applied to the smaller canvas dimension to compute padding.
- *   - radiusFactor {number}: divisor applied to step size to compute circle radius.
- *   - strokeDivisor {number}: divisor applied to canvas size to compute stroke width.
- *   - alpha {number}: stroke alpha in [0,1].
- */
-
-/**
- * Draws a grid of vesica piscis pairs (two overlapping circles) onto a 2D canvas context.
- *
- * Renders `rows × columns` pairs evenly distributed inside the provided dimensions, using
- * settings to derive padding, circle radius, horizontal offset between paired circles,
- * stroke width, and alpha. The function mutates the supplied canvas context by stroking
- * each vesica pair and returns summary metrics.
- *
- * @param {CanvasRenderingContext2D} ctx - Canvas 2D context to draw into.
- * @param {{width:number,height:number}} dims - Drawing area dimensions in pixels.
- * @param {string} color - Hex color used for strokes (converted with alpha).
- * @param {{ELEVEN:number,TWENTYTWO:number}} numbers - Numeric constants used to compute offsets (expects typical constants like ELEVEN and TWENTYTWO).
- * @param {Object} settings - Vesica field settings:
- *   - rows {number}: number of grid rows (min 1).
- *   - columns {number}: number of grid columns (min 1).
- *   - paddingDivisor {number}: divisor of the smaller canvas dimension to compute outer padding.
- *   - radiusFactor {number}: divisor applied to cell size to compute circle radius.
- *   - strokeDivisor {number}: divisor of canvas size to compute stroke width.
- *   - alpha {number}: stroke opacity in [0,1].
- *
- * @returns {{circles:number, radius:number}} Summary with the total number of circles drawn and the computed circle radius in pixels.
- */
-
-
-/**
- * Render a staggered grid of stroked circles ("vesica" field) across the canvas.
- *
- * Draws a padded, rectangular lattice of evenly spaced stroked circles. Rows can be horizontally offset
- * (every other row is shifted by half a column) to produce a staggered pattern. Vertical placement is
- * slightly compressed by a numerology-derived ratio (uses N.NINE and N.SEVEN). Circles whose centers
- * fall outside the padded drawing area (considering radius) are skipped.
- *
- * The function saves and restores the canvas context state; it does not return a value.
- *
- * @param {CanvasRenderingContext2D} ctx - Canvas 2D context to draw into.
- * @param {number} width - Full drawing width (pixels).
- * @param {number} height - Full drawing height (pixels).
- * @param {string} color - Base stroke color (hex string accepted); alpha from settings is applied.
- * @param {Object} N - Numerology constants object (expects numeric properties like NINE and SEVEN).
- * @param {Object} settings - Geometry settings:
- *   - rows {number} number of rows (min 2)
- *   - columns {number} number of columns (min 2)
- *   - paddingDivisor {number} divisor to compute padding from min(width,height)
- *   - radiusFactor {number} factor to derive circle radius from grid step
- *   - strokeDivisor {number} divisor to compute stroke width from min(width,height)
- *   - alpha {number} stroke alpha (0..1)
- */
-
-
-/**
- * Render a grid of overlapping "vesica" circle pairs across the padded drawable area.
- *
- * Computes per-cell positions from dims and settings, derives a radius, horizontal pair offset,
- * and stroke width, then strokes two circles per grid cell. Returns the number of circles drawn
- * and the computed radius in pixels.
- *
- * @param {Object} dims - Normalized drawable dimensions: { width, height }.
- * @param {string} color - Base stroke color (hex or any canvas-acceptable color); alpha applied from settings.
- * @param {Object} numbers - Numeric constants used for layout (used to compute the pair offset).
- * @param {Object} settings - Vesica layout options:
- *   - rows {number} number of grid rows (>=1)
- *   - columns {number} number of grid columns (>=1)
- *   - paddingDivisor {number} divisor to compute outer padding from min(width,height)
- *   - radiusFactor {number} divisor applied to cell step to compute circle radius
- *   - strokeDivisor {number} divisor to compute stroke width from min(width,height)
- *   - alpha {number} stroke alpha (0–1)
- * @return {{circles: number, radius: number}} Total circles stroked and the radius (px) used for each circle.
- */
-
-
-
-function drawVesicaField(ctx, dims, color, numbers, settings) {
-  const rows = Math.max(1, settings.rows);
-  const columns = Math.max(1, settings.columns);
-  const padding = Math.min(dims.width, dims.height) / settings.paddingDivisor;
-  const availableWidth = dims.width - padding * 2;
-  const availableHeight = dims.height - padding * 2;
-  const stepX = columns > 1 ? availableWidth / (columns - 1) : 0;
-  const stepY = rows > 1 ? availableHeight / (rows - 1) : 0;
-
-  const radius = Math.min(stepX, stepY) / settings.radiusFactor;
-  const offset = radius * (numbers.ELEVEN / numbers.TWENTYTWO);
-  const strokeWidth = Math.max(
-    1,
-    Math.min(dims.width, dims.height) / settings.strokeDivisor,
-  );
-
-
-  const radius = Math.min(stepX, stepY) / settings.radiusFactor;
-  const offset = radius * (numbers.ELEVEN / numbers.TWENTYTWO);
-  const strokeWidth = Math.max(
-    1,
-    Math.min(dims.width, dims.height) / settings.strokeDivisor,
-  );
-
-  const radius = Math.min(stepX, stepY) / settings.radiusFactor;
-  const offset = radius * (numbers.ELEVEN / numbers.TWENTYTWO);
-  const strokeWidth = Math.max(
-    1,
-    Math.min(dims.width, dims.height) / settings.strokeDivisor,
-  );
-
- * Render a staggered grid of stroked circles ("vesica" field) across the canvas.
- *
- * Draws a padded, rectangular lattice of evenly spaced stroked circles. Rows can be horizontally offset
- * (every other row is shifted by half a column) to produce a staggered pattern. Vertical placement is
- * slightly compressed by a numerology-derived ratio (uses N.NINE and N.SEVEN). Circles whose centers
- * fall outside the padded drawing area (considering radius) are skipped.
- *
- * The function saves and restores the canvas context state; it does not return a value.
- *
- * @param {CanvasRenderingContext2D} ctx - Canvas 2D context to draw into.
- * @param {number} width - Full drawing width (pixels).
- * @param {number} height - Full drawing height (pixels).
- * @param {string} color - Base stroke color (hex string accepted); alpha from settings is applied.
- * @param {Object} N - Numerology constants object (expects numeric properties like NINE and SEVEN).
- * @param {Object} settings - Geometry settings:
- *   - rows {number} number of rows (min 2)
- *   - columns {number} number of columns (min 2)
- *   - paddingDivisor {number} divisor to compute padding from min(width,height)
- *   - radiusFactor {number} factor to derive circle radius from grid step
- *   - strokeDivisor {number} divisor to compute stroke width from min(width,height)
- *   - alpha {number} stroke alpha (0..1)
- */
-
-function drawVesicaField(ctx, width, height, color, N, settings) {
-  const rows = Math.max(2, settings.rows);
-  const columns = Math.max(2, settings.columns);
-  const padding = Math.min(width, height) / settings.paddingDivisor;
-
-  const spanX = width - padding * 2;
-  const spanY = height - padding * 2;
-  const stepX = columns > 1 ? spanX / (columns - 1) : spanX;
-  const stepY = rows > 1 ? spanY / (rows - 1) : spanY;
-  const radius = Math.min(stepX, stepY) * (N.NINE / N.ELEVEN) / settings.radiusFactor;
-  const strokeWidth = Math.max(1, Math.min(width, height) / settings.strokeDivisor) * (N.THIRTYTHREE / N.NINETYNINE);
-
-  const horizontalSpan = width - padding * 2;
-  const verticalSpan = height - padding * 2;
-  const stepX = columns > 1 ? horizontalSpan / (columns - 1) : 0;
-  const stepY = rows > 1 ? verticalSpan / (rows - 1) : 0;
-  const radius = Math.min(stepX, stepY) / settings.radiusFactor;
-  const strokeWidth = Math.max(1, Math.min(width, height) / settings.strokeDivisor);
-
-
-
+  const numbers = normaliseNumbers(options.NUM);
+  const palette = normalisePalette(options.palette);
+  const geometry = normaliseGeometry(options.geometry);
+  const notice = typeof options.notice === "string" && options.notice.trim() ? options.notice.trim() : null;
 
   ctx.save();
-  ctx.strokeStyle = colorWithAlpha(color, settings.alpha);
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+  ctx.clearRect(0, 0, width, height);
+  ctx.fillStyle = palette.bg;
+  ctx.fillRect(0, 0, width, height);
+  ctx.restore();
+
+  const dims = { width, height };
+  drawVesicaField(ctx, dims, palette, geometry.vesica, numbers);
+  drawTreeOfLife(ctx, dims, palette, geometry.treeOfLife, numbers);
+  drawFibonacciCurve(ctx, dims, palette, geometry.fibonacci, numbers);
+  drawDoubleHelix(ctx, dims, palette, geometry.helix, numbers);
+
+  if (notice) {
+    drawNotice(ctx, dims, palette, notice);
+  }
+
+  return { ok: true, notice };
+}
+
+function drawVesicaField(ctx, dims, palette, geo, numbers) {
+  const columns = Math.max(2, Math.floor(toPositiveNumber(geo.columns, DEFAULT_GEOMETRY.vesica.columns)));
+  const rows = Math.max(2, Math.floor(toPositiveNumber(geo.rows, DEFAULT_GEOMETRY.vesica.rows)));
+  const margin = Math.min(dims.width, dims.height) / toPositiveNumber(geo.paddingFactor, DEFAULT_GEOMETRY.vesica.paddingFactor);
+  const gridWidth = dims.width - margin * 2;
+  const gridHeight = dims.height - margin * 2;
+  const stepX = gridWidth / (columns - 1);
+  const stepY = gridHeight / (rows - 1);
+  const baseRadius = Math.min(stepX, stepY) / toPositiveNumber(geo.radiusFactor, DEFAULT_GEOMETRY.vesica.radiusFactor);
+  const strokeDivisor = toPositiveNumber(geo.strokeDivisor, DEFAULT_GEOMETRY.vesica.strokeDivisor);
+  const strokeWidth = Math.max(0.75, Math.min(stepX, stepY) / strokeDivisor * numbers.THREE);
+
+  ctx.save();
+  ctx.strokeStyle = applyAlpha(getLayerColor(palette, 0), clamp01(geo.alpha));
   ctx.lineWidth = strokeWidth;
   ctx.lineCap = "round";
 
-  ctx.lineJoin = "round";
-
-
-
-  let circles = 0;
   for (let row = 0; row < rows; row += 1) {
-    for (let column = 0; column < columns; column += 1) {
-      const cx = padding + column * stepX;
-      const cy = padding + row * stepY;
-      strokeVesicaPair(ctx, cx, cy, radius, offset);
-      circles += 2;
-
-
-
-/**
- * Stroke a pair of equal circles (a vesica pair) horizontally offset from a center point.
- *
- * Draws two stroked circles centered at (cx - offset, cy) and (cx + offset, cy) with the given radius.
- *
- * @param {CanvasRenderingContext2D} ctx - 2D rendering context to draw onto.
- * @param {number} cx - X coordinate of the pair's central anchor point.
- * @param {number} cy - Y coordinate of the pair's central anchor point.
- * @param {number} radius - Radius of each circle.
- * @param {number} offset - Horizontal offset from the central anchor to each circle's center.
- */
-function strokeVesicaPair(ctx, cx, cy, radius, offset) {
-  ctx.beginPath();
-  ctx.arc(cx - offset, cy, radius, 0, Math.PI * 2);
-  ctx.stroke();
-  ctx.beginPath();
-  ctx.arc(cx + offset, cy, radius, 0, Math.PI * 2);
-  ctx.stroke();
-}
-
-/**
- * Render a Tree-of-Life scaffold (edges and nodes) onto the provided 2D canvas context.
- *
- * Draws straight edges between configured node pairs, fills and strokes node circles,
- * and optionally renders centered node labels. Node positions are laid out vertically
- * by `level` and horizontally by `xFactor`, all constrained inside an inner margin
- * computed from `settings.marginDivisor`.
- *
- * settings: an object that must include:
- * - nodes: array of node objects with { id, title, level, xFactor } used to compute positions.
- * - edges: array of [fromId, toId] pairs referencing node ids.
- * - marginDivisor: number dividing the smaller canvas dimension to compute outer margin.
- * - radiusDivisor: number dividing the smaller canvas dimension to compute node radius.
- * - labelOffset: vertical offset (pixels) applied when drawing labels (0 to disable).
- * - labelFont: CSS font string used when drawing labels.
- *
- * Returns an object with counts of rendered elements: { nodes, paths }.
- */
-
-
-
-  let circles = 0;
-  for (let row = 0; row < rows; row += 1) {
-    for (let column = 0; column < columns; column += 1) {
-      const cx = padding + column * stepX;
-      const cy = padding + row * stepY;
-      strokeVesicaPair(ctx, cx, cy, radius, offset);
-      circles += 2;
-
-  ctx.lineJoin = "round";
-
-
-  let circles = 0;
-  for (let row = 0; row < rows; row += 1) {
-
-    const offset = row % 2 === 0 ? 0 : stepX / N.THREE;
-    const baseY = padding + row * stepY;
-    const y = clamp(baseY, padding, height - padding);
-    for (let column = 0; column < columns; column += 1) {
-      const baseX = padding + column * stepX + offset;
-      const x = clamp(baseX, padding, width - padding);
-      strokeCircle(ctx, x, y, radius);
-
-
-    for (let column = 0; column < columns; column += 1) {
-      const cx = padding + column * stepX;
-      const cy = padding + row * stepY;
-      strokeVesicaPair(ctx, cx, cy, radius, offset);
-      circles += 2;
-
-    const ratioY = rows > 1 ? row / (rows - 1) : 0;
-    const y = padding + Math.min(1, ratioY * (N.NINE / N.SEVEN)) * verticalSpan;
-    const offset = row % 2 === 0 ? 0 : stepX / 2;
-
-    for (let column = 0; column < columns; column += 1) {
-      const ratioX = columns > 1 ? column / (columns - 1) : 0;
-      const x = padding + offset + ratioX * horizontalSpan;
-      if (x < padding - radius || x > width - padding + radius) {
-        continue;
-      }
-      strokeCircle(ctx, x, y, radius);
-
-
-
-
+    for (let col = 0; col < columns; col += 1) {
+      const x = margin + col * stepX;
+      const y = margin + row * stepY;
+      ctx.beginPath();
+      ctx.arc(x, y, baseRadius, 0, Math.PI * 2);
+      ctx.stroke();
     }
   }
 
+  // Highlight central vesica pair (why: keeps womb-of-forms emphasis without motion).
+  const centerRadius = Math.min(gridWidth, gridHeight) / numbers.THREE;
+  const centerX = dims.width / 2;
+  const centerY = dims.height / 2;
+  ctx.strokeStyle = applyAlpha(getLayerColor(palette, 1), clamp01(geo.alpha * 0.75));
+  ctx.beginPath();
+  ctx.arc(centerX - centerRadius / 2, centerY, centerRadius, 0, Math.PI * 2);
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.arc(centerX + centerRadius / 2, centerY, centerRadius, 0, Math.PI * 2);
+  ctx.stroke();
+
   ctx.restore();
-  return { circles, radius };
-
 }
 
-/**
- * Render the "Tree of Life" layer: connective lines, filled node glyphs, and textual labels.
- *
- * Draws edges behind nodes, renders each node as a filled/stroked circle, and draws two-line
- * labels beneath each node. Coordinates are computed from the provided geometry (levels and
- * xFactor) and are clamped to the canvas bounds; edges referencing missing node ids are ignored.
- *
- * @param {CanvasRenderingContext2D} ctx - Canvas 2D context to draw into.
- * @param {number} width - Canvas drawing width in pixels.
- * @param {number} height - Canvas drawing height in pixels.
- * @param {string} pathColor - Base color for connective lines (hex or CSS color).
- * @param {string} nodeColor - Base color for node fills and strokes (hex or CSS color).
- * @param {string} labelColor - Color used for node labels (hex or CSS color).
- * @param {object} N - Numerology constants (expects numeric keys used for sizing/scaling).
- * @param {object} tree - Normalized tree geometry and content:
- *   - marginDivisor {number} controls outer margin as min(width,height)/marginDivisor.
- *   - radiusDivisor {number} controls node radius as min(width,height)/radiusDivisor.
- *   - labelOffset {number} vertical offset for label placement below each node.
- *   - labelFont {string} CSS font used for labels.
- *   - nodes {Array} array of node objects with at least: id (string), level (number), xFactor (0–1),
- *     title (string), meaning (string).
- *   - edges {Array} array of two-element id arrays [fromId, toId]; edges with unknown ids are skipped.
- */
-
-/**
- * Stroke two horizontally offset circles (a vesica pair) about a central anchor.
- *
- * Renders two full-circle arcs centered at (cx - offset, cy) and (cx + offset, cy)
- * and strokes them using the canvas context's current stroke style and line width.
- *
- * @param {number} cx - X coordinate of the pair's central anchor point.
- * @param {number} cy - Y coordinate of the pair's central anchor point.
- * @param {number} radius - Radius of each circle (expected > 0).
- * @param {number} offset - Horizontal distance from the anchor to each circle's center.
- */
-function strokeVesicaPair(ctx, cx, cy, radius, offset) {
-  ctx.beginPath();
-  ctx.arc(cx - offset, cy, radius, 0, Math.PI * 2);
-  ctx.stroke();
-  ctx.beginPath();
-  ctx.arc(cx + offset, cy, radius, 0, Math.PI * 2);
-  ctx.stroke();
-
-}
-
-function strokeVesicaPair(ctx, cx, cy, radius, offset) {
-  ctx.beginPath();
-  ctx.arc(cx - offset, cy, radius, 0, Math.PI * 2);
-  ctx.stroke();
-  ctx.beginPath();
-  ctx.arc(cx + offset, cy, radius, 0, Math.PI * 2);
-  ctx.stroke();
-}
-
-
-/**
- * Render the Tree of Life scaffold (edges, node discs, and optional centered labels) onto a 2D canvas.
- *
- * Layout:
- * - Positions nodes inside an inner margin computed from dims and settings.marginDivisor.
- * - Node x-positions are determined by each node's `xFactor` (clamped to [0,1]); y-positions are derived from node `level`.
- * - Edges are stroked between sanitized node positions using a path width scaled by `numbers.NINETYNINE`.
- * - Nodes are drawn as filled circles with stroked outlines sized by settings.radiusDivisor.
- * - If settings.labelOffset and settings.labelFont are provided, node titles are drawn centered at a vertical offset.
- *
- * @param {Object} dims - Canvas dimensions with numeric `width` and `height`.
- * @param {Object} palette - Color palette (expects at least `layers` array and `ink`) used for strokes/fills.
- * @param {Object} numbers - Numeric constants (uses `numbers.NINETYNINE` to compute edge path width).
- * @param {Object} settings - Tree geometry and rendering options:
- *   - {Array<Object>} nodes - Array of nodes: each must include `id`, `title`, `level`, and `xFactor`.
- *   - {Array<[string,string]>} edges - Array of [fromId, toId] pairs; non-matching ids are skipped.
- *   - {number} marginDivisor - Divisor of the smaller canvas dimension to compute outer margin.
- *   - {number} radiusDivisor - Divisor of the smaller canvas dimension to compute node radius.
- *   - {number} labelOffset - Vertical offset for labels (0 disables labels).
- *   - {string} labelFont - CSS font string used when rendering labels.
- *
- * @returns {{nodes: number, paths: number}} Counts: number of positioned nodes and number of declared edges.
- */
-
-function strokeVesicaPair(ctx, cx, cy, radius, offset) {
-  ctx.beginPath();
-  ctx.arc(cx - offset, cy, radius, 0, Math.PI * 2);
-  ctx.stroke();
-  ctx.beginPath();
-  ctx.arc(cx + offset, cy, radius, 0, Math.PI * 2);
-  ctx.stroke();
-}
-
-
-/**
- * Render the Tree-of-Life layer: connective edges, nodes, and labels onto the canvas context.
- *
- * Draws edges first (semi-transparent stroked lines), then node discs with outlines, then centered labels
- * (title and optional meaning) below each node. Positions are computed from `tree` layout parameters:
- * margins, node `level` (vertical spacing), and node `xFactor` (horizontal position as a 0..1 factor).
- *
- * `tree` shape (required): an object with the following properties used by this renderer:
- * - marginDivisor: number — divisor of min(width,height) to compute outer margin.
- * - radiusDivisor: number — divisor of min(width,height) to compute node radius.
- * - labelOffset: number — vertical offset in pixels from node center to first label line.
- * - labelLineHeight: number — vertical spacing between label lines.
- * - labelFont: string — CSS font used for label text.
- * - nodes: array of node objects, each with:
- *     - id: string — unique identifier.
- *     - title: string — primary label text.
- *     - meaning?: string — optional second-line label.
- *     - level: number — integer level (0..N) used to compute vertical placement.
- *     - xFactor: number — horizontal placement factor clamped to [0,1].
- * - edges: array of [fromId, toId] pairs. Edges referencing missing node ids are ignored.
- *
- * Side effects: issues drawing commands on the provided 2D canvas rendering context. No return value.
- */
-
-
-
-
-function drawTreeOfLife(ctx, dims, palette, numbers, settings) {
-  const margin = Math.min(dims.width, dims.height) / settings.marginDivisor;
+function drawTreeOfLife(ctx, dims, palette, geo, numbers) {
+  const margin = Math.min(dims.width, dims.height) / toPositiveNumber(geo.marginFactor, DEFAULT_GEOMETRY.treeOfLife.marginFactor);
+  const verticalSpace = dims.height - margin * 2;
+  const levels = geo.nodes.map(node => node.level);
+  const maxLevel = levels.length ? Math.max(...levels) : 1;
+  const levelStep = maxLevel > 0 ? verticalSpace / maxLevel : verticalSpace;
   const usableWidth = dims.width - margin * 2;
-  const usableHeight = dims.height - margin * 2;
-  const radius = Math.max(
-    4,
-    Math.min(dims.width, dims.height) / settings.radiusDivisor,
-  );
-  const pathWidth = Math.max(
-    1,
-    Math.min(dims.width, dims.height) / numbers.NINETYNINE,
-  );
-
-  const maxLevel = settings.nodes.reduce(
-    (acc, node) => Math.max(acc, node.level),
-    0,
-  );
-  const levelStep = maxLevel > 0 ? usableHeight / maxLevel : 0;
-
+  const nodeRadius = Math.max(6, Math.min(dims.width, dims.height) / toPositiveNumber(geo.radiusDivisor, DEFAULT_GEOMETRY.treeOfLife.radiusDivisor));
+  const pathWidth = Math.max(1.5, nodeRadius / toPositiveNumber(geo.pathWidthDivisor, DEFAULT_GEOMETRY.treeOfLife.pathWidthDivisor) * numbers.SEVEN);
 
   const positions = new Map();
-  for (const node of settings.nodes) {
+  geo.nodes.forEach(node => {
     const x = margin + clamp01(node.xFactor) * usableWidth;
     const y = margin + node.level * levelStep;
-
-
-
-  const positions = new Map();
-  for (const node of settings.nodes) {
-    const x = margin + clamp01(node.xFactor) * usableWidth;
-    const y = margin + node.level * levelStep;
-
-
-  const positions = new Map();
-  for (const node of settings.nodes) {
-    const x = margin + clamp01(node.xFactor) * usableWidth;
-    const y = margin + node.level * levelStep;
-    positions.set(node.id, { x, y, node });
-  }
+    positions.set(node.id, { x, y, data: node });
+  });
 
   ctx.save();
-  ctx.strokeStyle = colorWithAlpha(palette.layers[1], 0.7);
+  ctx.strokeStyle = applyAlpha(getLayerColor(palette, 1), 0.7);
   ctx.lineWidth = pathWidth;
   ctx.lineCap = "round";
-  ctx.lineJoin = "round";
-  for (const [fromId, toId] of settings.edges) {
-    const from = positions.get(fromId);
-    const to = positions.get(toId);
-    if (!from || !to) {
-      continue;
-    }
-    ctx.beginPath();
-    ctx.moveTo(from.x, from.y);
-    ctx.lineTo(to.x, to.y);
-    ctx.stroke();
-  }
-  ctx.restore();
 
-  ctx.save();
-  ctx.fillStyle = palette.layers[2];
-  ctx.strokeStyle = palette.ink;
-  ctx.lineWidth = Math.max(1, pathWidth * 0.75);
-  for (const point of positions.values()) {
-
- * Render the Tree-of-Life layer: connective edges, nodes, and labels onto the canvas context.
- *
- * Draws edges first (semi-transparent stroked lines), then node discs with outlines, then centered labels
- * (title and optional meaning) below each node. Positions are computed from `tree` layout parameters:
- * margins, node `level` (vertical spacing), and node `xFactor` (horizontal position as a 0..1 factor).
- *
- * `tree` shape (required): an object with the following properties used by this renderer:
- * - marginDivisor: number — divisor of min(width,height) to compute outer margin.
- * - radiusDivisor: number — divisor of min(width,height) to compute node radius.
- * - labelOffset: number — vertical offset in pixels from node center to first label line.
- * - labelLineHeight: number — vertical spacing between label lines.
- * - labelFont: string — CSS font used for label text.
- * - nodes: array of node objects, each with:
- *     - id: string — unique identifier.
- *     - title: string — primary label text.
- *     - meaning?: string — optional second-line label.
- *     - level: number — integer level (0..N) used to compute vertical placement.
- *     - xFactor: number — horizontal placement factor clamped to [0,1].
- * - edges: array of [fromId, toId] pairs. Edges referencing missing node ids are ignored.
- *
- * Side effects: issues drawing commands on the provided 2D canvas rendering context. No return value.
- */
-
-
-function drawTreeOfLife(ctx, width, height, pathColor, nodeColor, labelColor, N, tree) {
-  const margin = Math.min(width, height) / tree.marginDivisor;
-  const top = margin;
-  const bottom = height - margin;
-
-  const horizontalSpan = width - margin * 2;
-  const maxLevel = tree.nodes.reduce((acc, node) => Math.max(acc, node.level), 0);
-  const levelStep = maxLevel > 0 ? (bottom - top) / Math.max(1, maxLevel) : 0;
-  const radius = Math.max(4, Math.min(width, height) / tree.radiusDivisor);
-  const pathWidth = Math.max(1, Math.min(width, height) / N.NINETYNINE);
-
-  const positions = new Map();
-  for (const node of tree.nodes) {
-    const usableLevel = clamp(node.level, 0, maxLevel);
-    const rawY = top + usableLevel * levelStep * (N.NINE / N.ELEVEN);
-    const y = clamp(rawY, top, bottom);
-    const x = margin + clamp01(node.xFactor) * horizontalSpan;
-
-  const verticalSpan = bottom - top;
-  const maxLevel = tree.nodes.reduce((acc, node) => Math.max(acc, node.level), 0);
-  const levelStep = maxLevel > 0 ? verticalSpan / maxLevel : 0;
-  const radius = Math.max(4, Math.min(width, height) / tree.radiusDivisor);
-  const lineWidth = Math.max(1, Math.min(width, height) / N.NINETYNINE);
-
-  const positions = new Map();
-  tree.nodes.forEach((node) => {
-    const x = margin + clamp01(node.xFactor) * (width - margin * 2);
-    const y = top + node.level * levelStep;
-
-
-
-    positions.set(node.id, { x, y, node });
-  });
-
-
-  // Calm connective lines sit behind the node glyphs (why: maintains layered depth).
-  ctx.save();
-
-  // Calm connective lines first so nodes remain readable (why: layered depth).
-
-
-  ctx.strokeStyle = colorWithAlpha(palette.layers[1], 0.7);
-  ctx.lineWidth = pathWidth;
-  ctx.lineCap = "round";
-  ctx.lineJoin = "round";
-  for (const [fromId, toId] of settings.edges) {
-    const from = positions.get(fromId);
-    const to = positions.get(toId);
-    if (!from || !to) {
-      continue;
-    }
-    ctx.beginPath();
-    ctx.moveTo(from.x, from.y);
-    ctx.lineTo(to.x, to.y);
-    ctx.stroke();
-  }
-
-  ctx.stroke();
-  ctx.restore();
-
-  // Sephirot overlay to keep them legible.
-  ctx.save();
-  ctx.fillStyle = colorWithAlpha(nodeColor, 0.9);
-  ctx.strokeStyle = colorWithAlpha(nodeColor, 0.9);
-  ctx.lineWidth = Math.max(1, pathWidth * (N.THREE / N.TWENTYTWO));
-  for (const entry of positions.values()) {
-
-  ctx.restore();
-
-  ctx.save();
-  ctx.fillStyle = palette.layers[2];
-  ctx.strokeStyle = palette.ink;
-  ctx.lineWidth = Math.max(1, pathWidth * 0.75);
-  for (const point of positions.values()) {
-d
-
-  ctx.strokeStyle = colorWithAlpha(pathColor, 0.75);
-  ctx.lineWidth = lineWidth;
-  ctx.lineCap = "round";
-  ctx.lineJoin = "round";
-  tree.edges.forEach((edge) => {
-    const start = positions.get(edge[0]);
-    const end = positions.get(edge[1]);
-    if (!start || !end) {
-      return;
-    }
-    ctx.beginPath();
-    ctx.moveTo(start.x, start.y);
-    ctx.lineTo(end.x, end.y);
-    ctx.stroke();
-  });
-  ctx.restore();
-
-  ctx.save();
-  ctx.fillStyle = nodeColor;
-  ctx.strokeStyle = colorWithAlpha(nodeColor, 0.9);
-  ctx.lineWidth = Math.max(1, lineWidth * 0.75);
-  positions.forEach((entry) => {
-
-
-
-
-    ctx.beginPath();
-    ctx.arc(point.x, point.y, radius, 0, Math.PI * 2);
-    ctx.fill();
-    ctx.stroke();
-
-  }
-  ctx.restore();
-
-  // Labels explain lore without crowding.
-  ctx.save();
-  ctx.fillStyle = colorWithAlpha(labelColor, 0.88);
-  ctx.font = tree.labelFont;
-  ctx.textAlign = "center";
-  ctx.textBaseline = "top";
-  for (const entry of positions.values()) {
-    const textY = entry.y + tree.labelOffset;
-    ctx.fillText(entry.node.title, entry.x, textY);
-    ctx.fillText(entry.node.meaning, entry.x, textY + 14);
-  }
-
-
-
-
-  }
-  ctx.restore();
-
-  if (settings.labelOffset !== 0 && settings.labelFont) {
-    ctx.save();
-    ctx.fillStyle = palette.ink;
-    ctx.font = settings.labelFont;
-    ctx.textAlign = "center";
-    ctx.textBaseline = "middle";
-    for (const point of positions.values()) {
-      const labelY = point.y + settings.labelOffset;
-      ctx.fillText(point.node.title, point.x, labelY);
-    }
-    ctx.restore();
-  }
-
-  return { nodes: positions.size, paths: settings.edges.length };
-
-}
-
-function drawFibonacciCurve(ctx, dims, color, numbers, settings) {
-  const samples = Math.max(2, settings.sampleCount);
-  const turns = settings.turns;
-  const phi = Math.max(1.0001, settings.phi);
-  const totalAngle = turns * Math.PI * 2;
-  const baseRadius =
-    Math.min(dims.width, dims.height) / settings.baseRadiusDivisor;
-  const lineWidth = Math.max(
-    1,
-    Math.min(dims.width, dims.height) / numbers.NINETYNINE,
-  );
-  const centerX = dims.width * 0.72;
-  const centerY = dims.height * 0.28;
-
-
-}
-
-/**
- * Draws a golden-spiral-like Fibonacci curve onto the provided 2D canvas context.
- *
- * The curve is rendered as a stroked polyline centered proportionally within the canvas
- * using numerology constants for placement and the provided settings for sampling and scale.
- *
- * @param {number} width - Canvas width in pixels.
- * @param {number} height - Canvas height in pixels.
- * @param {string} color - Base hex color used for the stroke.
- * @param {Object} N - Numerology constants used for proportional placement and sizing.
- * @param {Object} settings - Curve parameters.
- * @param {number} settings.sampleCount - Number of points sampled along the curve (minimum 2).
- * @param {number} settings.turns - Number of full revolutions the spiral makes (>= 0).
- * @param {number} settings.phi - Growth factor for radius (clamped to >= 1.0001).
- * @param {number} settings.baseRadiusDivisor - Divisor of min(width,height) to compute base radius.
- * @param {number} settings.alpha - Stroke alpha applied to the color (0–1).
-
- * Render a logarithmic (Fibonacci) spiral as a stroked polyline and return sampling info.
- *
- * Draws a logarithmic spiral centered at (72% width, 28% height) of the canvas. The spiral is sampled
- * uniformly in angle over `turns` full rotations; radius increases multiplicatively by `phi` per turn.
- *
- * @param {Object} dims - Canvas dimensions object with numeric `width` and `height`.
- * @param {string} color - Stroke color (hex or any valid CSS color string).
- * @param {Object} numbers - Numeric constants; used to compute stroke width (expects `numbers.NINETYNINE`).
- * @param {Object} settings - Spiral configuration:
- *   - {number} sampleCount: number of sample points along the spiral (minimum 2).
- *   - {number} turns: number of full rotations to draw.
- *   - {number} phi: growth factor per turn (clamped to at least 1.0001).
- *   - {number} baseRadiusDivisor: divisor of the smaller canvas dimension to derive the base radius.
- *   - {number} alpha: stroke alpha in [0,1].
- * @returns {{points: number}} Object containing `points`, the number of samples drawn.
-
- * Draws a static Fibonacci/logarithmic spiral as a stroked polyline on a 2D canvas.
- *
- * The spiral is sampled at `settings.sampleCount` points, centered at a fixed
- * offset (72% width, 28% height) and stroked using `color` combined with
- * `settings.alpha`. The growth per turn is controlled by `settings.phi`.
- *
- * @param {Object} dims - Canvas dimensions containing numeric `width` and `height`.
- * @param {string} color - Base hex color (e.g. "#rrggbb") used for the stroke; alpha is applied from `settings.alpha`.
- * @param {Object} numbers - Numeric constants used for scaling (e.g. line width divisor like NINETYNINE).
- * @param {Object} settings - Spiral settings:
- *   - {number} sampleCount - Number of sampled points along the spiral (minimum 2).
- *   - {number} turns - Number of full rotations.
- *   - {number} phi - Growth factor per turn (values < 1.0001 are clamped to 1.0001).
- *   - {number} baseRadiusDivisor - Divisor of min(width,height) to compute base radius.
- *   - {number} alpha - Stroke alpha in [0,1].
- * @return {{points: number}} Object with `points` equal to the number of sampled points drawn.
-
- */
-function drawFibonacciCurve(ctx, dims, color, numbers, settings) {
-  const samples = Math.max(2, settings.sampleCount);
-  const turns = settings.turns;
-  const phi = Math.max(1.0001, settings.phi);
-  const totalAngle = turns * Math.PI * 2;
-  const baseRadius =
-    Math.min(dims.width, dims.height) / settings.baseRadiusDivisor;
-  const lineWidth = Math.max(
-    1,
-    Math.min(dims.width, dims.height) / numbers.NINETYNINE,
-  );
-  const centerX = dims.width * 0.72;
-  const centerY = dims.height * 0.28;
-
-}
-
-function drawFibonacciCurve(ctx, dims, color, numbers, settings) {
-  const samples = Math.max(2, settings.sampleCount);
-  const turns = settings.turns;
-  const phi = Math.max(1.0001, settings.phi);
-  const totalAngle = turns * Math.PI * 2;
-  const baseRadius =
-    Math.min(dims.width, dims.height) / settings.baseRadiusDivisor;
-  const lineWidth = Math.max(
-    1,
-    Math.min(dims.width, dims.height) / numbers.NINETYNINE,
-  );
-  const centerX = dims.width * 0.72;
-  const centerY = dims.height * 0.28;
-
-  });
-  ctx.restore();
-
-  ctx.save();
-  ctx.fillStyle = labelColor;
-  ctx.font = tree.labelFont;
-  ctx.textAlign = "center";
-  ctx.textBaseline = "top";
-  const lineHeight = tree.labelLineHeight;
-  positions.forEach((entry) => {
-    const baseY = entry.y + tree.labelOffset;
-    ctx.fillText(entry.node.title, entry.x, baseY);
-    if (entry.node.meaning) {
-      ctx.fillText(entry.node.meaning, entry.x, baseY + lineHeight);
-    }
-  });
-
-  ctx.restore();
-}
-
-/**
- * Draws a Fibonacci-style spiral curve onto the canvas context.
- *
- * The function samples points along an exponential (phi-based) polar spiral and renders
- * a stroked polyline using the provided color and settings. If `settings.turns` is zero
- * the function exits without drawing.
- *
- * @param {object} N - Numerology constants (object with numeric keys such as TWENTYTWO, ELEVEN, NINETYNINE) used for positioning and scale offsets.
- * @param {object} settings - Geometry and sampling controls:
- *   - {number} sampleCount: number of points to sample along the curve (minimum 2).
- *   - {number} turns: number of full revolutions; if 0 the function does nothing.
- *   - {number} baseRadiusDivisor: divisor used to compute maximum radius from canvas size.
- *   - {number} phi: growth base (golden-ratio-like factor) controlling exponential radius growth.
- *   - {number} alpha: stroke alpha applied to the provided color.
- */
-function drawFibonacciCurve(ctx, width, height, color, N, settings) {
-
-  const samples = Math.max(2, settings.sampleCount);
-  const turns = Math.max(0, settings.turns);
-  const totalAngle = turns * Math.PI * 2;
-  const phi = Math.max(1.0001, settings.phi);
-  const centerX = width * (N.ELEVEN / N.TWENTYTWO);
-  const centerY = height * (N.SEVEN / N.ELEVEN);
-  const baseRadius = Math.min(width, height) / settings.baseRadiusDivisor;
-  const lineWidth = Math.max(1, Math.min(width, height) / N.NINETYNINE);
-
-  const sampleCount = Math.max(2, settings.sampleCount);
-  const turns = Math.max(0, settings.turns);
-  if (turns === 0) {
-    return;
-  }
-  const phi = Math.max(1.0001, settings.phi);
-  const totalAngle = turns * Math.PI * 2;
-  const maxRadius = Math.min(width, height) / settings.baseRadiusDivisor;
-  const growth = Math.pow(phi, turns);
-  const baseRadius = maxRadius / growth;
-  const centerX = width / 2 + width / N.TWENTYTWO;
-  const centerY = height / 2 - height / N.ELEVEN;
-  const lineWidth = Math.max(1, Math.min(width, height) / N.NINETYNINE);
-
-
-
-
-
-  ctx.save();
-  ctx.strokeStyle = colorWithAlpha(color, settings.alpha);
-  ctx.lineWidth = lineWidth;
-  ctx.lineCap = "round";
-  ctx.lineJoin = "round";
-  ctx.beginPath();
-
-
-  for (let index = 0; index < samples; index += 1) {
-    const t = samples > 1 ? index / (samples - 1) : 0;
-
-  for (let index = 0; index < samples; index += 1) {
-    const t = samples > 1 ? index / (samples - 1) : 0;
-
-
-  for (let index = 0; index < samples; index += 1) {
-    const t = samples > 1 ? index / (samples - 1) : 0;
-
-    const angle = t * totalAngle;
-    const radius = baseRadius * Math.pow(phi, t * turns * (N.THREE / N.SEVEN));
-    const x = centerX + radius * Math.cos(angle);
-    const y = centerY + radius * Math.sin(angle);
-
-
-  for (let index = 0; index < sampleCount; index += 1) {
-    const t = sampleCount > 1 ? index / (sampleCount - 1) : 0;
-
-
-    const angle = t * totalAngle;
-    const radius = baseRadius * Math.pow(phi, t * turns);
-    const x = centerX + Math.cos(angle) * radius;
-    const y = centerY + Math.sin(angle) * radius;
-
-    if (index === 0) {
-      ctx.moveTo(x, y);
-    } else {
-      ctx.lineTo(x, y);
-    }
-  }
-
-  ctx.stroke();
-  ctx.restore();
-
-
-  return { points: samples };
-}
-
-/**
- * Render a static double-helix lattice onto a 2D canvas context.
- *
- * Draws two sinusoidal strands and a configurable number of static cross-ties (rungs)
- * between them. Strand and rung colors are derived from the provided primary and
- * secondary colors with per-element alpha from settings. Scaling and placement are
- * influenced by the numerology object N.
- *
- * @param {CanvasRenderingContext2D} ctx - Canvas 2D rendering context to draw into.
- * @param {number} width - Canvas drawing width in pixels.
- * @param {number} height - Canvas drawing height in pixels.
- * @param {string} primaryColor - Hex color used for the first strand.
- * @param {string} secondaryColor - Hex color used for the second strand and rungs.
- * @param {object} N - Numerology constants (e.g., N.SEVEN, N.NINE, N.ELEVEN, N.NINETYNINE) used for scale factors.
- * @param {object} settings - Helix geometry and styling:
- *   - sampleCount: number of sample points per strand (minimum 2).
- *   - cycles: number of full sine cycles along the strand length.
- *   - amplitudeDivisor: divisor to compute vertical amplitude from min(width,height).
- *   - phaseOffset: phase offset in degrees applied to the second strand.
- *   - strandAlpha: alpha applied to strand stroke colors.
- *   - rungAlpha: alpha applied to rung (cross-tie) stroke color.
- *   - crossTieCount: number of static cross-ties to draw (minimum 1).
- */
-
- * Render a double-helix lattice (two phase-shifted strands with cross-rungs) onto the canvas.
- *
- * Draws two sinusoidal strands across the horizontal span and connects them with
- * regularly spaced rungs. Strand amplitudes, phase offset, sampling, number of
- * cycles, and alpha values are taken from `settings`; palette and numeric
- * constants control colors and stroke sizing. Returns a simple summary object
- * with the number of drawn rungs.
- *
- * @param {CanvasRenderingContext2D} ctx - 2D rendering context to draw into.
- * @param {{width: number, height: number}} dims - Normalized drawing dimensions.
- * @param {{ink: string, layers: string[]}} palette - Palette containing `ink` and `layers` colors; strands use layers[4] and layers[5].
- * @param {{ONEFORTYFOUR: number, THIRTYTHREE: number}} numbers - Numeric constants used for sizing and margins.
- * @param {Object} settings - Helix layout options. Expected properties:
- *   - sampleCount {number} number of sample points per strand (min 2),
- *   - cycles {number} number of full sinusoidal cycles across the span,
- *   - amplitudeDivisor {number} divisor applied to canvas height to compute strand amplitude,
- *   - phaseOffset {number} phase offset in degrees applied to the second strand,
- *   - crossTieCount {number} requested count of cross-rungs,
- *   - strandAlpha {number} alpha for strand strokes (0..1),
- *   - rungAlpha {number} alpha for rung strokes (0..1).
- * @returns {{rungs: number}} Number of cross-rungs actually drawn.
- */
-
- * Draws a double-helix lattice: two sinusoidal strands across the canvas and cross-ties between them.
- *
- * The function computes two x-monotone polylines (strands) sampled from left to right using
- * `settings.sampleCount`, `settings.cycles` and `settings.phaseOffset`. Strand geometry is scaled
- * by `settings.amplitudeDivisor` and constrained to the canvas height; strands are stroked using
- * `strandColor` with `settings.strandAlpha`. A configurable number of cross-ties (`settings.crossTieCount`)
- * are drawn between corresponding sample points using `rungColor` and `settings.rungAlpha`.
- *
- * @param {string} strandColor - CSS color for the helix strands (hex or any valid canvas color string).
- * @param {string} rungColor - CSS color for the cross-ties between strands.
- * @param {object} settings - Helix drawing parameters:
- *   - {number} sampleCount: number of samples per strand (min 2).
- *   - {number} cycles: number of full sine cycles across the span.
- *   - {number} amplitudeDivisor: divisor used to compute vertical amplitude from canvas height.
- *   - {number} phaseOffset: phase offset between the two strands in degrees.
- *   - {number} crossTieCount: number of cross-ties (rungs) to draw.
- *   - {number} strandAlpha: stroke alpha for the strands (0..1).
- *   - {number} rungAlpha: stroke alpha for the rungs (0..1).
- */
-
-
-function drawHelixLattice(ctx, width, height, primaryColor, secondaryColor, N, settings) {
-  const samples = Math.max(2, settings.sampleCount);
-  const cycles = Math.max(0, settings.cycles);
-  const amplitude = Math.min(width, height) / settings.amplitudeDivisor;
-  const centerX = width / 2;
-  const centerY = height / 2;
-  const length = width * (N.NINE / N.ELEVEN);
-  const strandOffset = settings.phaseOffset * (Math.PI / 180);
-  const pathWidth = Math.max(1, Math.min(width, height) / N.NINETYNINE);
-
-  const strandA = [];
-  const strandB = [];
-  for (let index = 0; index < samples; index += 1) {
-    const t = samples > 1 ? index / (samples - 1) : 0;
-    const angle = t * cycles * Math.PI * 2;
-    const x = centerX - length / 2 + t * length;
-    const yA = centerY + Math.sin(angle) * amplitude * (N.SEVEN / N.NINE);
-    const yB = centerY + Math.sin(angle + strandOffset) * amplitude * (N.SEVEN / N.NINE);
-    strandA.push({ x, y: yA });
-    strandB.push({ x, y: yB });
-  }
-
-  ctx.save();
-  ctx.lineCap = "round";
-  ctx.lineJoin = "round";
-
-  ctx.strokeStyle = colorWithAlpha(primaryColor, settings.strandAlpha);
-  ctx.lineWidth = pathWidth;
-
-
-  return { points: samples };
-}
-
-/**
- * Draws a static double-helix lattice: two phase-offset sinusoidal strands across the canvas with optional cross-ties.
- *
- * Samples two sinusoidal polylines horizontally across dims, strokes each strand using palette layer colors with
- * the provided strandAlpha, and draws a series of cross-ties (rungs) between corresponding sample points using
- * palette.ink with rungAlpha. Returns the actual number of rungs drawn.
- *
- * @param {{width:number,height:number}} dims - Normalized drawing dimensions.
- * @param {Object} palette - Color palette; expects palette.layers (array) and palette.ink.
- * @param {Object} numbers - Numeric constants used for sizing (e.g., ONEFORTYFOUR, THIRTYTHREE).
- * @param {Object} settings - Helix configuration:
- *   - {number} sampleCount - Number of sample points along each strand (minimum 2).
- *   - {number} cycles - Number of sinusoidal cycles across the horizontal span.
- *   - {number} amplitudeDivisor - Divisor of dims.height used to compute strand amplitude.
- *   - {number} phaseOffset - Phase offset between strands in degrees.
- *   - {number} crossTieCount - Desired number of cross-ties; actual rungs are clamped and computed from samples.
- *   - {number} strandAlpha - Alpha applied to strand stroke colors (0–1).
- *   - {number} rungAlpha - Alpha applied to cross-tie stroke color (0–1).
- * @return {{rungs:number}} The number of cross-ties actually drawn.
- */
-
-
-  return { points: samples };
-}
-
-
-
-
-function drawHelixLattice(ctx, dims, palette, numbers, settings) {
-  const samples = Math.max(2, settings.sampleCount);
-  const cycles = settings.cycles;
-  const amplitude = dims.height / settings.amplitudeDivisor;
-  const phase = (settings.phaseOffset * Math.PI) / 180;
-  const centerY = dims.height * 0.7;
-  const marginX = dims.width / numbers.THIRTYTHREE;
-  const spanX = dims.width - marginX * 2;
-  const stepX = samples > 1 ? spanX / (samples - 1) : 0;
-  const angleStep =
-    cycles > 0 ? (Math.PI * 2 * cycles) / Math.max(1, samples - 1) : 0;
-
-  const strandA = [];
-  const strandB = [];
-  for (let index = 0; index < samples; index += 1) {
-    const x = marginX + stepX * index;
-    const angle = angleStep * index;
-    const yA = centerY + Math.sin(angle) * amplitude;
-    const yB = centerY + Math.sin(angle + phase) * amplitude;
-
-/**
- * Draws a double-helix lattice: two sinusoidal strands across the canvas and cross-ties between them.
- *
- * The function computes two x-monotone polylines (strands) sampled from left to right using
- * `settings.sampleCount`, `settings.cycles` and `settings.phaseOffset`. Strand geometry is scaled
- * by `settings.amplitudeDivisor` and constrained to the canvas height; strands are stroked using
- * `strandColor` with `settings.strandAlpha`. A configurable number of cross-ties (`settings.crossTieCount`)
- * are drawn between corresponding sample points using `rungColor` and `settings.rungAlpha`.
- *
- * @param {string} strandColor - CSS color for the helix strands (hex or any valid canvas color string).
- * @param {string} rungColor - CSS color for the cross-ties between strands.
- * @param {object} settings - Helix drawing parameters:
- *   - {number} sampleCount: number of samples per strand (min 2).
- *   - {number} cycles: number of full sine cycles across the span.
- *   - {number} amplitudeDivisor: divisor used to compute vertical amplitude from canvas height.
- *   - {number} phaseOffset: phase offset between the two strands in degrees.
- *   - {number} crossTieCount: number of cross-ties (rungs) to draw.
- *   - {number} strandAlpha: stroke alpha for the strands (0..1).
- *   - {number} rungAlpha: stroke alpha for the rungs (0..1).
- */
-
-
-function drawHelixLattice(ctx, width, height, strandColor, rungColor, N, settings) {
-  const sampleCount = Math.max(2, settings.sampleCount);
-  const cycles = Math.max(0, settings.cycles);
-  const marginX = width / N.ELEVEN;
-  const startX = marginX;
-  const endX = width - marginX;
-  const amplitude = Math.min(height / settings.amplitudeDivisor, height / N.THREE);
-  const baseline = height / 2;
-  const totalAngle = cycles * Math.PI * 2;
-  const phase = (settings.phaseOffset * Math.PI) / 180;
-  const strandWidth = Math.max(1, Math.min(width, height) / N.NINETYNINE);
-
-  const strandA = [];
-  const strandB = [];
-  for (let index = 0; index < sampleCount; index += 1) {
-    const t = sampleCount > 1 ? index / (sampleCount - 1) : 0;
-    const x = startX + t * (endX - startX);
-    const angle = t * totalAngle;
-    const yA = baseline + Math.sin(angle) * amplitude;
-    const yB = baseline + Math.sin(angle + phase) * amplitude;
-
-
-    strandA.push({ x, y: yA });
-    strandB.push({ x, y: yB });
-  }
-
-  ctx.save();
-
-  ctx.lineWidth = Math.max(
-    1.2,
-    Math.min(dims.width, dims.height) / numbers.ONEFORTYFOUR,
-  );
-
-  ctx.strokeStyle = colorWithAlpha(palette.layers[4], settings.strandAlpha);
-  drawPolyline(ctx, strandA);
-
-  ctx.strokeStyle = colorWithAlpha(palette.layers[5], settings.strandAlpha);
-  drawPolyline(ctx, strandB);
-
-  const rungCount = Math.max(1, settings.crossTieCount);
-  const rungStep = Math.max(1, Math.floor(samples / rungCount));
-  ctx.strokeStyle = colorWithAlpha(palette.ink, settings.rungAlpha);
-  ctx.lineWidth = Math.max(
-    1,
-    Math.min(dims.width, dims.height) / numbers.ONEFORTYFOUR,
-  );
-  let drawn = 0;
-  for (let index = 0; index < samples; index += rungStep) {
-    const a = strandA[index];
-    const b = strandB[index];
-    if (!a || !b) {
-      continue;
-    }
+  geo.edges.forEach(edge => {
+    const a = positions.get(edge[0]);
+    const b = positions.get(edge[1]);
+    if (!a || !b) return;
     ctx.beginPath();
     ctx.moveTo(a.x, a.y);
     ctx.lineTo(b.x, b.y);
     ctx.stroke();
-    drawn += 1;
-
-  }
+  });
 
   ctx.restore();
-  return { rungs: drawn };
-}
 
-/**
+  ctx.save();
+  ctx.fillStyle = getLayerColor(palette, 2);
+  ctx.strokeStyle = applyAlpha(palette.ink, 0.4);
+  ctx.lineWidth = Math.max(1, nodeRadius / numbers.THIRTYTHREE * numbers.THREE);
 
- * Draws a stroked polyline through a sequence of points on the provided 2D canvas context.
- *
- * If `points` is empty the function does nothing. Each point must be an object with numeric `x` and `y`.
- *
- * @param {Array<{x: number, y: number}>} points - Ordered vertices of the polyline.
+  geo.nodes.forEach(node => {
+    const position = positions.get(node.id);
+    if (!position) return;
+    ctx.beginPath();
+    ctx.arc(position.x, position.y, nodeRadius, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.stroke();
+  });
 
- * Stroke a polyline connecting an ordered sequence of 2D points.
- *
- * Draws straight segments between consecutive points in `points` on the provided 2D canvas context.
- * If `points` contains fewer than two coordinates the function is a no-op.
- *
- * @param {{x: number, y: number}[]} points - Ordered array of points defining the polyline.
+  ctx.fillStyle = palette.ink;
+  ctx.font = geo.labelFont || DEFAULT_GEOMETRY.treeOfLife.labelFont;
+  ctx.textAlign = "center";
+  ctx.textBaseline = "top";
 
- */
-function drawPolyline(ctx, points) {
-  if (points.length === 0) {
-    return;
-  }
-  ctx.beginPath();
-  ctx.moveTo(points[0].x, points[0].y);
-  for (let index = 1; index < points.length; index += 1) {
-    const point = points[index];
-    ctx.lineTo(point.x, point.y);
+  const labelOffset = typeof geo.labelOffset === "number"
+    ? geo.labelOffset
+    : DEFAULT_GEOMETRY.treeOfLife.labelOffset;
 
-  }
-  ctx.stroke();
-}
-
-/**
- * Draws a centered, bottom-aligned notice on the canvas.
- *
- * The function renders `message` centered horizontally near the bottom edge of the drawing area
- * and preserves the canvas context state (saves and restores). Font size is computed as
- * max(14, width/72) pixels. A vertical padding of min(width, height) / 33 is used to offset the text
- * from the bottom edge. The rendered text is drawn with the provided `color` at 90% opacity.
- *
- * @param {Object} dims - Drawing area dimensions.
- * @param {number} dims.width - Width in pixels.
- * @param {number} dims.height - Height in pixels.
- * @param {string} color - CSS color (hex, rgb, etc.) used for the notice text.
- * @param {string} message - The text to render.
- */
-
-
-  }
-  ctx.stroke();
-}
-
-/**
- * Draw a short bottom-centered notice text on the canvas.
- *
- * Renders `message` centered along the bottom edge of the drawing area using a responsive
- * font size and a semi-opaque version of `color` (alpha = 0.9). The vertical inset (padding)
- * is computed from `dims` using DEFAULT_NUMBERS.THIRTYTHREE to keep spacing proportional to
- * canvas size. The function saves and restores the canvas state around the draw operation.
- *
- * @param {{width:number, height:number}} dims - Canvas drawable dimensions; must contain numeric `width` and `height`.
- * @param {string} color - Base CSS color (hex or other); rendered with alpha = 0.9.
- * @param {string} message - The text to draw, centered at the bottom of the canvas.
- */
-
-  }
+  geo.nodes.forEach(node => {
+    const position = positions.get(node.id);
+    if (!position) return;
+    const labelY = position.y + nodeRadius + labelOffset;
+    const text = `${node.title}`;
+    ctx.fillText(text, position.x, labelY);
+  });
 
   ctx.restore();
-  return { rungs: drawn };
 }
 
-function drawPolyline(ctx, points) {
-  if (points.length === 0) {
-    return;
+function drawFibonacciCurve(ctx, dims, palette, geo, numbers) {
+  const samples = Math.max(8, Math.floor(toPositiveNumber(geo.sampleCount, DEFAULT_GEOMETRY.fibonacci.sampleCount)));
+  const turns = toPositiveNumber(geo.turns, DEFAULT_GEOMETRY.fibonacci.turns);
+  const phi = toPositiveNumber(geo.phi, DEFAULT_GEOMETRY.fibonacci.phi);
+  const baseRadius = Math.min(dims.width, dims.height) / toPositiveNumber(geo.baseRadiusDivisor, DEFAULT_GEOMETRY.fibonacci.baseRadiusDivisor);
+  const totalAngle = turns * Math.PI * 2;
+  const centerX = dims.width * clamp01(geo.centerOffsetX);
+  const centerY = dims.height * clamp01(geo.centerOffsetY);
+
+  const points = [];
+  for (let i = 0; i < samples; i += 1) {
+    const t = i / (samples - 1);
+    const angle = t * totalAngle;
+    const radius = baseRadius * Math.pow(phi, angle / Math.PI);
+    const x = centerX + radius * Math.cos(angle);
+    const y = centerY + radius * Math.sin(angle);
+    points.push({ x, y });
   }
 
+  ctx.save();
+  ctx.lineWidth = toPositiveNumber(geo.thickness, DEFAULT_GEOMETRY.fibonacci.thickness);
+  ctx.strokeStyle = applyAlpha(getLayerColor(palette, 3), clamp01(geo.alpha));
+  ctx.lineCap = "round";
   ctx.beginPath();
-  ctx.moveTo(points[0].x, points[0].y);
-  for (let index = 1; index < points.length; index += 1) {
-    const point = points[index];
-    ctx.lineTo(point.x, point.y);
-  }
-  ctx.stroke();
-
-
-  ctx.strokeStyle = colorWithAlpha(secondaryColor, settings.strandAlpha);
-  ctx.beginPath();
-  for (let index = 0; index < strandB.length; index += 1) {
-    const point = strandB[index];
+  points.forEach((point, index) => {
     if (index === 0) {
       ctx.moveTo(point.x, point.y);
     } else {
       ctx.lineTo(point.x, point.y);
     }
-  }
+  });
   ctx.stroke();
-
-  // Cross ties keep strands linked without motion (why: static double helix request).
-  ctx.strokeStyle = colorWithAlpha(secondaryColor, settings.rungAlpha);
-  const ties = Math.max(1, settings.crossTieCount);
-  for (let tie = 0; tie < ties; tie += 1) {
-    const t = ties > 1 ? tie / (ties - 1) : 0;
-    const indexA = Math.round(t * (strandA.length - 1));
-    const indexB = Math.round(t * (strandB.length - 1));
-    const pointA = strandA[indexA];
-    const pointB = strandB[indexB];
-
-  ctx.strokeStyle = colorWithAlpha(strandColor, settings.strandAlpha);
-  ctx.lineWidth = strandWidth;
-  ctx.lineCap = "round";
-  ctx.lineJoin = "round";
-  drawPolyline(ctx, strandA);
-  drawPolyline(ctx, strandB);
   ctx.restore();
+}
+
+function drawDoubleHelix(ctx, dims, palette, geo, numbers) {
+  const pointsCount = Math.max(2, Math.floor(toPositiveNumber(geo.strandPoints, DEFAULT_GEOMETRY.helix.strandPoints)));
+  const rungCount = Math.max(2, Math.floor(toPositiveNumber(geo.rungCount, DEFAULT_GEOMETRY.helix.rungCount)));
+  const sideMargin = dims.width / toPositiveNumber(geo.sideMarginDivisor, DEFAULT_GEOMETRY.helix.sideMarginDivisor);
+  const amplitude = Math.min(dims.width, dims.height) / toPositiveNumber(geo.amplitudeDivisor, DEFAULT_GEOMETRY.helix.amplitudeDivisor);
+  const frequency = Math.PI * 2 * toPositiveNumber(geo.frequencyTurns, DEFAULT_GEOMETRY.helix.frequencyTurns);
+  const strandThickness = toPositiveNumber(geo.strandThickness, DEFAULT_GEOMETRY.helix.strandThickness);
+  const centerY = dims.height / 2 + (geo.verticalCenterOffset || 0);
+  const startX = sideMargin;
+  const endX = dims.width - sideMargin;
+  const length = endX - startX;
+
+  const strandA = [];
+  const strandB = [];
+  for (let i = 0; i < pointsCount; i += 1) {
+    const t = i / (pointsCount - 1);
+    const angle = t * frequency;
+    const x = startX + t * length;
+    const yA = centerY + Math.sin(angle) * amplitude;
+    const yB = centerY + Math.sin(angle + Math.PI) * amplitude;
+    strandA.push({ x, y: yA });
+    strandB.push({ x, y: yB });
+  }
 
   ctx.save();
-  ctx.strokeStyle = colorWithAlpha(rungColor, settings.rungAlpha);
-  ctx.lineWidth = Math.max(1, strandWidth * 0.85);
   ctx.lineCap = "round";
-  const rungCount = Math.max(1, settings.crossTieCount);
-  for (let rung = 0; rung < rungCount; rung += 1) {
-    const t = rungCount > 1 ? rung / (rungCount - 1) : 0;
-    const index = Math.floor(t * (strandA.length - 1));
-    const start = strandA[index];
-    const end = strandB[index];
-    if (!start || !end) {
-      continue;
-    }
+  ctx.lineJoin = "round";
+  ctx.lineWidth = strandThickness;
+  ctx.strokeStyle = applyAlpha(getLayerColor(palette, 4), 0.9);
+  drawPolyline(ctx, strandA);
+  ctx.strokeStyle = applyAlpha(getLayerColor(palette, 5), 0.85);
+  drawPolyline(ctx, strandB);
 
+  ctx.lineWidth = Math.max(1, strandThickness * 0.75);
+  ctx.strokeStyle = applyAlpha(getLayerColor(palette, 5), clamp01(geo.rungAlpha));
+  for (let i = 0; i < rungCount; i += 1) {
+    const t = rungCount === 1 ? 0 : i / (rungCount - 1);
+    const pointA = sampleAt(strandA, t);
+    const pointB = sampleAt(strandB, t);
     ctx.beginPath();
-    ctx.moveTo(start.x, start.y);
-    ctx.lineTo(end.x, end.y);
+    ctx.moveTo(pointA.x, pointA.y);
+    ctx.lineTo(pointB.x, pointB.y);
     ctx.stroke();
   }
 
   ctx.restore();
-
 }
-
-
-
-
-function drawCanvasNotice(ctx, dims, color, message) {
-  const padding =
-    Math.min(dims.width, dims.height) / DEFAULT_NUMBERS.THIRTYTHREE;
-  ctx.save();
-  ctx.fillStyle = colorWithAlpha(color, 0.9);
-  ctx.font = `${Math.max(14, dims.width / 72)}px system-ui, -apple-system, Segoe UI, sans-serif`;
-  ctx.textAlign = "center";
-  ctx.textBaseline = "bottom";
-  ctx.fillText(message, dims.width / 2, dims.height - padding);
-  ctx.restore();
-}
-
-
-/**
-
-/**
- * Build a concise human-readable summary of rendered layer statistics.
- *
- * @param {Object} stats - Aggregated per-layer statistics returned by rendering functions.
- * @param {Object} stats.vesicaStats - Vesica field stats containing numeric `circles`.
- * @param {Object} stats.treeStats - Tree-of-Life stats containing numeric `paths` and `nodes`.
- * @param {Object} stats.fibonacciStats - Fibonacci stats containing numeric `points`.
- * @param {Object} stats.helixStats - Helix stats containing numeric `rungs`.
- * @returns {string} A single-line summary describing counts for each rendered layer.
- */
-
-
-/**
- * Stroke a circle at the given center using the current stroke style.
- *
- * Uses the canvas context's current strokeStyle, lineWidth, and lineJoin settings.
- *
- * @param {CanvasRenderingContext2D} ctx - Rendering context with a valid canvas.
- * @param {number} cx - X coordinate of the circle center.
- * @param {number} cy - Y coordinate of the circle center.
- * @param {number} radius - Circle radius (expected non-negative).
- */
-function strokeCircle(ctx, cx, cy, radius) {
-  ctx.beginPath();
-  ctx.arc(cx, cy, radius, 0, Math.PI * 2);
-  ctx.stroke();
-}
-
-/**
- * Convert a value to a finite number, returning a fallback if conversion fails.
- *
- * Attempts to coerce `value` with `Number(value)` and returns the result if it is a finite number;
- * otherwise returns `fallback`. Treats `NaN`, `Infinity`, and `-Infinity` as invalid.
- *
- * @param {*} value - The value to convert to a number.
- * @param {number} fallback - The number to return when `value` cannot be converted to a finite number.
- * @returns {number} The finite numeric conversion of `value`, or `fallback` if conversion is not finite.
- */
- * Stroke a polyline connecting an ordered list of points on the given 2D canvas context.
- *
- * Does nothing when `points` is not a non-empty array. The function issues a single
- * stroked path (beginPath/moveTo/lineTo/stroke) — the context's current stroke style,
- * lineWidth, lineJoin, and lineCap are used.
- *
- * @param {Array<{x: number, y: number}>} points - Ordered vertices of the polyline; each item must have numeric `x` and `y`.
- */
-
-
-
-/**
- * Build a concise, human-readable one-line summary of per-layer render counts.
- *
- * Returns a sentence describing vesica circles, Tree-of-Life paths/nodes,
- * Fibonacci spiral points, and helix rungs based on the provided stats.
- *
- * @param {Object} stats - Aggregated render statistics.
- * @param {Object} stats.vesicaStats - Vesica layer stats (expects `circles`).
- * @param {number} stats.vesicaStats.circles - Number of vesica circles drawn.
- * @param {Object} stats.treeStats - Tree-of-Life layer stats (expects `paths` and `nodes`).
- * @param {number} stats.treeStats.paths - Number of edges/paths drawn.
- * @param {number} stats.treeStats.nodes - Number of nodes drawn.
- * @param {Object} stats.fibonacciStats - Fibonacci/spiral layer stats (expects `points`).
- * @param {number} stats.fibonacciStats.points - Number of sampled spiral points drawn.
- * @param {Object} stats.helixStats - Helix lattice layer stats (expects `rungs`).
- * @param {number} stats.helixStats.rungs - Number of cross-tie rungs drawn.
- * @returns {string} One-line summary, e.g. "Layers rendered - 72 vesica circles; 9 paths / 10 nodes; 128 spiral points; 24 helix rungs."
- */
-
-
-
-function summariseLayers(stats) {
-  const vesica = `${stats.vesicaStats.circles} vesica circles`;
-  const tree = `${stats.treeStats.paths} paths / ${stats.treeStats.nodes} nodes`;
-  const fibonacci = `${stats.fibonacciStats.points} spiral points`;
-  const helix = `${stats.helixStats.rungs} helix rungs`;
-  return `Layers rendered - ${vesica}; ${tree}; ${fibonacci}; ${helix}.`;
-}
-
-
-/**
- * Convert a 6‑digit hex color and an alpha value to an `rgba(...)` CSS string.
- *
- * Returns an `rgba(r,g,b,a)` string where `r`, `g`, and `b` are parsed from the
- * provided 6‑character hex (with or without a leading `#`) and `a` is the input
- * alpha clamped to [0, 1]. If the hex is not a valid 6‑hex string, the
- * function falls back to opaque white (255,255,255) with the clamped alpha.
- *
- * @param {string} hex - A 6‑digit hex color string (e.g. `"#ff00aa"` or `"ff00aa"`).
- * @param {number} alpha - Alpha value; will be clamped to the [0, 1] range.
- * @return {string} An `rgba(...)` CSS color string.
- */
-
-
-/**
- * Convert a 6-digit hex color (with or without leading '#') to an `rgba(...)` CSS string, clamping alpha to [0,1].
- *
- * If `hex` is not a valid 6-hex-digit string, the function falls back to semi-transparent white (`rgba(255,255,255,alpha)`).
- *
- * @param {string} hex - Color in 6-digit hexadecimal form, e.g. `"#ff00aa"` or `"ff00aa"`.
- * @param {number} alpha - Desired alpha value; will be clamped to the [0,1] range.
- * @returns {string} An `rgba(r,g,b,a)` CSS color string.
- */
-
-
-
-function colorWithAlpha(hex, alpha) {
-  const normalized = typeof hex === "string" ? hex.trim() : "";
-  const value = normalized.startsWith("#") ? normalized.slice(1) : normalized;
-  const safeAlpha = clamp01(alpha);
-  if (value.length !== 6) {
-    return `rgba(255,255,255,${safeAlpha})`;
-  }
-  const r = parseInt(value.slice(0, 2), 16);
-  const g = parseInt(value.slice(2, 4), 16);
-  const b = parseInt(value.slice(4, 6), 16);
-  return `rgba(${r},${g},${b},${safeAlpha})`;
-}
-
-
-/**
- * Coerce a value to a positive finite number, using a fallback when invalid.
- *
- * Converts `value` with `Number(value)` and returns it if it is finite and greater than 0.
- * Otherwise returns `Number(fallback)`.
- *
- * @param {*} value - Input to coerce to a positive finite number.
- * @param {*} fallback - Fallback used when `value` is not a positive finite number; also converted with `Number()`.
- * @returns {number} A positive finite number (result of `Number(value)` or `Number(fallback)`).
- */
-
-
-function toNumber(value, fallback) {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : fallback;
-
-
-
-function toPositiveNumber(value, fallback) {
-  const number = Number(value);
-  return Number.isFinite(number) && number > 0 ? number : Number(fallback);
-}
-
-/**
- * Convert a value to a positive integer, falling back when conversion fails.
- *
- * Attempts to coerce `value` to a number, rounds it to the nearest integer,
- * and returns it if finite and greater than zero. If the input is not a
- * finite positive integer after rounding, returns Number(fallback).
- *
- * @param {*} value - The value to convert to a positive integer.
- * @param {*} fallback - Value to return (via `Number(fallback)`) when conversion fails.
- * @return {number} A positive integer or the numeric conversion of `fallback`.
- */
-function toPositiveInteger(value, fallback) {
-  const number = Number(value);
-  const rounded = Math.round(number);
-  return Number.isFinite(number) && rounded > 0 ? rounded : Number(fallback);
-
-/**
- * Coerce a value to a finite positive number; otherwise return the numeric coercion of a fallback.
- * @param {*} value - Candidate to convert; accepted only if Number(value) is finite and > 0.
- * @param {*} fallback - Returned when `value` is invalid; converted with `Number(fallback)`.
- * @return {number} A finite positive number parsed from `value` or the result of `Number(fallback)` (may be NaN if `fallback` is not numeric).
- */
-function toPositiveNumber(value, fallback) {
-  const number = Number(value);
-  return Number.isFinite(number) && number > 0 ? number : Number(fallback);
-}
-
-/**
-
- * Convert a value to a finite number clamped into the inclusive range [0, 1].
- *
- * Non-numeric or non-finite inputs (NaN, Infinity, -Infinity) and values < 0 return 0.
- * Values > 1 return 1. Valid finite numbers between 0 and 1 are returned unchanged.
- *
- * @param {*} value - Input to coerce to a number and clamp.
- * @return {number} A number in the range [0, 1].
- */
-function clamp01(value) {
-
- * Convert a value to a finite positive integer (rounded); otherwise return the fallback.
- *
- * Attempts to coerce `value` to a Number, rounds it to the nearest integer, and returns it if finite and > 0.
- *
- * @param {*} value - The input to convert; any value coercible to a Number may be provided.
- * @param {number} fallback - Numeric fallback returned when `value` is non-finite or not a positive integer after rounding.
- * @return {number} A finite positive integer (rounded from `value`) or the numeric `fallback`.
- */
-function toPositiveInteger(value, fallback) {
-
-  const number = Number(value);
-  const rounded = Math.round(number);
-  return Number.isFinite(number) && rounded > 0 ? rounded : Number(fallback);
-}
-
-/**
- * Coerce a value to a Number and clamp it to the range [0, 1].
- *
- * Non-finite inputs (NaN, Infinity, -Infinity) and negatives return 0; values greater
- * than 1 return 1. Finite numbers within [0,1] are returned unchanged.
- *
- * @param {*} value - Input to convert and clamp.
- * @returns {number} A finite number between 0 and 1 inclusive.
- */
-
-function toPositiveNumber(value, fallback) {
-  const number = Number(value);
-  return Number.isFinite(number) && number > 0 ? number : Number(fallback);
-}
-
-function toPositiveInteger(value, fallback) {
-  const number = Number(value);
-  const rounded = Math.round(number);
-  return Number.isFinite(number) && rounded > 0 ? rounded : Number(fallback);
-
-/**
- * Stroke a circle at the given center using the current stroke style.
- *
- * Uses the canvas context's current strokeStyle, lineWidth, and lineJoin settings.
- *
- * @param {CanvasRenderingContext2D} ctx - Rendering context with a valid canvas.
- * @param {number} cx - X coordinate of the circle center.
- * @param {number} cy - Y coordinate of the circle center.
- * @param {number} radius - Circle radius (expected non-negative).
- */
-function strokeCircle(ctx, cx, cy, radius) {
-  ctx.beginPath();
-  ctx.arc(cx, cy, radius, 0, Math.PI * 2);
-  ctx.stroke();
-}
-
-/**
- * Stroke a polyline connecting an ordered list of points on the given 2D canvas context.
- *
- * Does nothing when `points` is not a non-empty array. The function issues a single
- * stroked path (beginPath/moveTo/lineTo/stroke) — the context's current stroke style,
- * lineWidth, lineJoin, and lineCap are used.
- *
- * @param {Array<{x: number, y: number}>} points - Ordered vertices of the polyline; each item must have numeric `x` and `y`.
- */
 
 function drawPolyline(ctx, points) {
-  if (!Array.isArray(points) || points.length === 0) {
-    return;
-  }
   ctx.beginPath();
   points.forEach((point, index) => {
     if (index === 0) {
@@ -2547,240 +336,270 @@ function drawPolyline(ctx, points) {
   ctx.stroke();
 }
 
-/**
- * Convert the input to a positive finite number; return the provided fallback if conversion fails or the result is not > 0.
- * @param {*} value - Value to convert to a positive finite number.
- * @param {number} fallback - Value returned when conversion is not a positive finite number.
- * @returns {number} The parsed positive finite number or the provided fallback.
- * Coerce a value to a finite Number, falling back to a provided alternative.
- *
- * Converts `value` using `Number(value)` and returns it if it's finite; otherwise
- * returns `Number(fallback)`. Note that the fallback is coerced with `Number`
- * as well (so if `fallback` is not a finite numeric representation, the result
- * may be `NaN`).
- *
- * @param {*} value - Candidate to convert to a number.
- * @param {*} fallback - Returned (after `Number(...)` coercion) when `value` is not finite.
- * @returns {number} A finite numeric conversion of `value`, or the numeric coercion of `fallback`.
- */
-function toNumber(value, fallback) {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : Number(fallback);
-
-}
-
-/**
- * Convert a value to a finite positive number, or return a fallback.
- *
- * Attempts to coerce `value` to a Number and returns it if it is finite and greater than 0;
- * otherwise returns `fallback`.
- *
- * @param {*} value - The value to coerce to a number.
- * @param {number} fallback - The value to return when `value` is not a finite positive number.
- * @return {number} The coerced positive number or the provided fallback.
- */
-function positiveNumber(value, fallback) {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
-}
-
-/**
- * Convert an input to a positive integer by rounding; returns the fallback when conversion fails or yields a non-positive value.
- *
- * The function attempts to coerce `value` to a Number, rounds it with `Math.round`, and returns the rounded value only if the
- * original numeric coercion produced a finite number and the rounded result is > 0. Otherwise the provided `fallback` is returned.
- *
- * @param {*} value - The value to convert to a positive integer.
- * @param {number} fallback - The value to return when `value` cannot be converted into a positive integer.
- * @returns {number} A positive integer (rounded result) or the provided `fallback`.
- * Coerce a value to a positive integer by numeric conversion and rounding; if the result is not a positive integer, return the provided fallback.
- * @param {*} value - Input to convert (will be Number(value) then Math.round).
- * @param {number} fallback - Returned when conversion fails to produce an integer > 0.
- * @return {number} The rounded positive integer or the fallback.
- */
-function positiveInteger(value, fallback) {
-  const parsed = Number(value);
-  const rounded = Math.round(parsed);
-
-  return Number.isFinite(parsed) && rounded > 0 ? rounded : fallback;
-
-  return Number.isInteger(rounded) && rounded > 0 ? rounded : fallback;
-
-}
-
-/**
- * Convert a value to a finite number, returning a fallback if conversion fails.
- *
- * Attempts to coerce `value` with `Number(value)` and returns the result if it's a finite number;
- * otherwise returns `fallback`.
- *
- * @param {*} value - Value to convert to a number.
- * @param {number} fallback - Value to return when `value` does not produce a finite number.
- * Convert a value to a finite number, falling back when conversion yields non-finite.
- *
- * Attempts to coerce `value` with `Number(value)` and returns the result if it's finite;
- * otherwise returns `fallback` unchanged.
- *
- * @param {*} value - The input to convert to a number.
- * @param {number} fallback - Value returned when `value` cannot be converted to a finite number.
- * @return {number} The finite numeric conversion of `value`, or `fallback` if conversion is not finite.
- */
-function finiteNumber(value, fallback) {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : fallback;
-
-/**
- * Constrains a number to the inclusive range [min, max].
- * @param {number} value - The value to clamp.
- * @param {number} min - Lower bound of the range.
- * @param {number} max - Upper bound of the range.
- * @return {number} The clamped value (min if value < min, max if value > max, otherwise value).
- */
-function clamp(value, min, max) {
-  return Math.min(max, Math.max(min, value));
-}
-
-/**
- * Convert a value to a finite number and clamp it into the inclusive range [0, 1].
- *
- * Non-finite inputs (NaN, Infinity, etc.) return 0. Values less than 0 return 0;
- * values greater than 1 return 1. Finite numbers within [0,1] are returned unchanged.
- *
- * @param {*} value - Value to convert and clamp.
- * @return {number} A finite number between 0 and 1 (inclusive).
-}
-
-
-/**
- * Clamp a numeric input to the range [0, 1]; non-finite inputs become 0.
- * @param {*} value - Value to coerce to a number and clamp. Non-finite or non-numeric inputs evaluate to 0.
- * @returns {number} A number in the closed interval [0, 1].
- */
-function clamp01(value) {
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed)) {
-    return 0;
+function sampleAt(points, t) {
+  if (!points.length) {
+    return { x: 0, y: 0 };
   }
-  if (parsed < 0) {
-    return 0;
+  if (points.length === 1) {
+    return points[0];
   }
-  if (parsed > 1) {
-    return 1;
-  }
-  return parsed;
+  const clamped = clamp01(t);
+  const index = clamped * (points.length - 1);
+  const lower = Math.floor(index);
+  const upper = Math.min(points.length - 1, lower + 1);
+  const ratio = index - lower;
+  const a = points[lower];
+  const b = points[upper];
+  return {
+    x: a.x + (b.x - a.x) * ratio,
+    y: a.y + (b.y - a.y) * ratio
+  };
 }
 
-/**
- * Convert a value to a finite alpha in the [0, 1] range, or return a fallback.
- *
- * If `value` can be parsed to a finite number it is clamped to the inclusive range [0, 1].
- * Otherwise the provided `fallback` is returned unchanged.
- *
- * @param {*} value - The input to convert to an alpha value.
- * @param {number} fallback - Value to return when `value` is not a finite number.
- * @return {number} A number in [0, 1] (from the clamped input) or `fallback` when input is invalid.
-
- * Clamp an input to the [0, 1] range, with special handling for exact zero and a fallback.
- *
- * Converts `value` to a Number and returns it clamped to [0, 1]. If `value === 0` the function
- * returns 0 exactly (preserving zero distinct from other falsy or invalid inputs). If `value`
- * is not a finite number, the provided `fallback` is returned unchanged.
- *
- * @param {*} value - The candidate value to clamp; may be any type that can be converted to Number.
- * @param {*} fallback - Value to return when `value` is not a finite number.
- * @return {number|*} A number in [0,1] when `value` is finite (or 0 when exactly zero); otherwise `fallback`.
-
-
- * Clamp a numeric value to the [0,1] range, returning a fallback when the input cannot be parsed as a finite number.
- *
- * @param {*} value - Value to coerce to a Number and clamp.
- * @param {number} fallback - Value returned when `value` is not a finite number.
- * @return {number} The parsed value clamped to [0, 1], or `fallback` if parsing produced a non-finite number.
-
- * Normalize an alpha-like value to the [0,1] range while preserving an explicit zero.
- *
- * Converts the input to a Number and returns it clamped to [0,1] when finite. If the
- * input is exactly 0, returns 0 (preserves intentional zero). If the input is not a
- * finite number, returns the provided fallback value.
- *
- * @param {*} value - Value to normalize; can be any type coercible to Number.
- * @param {number} fallback - Value returned when `value` is not a finite number.
- * @return {number} A number in [0,1] (or 0) when `value` is finite, otherwise `fallback`.
- * Clamp a numeric value to the [0,1] range, returning a fallback when the input cannot be parsed as a finite number.
- *
- * @param {*} value - Value to coerce to a Number and clamp.
- * @param {number} fallback - Value returned when `value` is not a finite number.
- * @return {number} The parsed value clamped to [0, 1], or `fallback` if parsing produced a non-finite number.
- */
-function clampAlpha(value, fallback) {
-
-
-
- */
-function clampAlpha(value, fallback) {
-
-  const parsed = Number(value);
-  if (Number.isFinite(parsed)) {
-    return Math.min(1, Math.max(0, parsed));
-
-
-  if (value === 0) {
-    return 0;
+function drawNotice(ctx, dims, palette, notice) {
+  const lines = notice.split(/\n+/).map(line => line.trim()).filter(Boolean);
+  if (!lines.length) {
+    return;
   }
-  const number = Number(value);
-  if (Number.isFinite(number)) {
-    return clamp01(number);
 
+  ctx.save();
+  const fontSize = 12;
+  const lineHeight = fontSize * 1.4;
+  ctx.font = `${fontSize}px system-ui, -apple-system, Segoe UI, sans-serif`;
+  ctx.textBaseline = "top";
+
+  let maxWidth = 0;
+  lines.forEach(line => {
+    const metrics = ctx.measureText ? ctx.measureText(line) : { width: line.length * fontSize * 0.6 };
+    if (metrics.width > maxWidth) {
+      maxWidth = metrics.width;
+    }
+  });
+
+  const padding = 8;
+  const boxWidth = maxWidth + padding * 2;
+  const boxHeight = lines.length * lineHeight + padding * 2;
+  const x = padding;
+  const y = dims.height - boxHeight - padding;
+
+  const accent = getLayerColor(palette, 5);
+  const fillStyle = applyAlpha(accent, 0.15);
+  const strokeStyle = applyAlpha(accent, 0.45);
+
+  if (typeof ctx.roundRect === "function") {
+    ctx.fillStyle = fillStyle;
+    ctx.strokeStyle = strokeStyle;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.roundRect(x, y, boxWidth, boxHeight, 6);
+    ctx.fill();
+    ctx.stroke();
+  } else {
+    drawRoundedRect(ctx, x, y, boxWidth, boxHeight, 6, fillStyle, strokeStyle);
+  }
+
+  ctx.fillStyle = palette.ink;
+  lines.forEach((line, index) => {
+    ctx.fillText(line, x + padding, y + padding + index * lineHeight);
+  });
+
+  ctx.restore();
+}
+
+function drawRoundedRect(ctx, x, y, width, height, radius, fillStyle, strokeStyle) {
+  const r = Math.max(0, radius);
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + width - r, y);
+  ctx.quadraticCurveTo(x + width, y, x + width, y + r);
+  ctx.lineTo(x + width, y + height - r);
+  ctx.quadraticCurveTo(x + width, y + height, x + width - r, y + height);
+  ctx.lineTo(x + r, y + height);
+  ctx.quadraticCurveTo(x, y + height, x, y + height - r);
+  ctx.lineTo(x, y + r);
+  ctx.quadraticCurveTo(x, y, x + r, y);
+  ctx.closePath();
+  ctx.fillStyle = fillStyle;
+  ctx.strokeStyle = strokeStyle;
+  ctx.lineWidth = 1;
+  ctx.fill();
+  ctx.stroke();
+}
+
+function normaliseNumbers(custom) {
+  const merged = { ...DEFAULT_NUM };
+  if (custom && typeof custom === "object") {
+    Object.keys(DEFAULT_NUM).forEach(key => {
+      if (hasFiniteNumber(custom[key])) {
+        merged[key] = Math.max(1, Number(custom[key]));
+      }
+    });
+  }
+  return merged;
+}
+
+function normalisePalette(custom) {
+  const palette = {
+    bg: FALLBACK_PALETTE.bg,
+    ink: FALLBACK_PALETTE.ink,
+    muted: FALLBACK_PALETTE.muted,
+    layers: [...FALLBACK_LAYERS]
+  };
+
+  if (!custom || typeof custom !== "object") {
+    return palette;
+  }
+
+  if (isHex(custom.bg)) {
+    palette.bg = custom.bg;
+  }
+  if (isHex(custom.ink)) {
+    palette.ink = custom.ink;
+  }
+  if (isHex(custom.muted)) {
+    palette.muted = custom.muted;
+  }
+  if (Array.isArray(custom.layers)) {
+    custom.layers.forEach((value, index) => {
+      if (isHex(value) && index < palette.layers.length) {
+        palette.layers[index] = value;
+      }
+    });
+  }
+
+  return palette;
+}
+
+function normaliseGeometry(custom) {
+  const geometry = cloneDefaultGeometry();
+  if (!custom || typeof custom !== "object") {
+    return geometry;
+  }
+
+  if (custom.vesica) {
+    geometry.vesica = {
+      ...geometry.vesica,
+      ...pickPositive(custom.vesica, ["rows", "columns", "paddingFactor", "radiusFactor", "strokeDivisor", "alpha"])
+    };
+  }
+
+  if (custom.treeOfLife) {
+    const source = custom.treeOfLife;
+    geometry.treeOfLife = {
+      ...geometry.treeOfLife,
+      ...pickPositive(source, ["marginFactor", "radiusDivisor", "pathWidthDivisor"])
+    };
+    if (typeof source.labelFont === "string") {
+      geometry.treeOfLife.labelFont = source.labelFont;
+    }
+    if (hasFiniteNumber(source.labelOffset)) {
+      geometry.treeOfLife.labelOffset = source.labelOffset;
+    }
+    if (Array.isArray(source.nodes) && source.nodes.length) {
+      geometry.treeOfLife.nodes = source.nodes.map(node => ({
+        id: node.id,
+        title: node.title,
+        meaning: node.meaning,
+        level: hasFiniteNumber(node.level) ? node.level : 0,
+        xFactor: hasFiniteNumber(node.xFactor) ? node.xFactor : 0.5
+      }));
+    }
+    if (Array.isArray(source.edges) && source.edges.length) {
+      geometry.treeOfLife.edges = source.edges
+        .filter(edge => Array.isArray(edge) && edge.length === 2)
+        .map(edge => [String(edge[0]), String(edge[1])]);
+    }
+  }
+
+  if (custom.fibonacci) {
+    geometry.fibonacci = {
+      ...geometry.fibonacci,
+      ...pickPositive(custom.fibonacci, ["sampleCount", "turns", "baseRadiusDivisor", "phi", "alpha", "thickness", "centerOffsetX", "centerOffsetY"])
+    };
+  }
+
+  if (custom.helix) {
+    geometry.helix = {
+      ...geometry.helix,
+      ...pickPositive(custom.helix, ["strandPoints", "rungCount", "sideMarginDivisor", "amplitudeDivisor", "frequencyTurns", "strandThickness", "rungAlpha", "verticalCenterOffset"])
+    };
+  }
+
+  return geometry;
+}
+
+function cloneDefaultGeometry() {
+  return {
+    vesica: { ...DEFAULT_GEOMETRY.vesica },
+    treeOfLife: {
+      ...DEFAULT_GEOMETRY.treeOfLife,
+      nodes: DEFAULT_GEOMETRY.treeOfLife.nodes.map(node => ({ ...node })),
+      edges: DEFAULT_GEOMETRY.treeOfLife.edges.map(edge => [...edge])
+    },
+    fibonacci: { ...DEFAULT_GEOMETRY.fibonacci },
+    helix: { ...DEFAULT_GEOMETRY.helix }
+  };
+}
+
+function pickPositive(source, keys) {
+  const result = {};
+  keys.forEach(key => {
+    if (hasFiniteNumber(source[key])) {
+      result[key] = Number(source[key]);
+    }
+  });
+  return result;
+}
+
+function toPositiveNumber(value, fallback) {
+  if (hasFiniteNumber(value)) {
+    const numeric = Number(value);
+    return numeric > 0 ? numeric : fallback;
   }
   return fallback;
-
-
-
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed)) {
-    return fallback;
-  }
-  if (parsed < 0) {
-    return 0;
-  }
-  if (parsed > 1) {
-    return 1;
-  }
-  return parsed;
 }
 
-/**
- * Convert a 6‑digit hex color to an `rgba(...)` string, with alpha clamped to [0,1].
- *
- * If `hex` is not a valid 6‑character hex (optionally prefixed with `#`), returns white with the provided alpha.
- *
- * @param {string} hex - Hex color string (e.g. `"#ff8800"` or `"ff8800"`). Only 6‑digit hex is supported.
- * @param {number} alpha - Desired alpha; values are clamped into the [0, 1] range.
- * @returns {string} An `rgba(r,g,b,a)` CSS color string.
- */
+function hasFiniteNumber(value) {
+  return typeof value === "number" && Number.isFinite(value);
+}
 
-/**
- * Convert a 6-digit hex color to an `rgba(...)` string with the specified alpha.
- *
- * Accepts a hex string with or without a leading `#`. If the input is not a valid
- * 6-hex-digit string, returns white with the clamped alpha as a safe fallback.
- *
- * @param {string} hex - A 6-digit hex color (e.g. "#ff7700" or "ff7700").
- * @param {number} alpha - Alpha value; will be clamped to the range [0, 1].
- * @return {string} An `rgba(r,g,b,a)` CSS color string.
- */
-
-function colorWithAlpha(hex, alpha) {
-  const value = typeof hex === "string" ? hex.trim() : "";
-  const stripped = value.startsWith("#") ? value.slice(1) : value;
-  if (stripped.length !== 6) {
-    const safeAlpha = clamp01(alpha);
-    return `rgba(255,255,255,${safeAlpha})`;
+function clamp01(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return 0;
   }
-  const r = parseInt(stripped.slice(0, 2), 16);
-  const g = parseInt(stripped.slice(2, 4), 16);
-  const b = parseInt(stripped.slice(4, 6), 16);
-  const safeAlpha = clamp01(alpha);
-  return `rgba(${r},${g},${b},${safeAlpha})`;
+  if (numeric < 0) {
+    return 0;
+  }
+  if (numeric > 1) {
+    return 1;
+  }
+  return numeric;
+}
 
+function getLayerColor(palette, index) {
+  const layers = Array.isArray(palette.layers) ? palette.layers : FALLBACK_LAYERS;
+  if (index >= 0 && index < layers.length && isHex(layers[index])) {
+    return layers[index];
+  }
+  return FALLBACK_LAYERS[Math.min(index, FALLBACK_LAYERS.length - 1)];
+}
+
+function isHex(value) {
+  return typeof value === "string" && /^#[0-9a-fA-F]{6}$/.test(value);
+}
+
+function applyAlpha(hex, alpha) {
+  const rgb = hexToRgb(isHex(hex) ? hex : "#ffffff");
+  const safeAlpha = clamp01(alpha);
+  return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${safeAlpha})`;
+}
+
+function hexToRgb(hex) {
+  const normalised = hex.replace("#", "");
+  return {
+    r: parseInt(normalised.slice(0, 2), 16),
+    g: parseInt(normalised.slice(2, 4), 16),
+    b: parseInt(normalised.slice(4, 6), 16)
+  };
 }


### PR DESCRIPTION
## Summary
- rebuild the offline index entry with calm ND-safe chrome, palette fallback messaging, and numerology constants
- rewrite the helix renderer module into layered pure helpers with geometry/palette validation and inline fallback notices
- refresh the renderer README with concise offline usage, layer ordering, and ND-safe rationale

## Testing
- node -e "import('./cosmic-helix/js/helix-renderer.mjs').then(m=>console.log(Object.keys(m)))"

------
https://chatgpt.com/codex/tasks/task_e_68cf6cf8e990832888cd0433c5408f06