### PR TITLE
Align helix renderer palette loader with offline-only policy

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -3,7 +3,7 @@
 Static, offline-first canvas capsule aligned with the luminous cosmology canon. Rendering happens once when `index.html` loads, painting four quiet layers (vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice). All geometry is parameterised by numerology anchors `{3, 7, 9, 11, 22, 33, 99, 144}` and every helper is a small, well-commented pure function so the composition stays ND-safe.
 
 ## Files delivered
-- `index.html` — Offline entry point. Loads the optional palette JSON, reports fallback status in the header, seeds the numerology constants, and invokes the renderer with a calm notice when data is missing.
+- `index.html` — Offline entry point. Loads the optional palette JSON without issuing network requests, reports fallback status in the header, seeds the numerology constants, and invokes the renderer with a calm notice when data is missing.
 - `js/helix-renderer.mjs` — Pure ES module containing the layered drawing helpers. Each layer explains how the numerology keeps depth without motion.
 - `data/palette.json` — Optional colour override. When absent the renderer uses its sealed fallback and paints a footer notice for reassurance.
 - `README_RENDERER.md` — This guide.
@@ -11,7 +11,7 @@ Static, offline-first canvas capsule aligned with the luminous cosmology canon. 
 ## How to use (offline)
 1. Download or clone this repository.
 2. Double-click `index.html` in any modern browser. No build steps, bundlers, or servers are required.
-3. If local JSON loading is blocked (common on hardened `file://` contexts) the fallback palette activates automatically, the header reports the change, and the canvas prints "Palette fallback active" near the base.
+3. The palette loader uses module-level JSON import assertions only; if that fails (common on hardened `file://` contexts) the fallback palette activates automatically, the header reports the change, and the canvas prints "Palette fallback active" near the base.
 
 ## Layer order (back to front)
 1. **Vesica field** — Intersecting circle grid arranged by a `{3 × 7}` cadence. A central mandorla glow reinforces the vesica without motion.
@@ -36,7 +36,7 @@ Update `data/palette.json` with your preferred ND-safe palette:
 }
 ```
 
-Missing or malformed palette data never stops rendering; the fallback palette keeps contrast calm and emits the inline notice.
+The loader never performs remote fetches; it only attempts module-level JSON import. Missing or malformed palette data never stops rendering, because the fallback palette keeps contrast calm and emits the inline notice.
 
 ## ND-safe rationale
 - No animation loops or timers — everything renders once.

--- a/index.html
+++ b/index.html
@@ -84,50 +84,62 @@
       palette: {
         bg: "#0b0b12",
         ink: "#e8e8f0",
+        muted: "#a6a6c1",
         layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
       }
     };
 
     async function loadPalette() {
       const url = "./data/palette.json";
-      if (window.location.protocol === "file:") {
-        const module = await import(url, { with: { type: "json" } })
-          .then((mod) => (mod && mod.default ? mod.default : null))
-          .catch(() => null);
-        if (module) {
-          return module;
+      const attempts = [
+        async () => {
+          return import(url, { assert: { type: "json" } });
+        },
+        async () => {
+          return import(url, { with: { type: "json" } });
+        }
+      ];
+      for (const attempt of attempts) {
+        try {
+          const mod = await attempt();
+          if (mod && typeof mod === "object") {
+            const payload = mod.default && typeof mod.default === "object"
+              ? mod.default
+              : typeof mod.palette === "object"
+              ? mod.palette
+              : mod;
+            if (payload && typeof payload === "object") {
+              return payload;
+            }
+          }
+        } catch (err) {
+          // Import assertions are not universal; keep iterating to honour offline fallback.
         }
       }
-      try {
-        const response = await fetch(url, { cache: "no-store" });
-        if (!response.ok) {
-          return null;
-        }
-        return await response.json();
-      } catch (err) {
-        return null;
-      }
+      return null;
     }
 
     function applyChromeColours(palette) {
       const root = document.documentElement;
       if (palette.bg) root.style.setProperty("--bg", palette.bg);
       if (palette.ink) root.style.setProperty("--ink", palette.ink);
-      if (Array.isArray(palette.layers) && palette.layers[0]) {
+      if (palette.muted) {
+        root.style.setProperty("--muted", palette.muted);
+      } else if (Array.isArray(palette.layers) && palette.layers[0]) {
         root.style.setProperty("--muted", palette.layers[0]);
       }
     }
 
     const palette = await loadPalette();
     const activePalette = palette || FALLBACK.palette;
-    const notice = palette ? null : "Palette fallback active (local data unavailable).";
+    const notice = palette ? "" : "Palette fallback active (local data unavailable).";
 
     applyChromeColours(activePalette);
 
     if (palette) {
-      statusEl.textContent = "Palette loaded from data/palette.json.";
+      statusEl.textContent = "Palette loaded from data/palette.json without network.";
     } else {
-      statusEl.textContent = "Palette missing or blocked; using sealed fallback.";
+      statusEl.textContent = "Palette missing or blocked; using sealed fallback (no network used).";
     }
 
     // ND-safe rationale: no animation, soft contrast, layered order preserves depth.


### PR DESCRIPTION
## Summary
- update the helix renderer entrypoint to rely on JSON module imports instead of fetch
- enhance the status text to confirm no network traffic and keep the fallback notice wording consistent
- document the offline import approach in README_RENDERER.md

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0294908088328b7e5653082190700

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Offline-friendly palette loading without any network requests.
  - Added muted color support in the fallback palette and applied when available.
  - Status messages now indicate palette source and offline/fallback usage.

- Bug Fixes
  - More robust handling of missing or malformed palette data; rendering continues with a safe fallback.
  - Notices clear on successful load and appear when fallback is active.

- Documentation
  - Updated README to clarify offline loading via JSON import assertions, no remote fetches, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->