### PR TITLE
Add Vite hub build with service status grid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,27 @@
-FROM alpine:3.20 AS build
-RUN apk add --no-cache build-base cmake
-WORKDIR /src
-COPY . .
-RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
- && cmake --build build --target app --parallel
-
-FROM alpine:3.20
+FROM node:20-alpine AS build
 WORKDIR /app
-COPY --from=build /src/build/app /app/app
-COPY public /app/public 2>/dev/null || true
-COPY core/health-check.html /app/public/core/health-check.html
-COPY registry /app/registry 2>/dev/null || true
+
+# Install dependencies first for better layer caching.
+COPY package.json ./
+RUN npm install --include=dev
+
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine AS runtime
+ENV NODE_ENV=production
+WORKDIR /app
+
+COPY --from=build /app/package.json ./package.json
+COPY --from=build /app/package-lock.json ./package-lock.json
+RUN npm install --omit=dev
+
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/server.mjs ./server.mjs
+COPY --from=build /app/assets ./assets
+COPY --from=build /app/registry ./registry
+
 ENV PORT=8080
 EXPOSE 8080
-CMD ["/app/app"]
 
+CMD ["node", "server.mjs"]

--- a/core/index.html
+++ b/core/index.html
@@ -20,6 +20,24 @@
     dialog:not([open]){display:none;}
     .dialog__header{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:12px;}
     .dialog__title{margin:0;font-size:16px;}
+    .hub{padding:16px;}
+    .apps{display:grid;gap:16px;max-width:1100px;margin:0 auto;}
+    .apps__header{display:flex;flex-wrap:wrap;align-items:baseline;gap:12px;}
+    .apps__header h2{margin:0;font-size:18px;}
+    .apps__summary{margin:0;color:var(--muted);font-size:13px;}
+    .apps__grid{display:grid;gap:12px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));}
+    .app-card{border:1px solid #1d1d2a;border-radius:12px;padding:12px 14px;background:rgba(17,17,26,0.6);display:grid;gap:8px;}
+    .app-card__header{display:flex;align-items:center;justify-content:space-between;gap:8px;}
+    .app-card__title{font-weight:600;}
+    .app-card__status{display:inline-flex;align-items:center;gap:6px;font-size:12px;color:var(--muted);}
+    .app-card__dot{width:9px;height:9px;border-radius:50%;display:inline-block;background:#4a4a5c;box-shadow:0 0 0 1px rgba(255,255,255,0.08);}
+    .app-card[data-state="ok"] .app-card__dot{background:#8fdf82;}
+    .app-card[data-state="warn"] .app-card__dot{background:#ffb347;}
+    .app-card[data-state="offline"] .app-card__dot{background:#ff6f61;}
+    .app-card__links{display:flex;flex-wrap:wrap;gap:8px;font-size:12px;}
+    .app-card__links a{color:var(--ink);text-decoration:none;padding:4px 8px;border:1px solid #1d1d2a;border-radius:6px;}
+    .app-card__links a:hover,.app-card__links a:focus{border-color:var(--muted);text-decoration:none;}
+    .app-card__meta{margin:0;font-size:12px;color:var(--muted);}
     .status-grid{margin:0 0 16px 0;padding:0;display:grid;gap:8px;}
     .status-grid div{display:grid;gap:4px;}
     .status-grid dt{font-weight:600;}
@@ -59,6 +77,22 @@
       </select>
     </label>
   </div>
+  <main class="hub" id="hub" aria-live="polite">
+    <section class="apps" aria-label="Service constellation">
+      <header class="apps__header">
+        <h2>Services</h2>
+        <p class="apps__summary" id="apps-summary">Probing health endpoints…</p>
+      </header>
+      <div class="apps__grid" id="apps-grid">
+        <article class="app-card app-card--loading">
+          <div class="app-card__header">
+            <span class="app-card__title">Loading service map…</span>
+          </div>
+          <p class="app-card__meta">If offline, statuses will settle into fallback mode.</p>
+        </article>
+      </div>
+    </section>
+  </main>
   <dialog id="about-dialog" aria-labelledby="about-title">
     <article>
       <div class="dialog__header">

--- a/core/index.js
+++ b/core/index.js
@@ -17,6 +17,74 @@ const aboutClose = document.getElementById("about-close");
 const codexStatusEl = document.getElementById("codex-status");
 const swStatusEl = document.getElementById("sw-status");
 const realmLinksEl = document.getElementById("realm-links");
+const appsGridEl = document.getElementById("apps-grid");
+const appsSummaryEl = document.getElementById("apps-summary");
+
+const appCardIndex = new Map();
+let currentApps = [];
+
+const DEFAULT_APPS = [
+  {
+    id: "cosmogenesis-learning-engine",
+    title: "Cosmogenesis Learning Engine",
+    role: "Hub / Mind Registry",
+    summary: "Master hub with ND-safe toggles and codex sync.",
+    url: "https://cosmogenesis-learning-engine.fly.dev/",
+    health: "https://cosmogenesis-learning-engine.fly.dev/core/health-check.html",
+    links: [
+      { label: "Open hub", href: "https://cosmogenesis-learning-engine.fly.dev/" },
+      { label: "Health", href: "https://cosmogenesis-learning-engine.fly.dev/core/health-check.html" },
+    ],
+  },
+  {
+    id: "circuitum99",
+    title: "Circuitum 99",
+    role: "Story Spine / Guardians",
+    summary: "Interactive spine with guardians and ND-safe rituals.",
+    url: "https://circuitum99.fly.dev/",
+    health: "https://circuitum99.fly.dev/core/health-check.html",
+    links: [
+      { label: "Launch", href: "https://circuitum99.fly.dev/" },
+      { label: "Health", href: "https://circuitum99.fly.dev/core/health-check.html" },
+    ],
+  },
+  {
+    id: "stone-cathedral",
+    title: "Stone Cathedral",
+    role: "Rooms Atlas / Museum",
+    summary: "Cathedral atlas with provenance-safe walkthroughs.",
+    url: "https://stone-cathedral.fly.dev/",
+    health: "https://stone-cathedral.fly.dev/core/health-check.html",
+    links: [
+      { label: "Open atlas", href: "https://stone-cathedral.fly.dev/" },
+      { label: "Health", href: "https://stone-cathedral.fly.dev/core/health-check.html" },
+    ],
+  },
+  {
+    id: "liber-arcanae",
+    title: "Liber Arcanae",
+    role: "Tarot Companions",
+    summary: "Tarot compendium with ND-safe overlays.",
+    url: "https://liber-arcanae.fly.dev/",
+    health: "https://liber-arcanae.fly.dev/core/health-check.html",
+    links: [
+      { label: "Visit", href: "https://liber-arcanae.fly.dev/" },
+      { label: "Health", href: "https://liber-arcanae.fly.dev/core/health-check.html" },
+    ],
+  },
+  {
+    id: "cosmic-helix",
+    title: "Cosmic Helix",
+    role: "Static Renderer",
+    summary: "Offline vesica + helix canvas for palette study.",
+    url: "https://cosmic-helix.fly.dev/",
+    health: "https://cosmic-helix.fly.dev/core/health-check.html",
+    links: [
+      { label: "Renderer", href: "https://cosmic-helix.fly.dev/" },
+      { label: "Health", href: "https://cosmic-helix.fly.dev/core/health-check.html" },
+    ],
+  },
+];
 
 function applySafety() {
   Safety.state.motion = motionSel.value;
@@ -113,6 +181,212 @@ function paintRealmLinks(result) {
   }
 }
 
+function normalizeApp(entry) {
+  if (!entry || typeof entry !== "object") return null;
+  const links = Array.isArray(entry.links) ? [...entry.links] : [];
+  if (links.length === 0 && entry.url) {
+    links.push({ label: "Open", href: String(entry.url) });
+  }
+  if (entry.health && !links.some((link) => link && link.href === entry.health)) {
+    links.push({ label: "Health", href: String(entry.health) });
+  }
+  const normalizedLinks = links
+    .map((link) => {
+      if (!link || !link.href) return null;
+      return {
+        label: link.label ? String(link.label) : "Open",
+        href: String(link.href),
+      };
+    })
+    .filter((link) => Boolean(link));
+  const app = {
+    id: String(entry.id || entry.title || "service"),
+    title: String(entry.title || entry.id || "Service"),
+    role: String(entry.role || "Service"),
+    summary: entry.summary ? String(entry.summary) : "",
+    health: String(entry.health || ""),
+    links: normalizedLinks,
+  };
+  if (!app.health) return null;
+  return app;
+}
+
+async function loadConfiguredApps() {
+  if (!appsGridEl) return [];
+  try {
+    const res = await fetch("./core/apps.json", { cache: "no-store" });
+    if (!res.ok) throw new Error(String(res.status));
+    const payload = await res.json();
+    if (payload && Array.isArray(payload.apps)) {
+      const apps = payload.apps
+        .map((raw) => normalizeApp(raw))
+        .filter((app) => Boolean(app));
+      if (apps.length > 0) {
+        return apps;
+      }
+    }
+  } catch (error) {
+    console.warn("App config fallback engaged", error);
+  }
+  return DEFAULT_APPS.map((app) => ({ ...app }));
+}
+
+function buildAppCard(app) {
+  const article = document.createElement("article");
+  article.className = "app-card";
+  article.dataset.state = "loading";
+
+  const header = document.createElement("div");
+  header.className = "app-card__header";
+
+  const title = document.createElement("span");
+  title.className = "app-card__title";
+  title.textContent = app.title;
+
+  const statusWrap = document.createElement("span");
+  statusWrap.className = "app-card__status";
+
+  const dot = document.createElement("span");
+  dot.className = "app-card__dot";
+
+  const statusText = document.createElement("span");
+  statusText.textContent = "probing…";
+
+  statusWrap.append(dot, statusText);
+  header.append(title, statusWrap);
+  article.append(header);
+
+  const role = document.createElement("p");
+  role.className = "app-card__meta";
+  role.textContent = app.role;
+  article.append(role);
+
+  if (app.summary) {
+    const summary = document.createElement("p");
+    summary.className = "app-card__meta";
+    summary.textContent = app.summary;
+    article.append(summary);
+  }
+
+  if (Array.isArray(app.links) && app.links.length > 0) {
+    const linksWrap = document.createElement("div");
+    linksWrap.className = "app-card__links";
+    for (const link of app.links) {
+      if (!link || !link.href) continue;
+      const anchor = document.createElement("a");
+      anchor.href = link.href;
+      anchor.textContent = link.label || "Open";
+      if (/^https?:/i.test(link.href)) {
+        anchor.target = "_blank";
+        anchor.rel = "noopener noreferrer";
+      }
+      linksWrap.append(anchor);
+    }
+    article.append(linksWrap);
+  }
+
+  return { node: article, statusText };
+}
+
+function renderAppGrid(apps) {
+  if (!appsGridEl) return;
+  appsGridEl.textContent = "";
+  appCardIndex.clear();
+
+  if (!Array.isArray(apps) || apps.length === 0) {
+    const fallbackCard = document.createElement("article");
+    fallbackCard.className = "app-card";
+    fallbackCard.dataset.state = "warn";
+    const info = document.createElement("p");
+    info.className = "app-card__meta";
+    info.textContent = "No services configured. Edit public/core/apps.json to add entries.";
+    fallbackCard.append(info);
+    appsGridEl.append(fallbackCard);
+    return;
+  }
+
+  for (const app of apps) {
+    const card = buildAppCard(app);
+    appCardIndex.set(app.id, card);
+    appsGridEl.append(card.node);
+  }
+}
+
+function setAppStatus(appId, state, message) {
+  const entry = appCardIndex.get(appId);
+  if (!entry) return;
+  entry.node.dataset.state = state;
+  entry.statusText.textContent = message;
+}
+
+async function probeApp(app) {
+  const controller = new AbortController();
+  const timer = window.setTimeout(() => controller.abort(), 4000);
+  try {
+    const res = await fetch(app.health, { signal: controller.signal, cache: "no-store" });
+    window.clearTimeout(timer);
+    if (res.ok) {
+      return { id: app.id, state: "ok", message: "online" };
+    }
+    return {
+      id: app.id,
+      state: "warn",
+      message: `http ${res.status}`,
+    };
+  } catch (error) {
+    window.clearTimeout(timer);
+    const reason = error?.name === "AbortError" ? "timeout" : error?.message || "offline";
+    return { id: app.id, state: "offline", message: reason };
+  }
+}
+
+function updateAppsSummary(results) {
+  if (!appsSummaryEl) return;
+  if (!results || results.length === 0) {
+    appsSummaryEl.textContent = "No services configured.";
+    return;
+  }
+  const tally = { ok: 0, warn: 0, offline: 0 };
+  for (const item of results) {
+    if (item.state && tally[item.state] !== undefined) {
+      tally[item.state] += 1;
+    }
+  }
+  const parts = [];
+  if (tally.ok) parts.push(`${tally.ok} online`);
+  if (tally.warn) parts.push(`${tally.warn} attention`);
+  if (tally.offline) parts.push(`${tally.offline} offline`);
+  const stamp = new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  appsSummaryEl.textContent = parts.length > 0
+    ? `${parts.join(" · ")} — checked ${stamp}`
+    : `Checked ${stamp}`;
+}
+
+async function refreshAppStatuses(apps) {
+  if (!Array.isArray(apps) || apps.length === 0) {
+    updateAppsSummary([]);
+    return;
+  }
+  if (appsSummaryEl) {
+    appsSummaryEl.textContent = "Checking statuses…";
+  }
+  for (const app of apps) {
+    setAppStatus(app.id, "loading", "probing…");
+  }
+  const results = await Promise.all(apps.map((app) => probeApp(app)));
+  for (const result of results) {
+    setAppStatus(result.id, result.state, result.message);
+  }
+  updateAppsSummary(results);
+}
+
+async function initHub() {
+  if (!appsGridEl) return;
+  currentApps = await loadConfiguredApps();
+  renderAppGrid(currentApps);
+  await refreshAppStatuses(currentApps);
+}
+
 async function boot() {
   let codexResult;
   let swResult;
@@ -152,4 +426,7 @@ async function boot() {
     if (realmResult) paintRealmLinks(realmResult);
   }
 }
+initHub().catch((error) => {
+  console.warn("Hub grid init failed", error);
+});
 boot();

--- a/fly.toml
+++ b/fly.toml
@@ -4,9 +4,9 @@ primary_region = "iad"
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = false
+  auto_stop_machines = true
   auto_start_machines = true
-  min_machines_running = 1
+  min_machines_running = 0
 
 [[services.http_checks]]
   path = "/core/health-check.html"

--- a/package.json
+++ b/package.json
@@ -12,10 +12,11 @@
   "scripts": {
     "registry": "node tools/build-registry.mjs",
     "validate": "node tools/validate.mjs",
-    "build": "npm run registry && npm run validate",
-    "dev": "http-server -p 5173 -c-1 .",
-    "start": "npm run dev",
-    "preview": "http-server -p 8080 -c-1 .",
+    "build": "npm run registry && npm run validate && npm run build:ui",
+    "build:ui": "vite build",
+    "dev": "vite dev",
+    "start": "node server.mjs",
+    "preview": "vite preview --host 0.0.0.0 --port 8080",
     "test": "./scripts/run-tests.sh",
     "fmt": "prettier -w .",
     "lint": "eslint .",
@@ -30,12 +31,15 @@
     "project": "node scripts/projection.mjs"
   },
   "dependencies": {
-    "ajv": "^8.17.1"
+    "ajv": "^8.17.1",
+    "compression": "^1.7.5",
+    "express": "^4.21.1"
   },
   "devDependencies": {
     "http-server": "^14.1.1",
     "eslint": "^8.57.0",
-    "prettier": "^3.4.2"
+    "prettier": "^3.4.2",
+    "vite": "^5.4.11"
   },
   "keywords": [
     "cosmogenesis",

--- a/public/core/apps.json
+++ b/public/core/apps.json
@@ -1,0 +1,64 @@
+{
+  "apps": [
+    {
+      "id": "cosmogenesis-learning-engine",
+      "title": "Cosmogenesis Learning Engine",
+      "role": "Hub / Mind Registry",
+      "summary": "Master hub with ND-safe toggles and codex sync.",
+      "url": "https://cosmogenesis-learning-engine.fly.dev/",
+      "health": "https://cosmogenesis-learning-engine.fly.dev/core/health-check.html",
+      "links": [
+        { "label": "Open hub", "href": "https://cosmogenesis-learning-engine.fly.dev/" },
+        { "label": "Health", "href": "https://cosmogenesis-learning-engine.fly.dev/core/health-check.html" }
+      ]
+    },
+    {
+      "id": "circuitum99",
+      "title": "Circuitum 99",
+      "role": "Story Spine / Guardians",
+      "summary": "Interactive spine with guardians and ND-safe rituals.",
+      "url": "https://circuitum99.fly.dev/",
+      "health": "https://circuitum99.fly.dev/core/health-check.html",
+      "links": [
+        { "label": "Launch", "href": "https://circuitum99.fly.dev/" },
+        { "label": "Health", "href": "https://circuitum99.fly.dev/core/health-check.html" }
+      ]
+    },
+    {
+      "id": "stone-cathedral",
+      "title": "Stone Cathedral",
+      "role": "Rooms Atlas / Museum",
+      "summary": "Cathedral atlas with provenance-safe walkthroughs.",
+      "url": "https://stone-cathedral.fly.dev/",
+      "health": "https://stone-cathedral.fly.dev/core/health-check.html",
+      "links": [
+        { "label": "Open atlas", "href": "https://stone-cathedral.fly.dev/" },
+        { "label": "Health", "href": "https://stone-cathedral.fly.dev/core/health-check.html" }
+      ]
+    },
+    {
+      "id": "liber-arcanae",
+      "title": "Liber Arcanae",
+      "role": "Tarot Companions",
+      "summary": "Tarot compendium with ND-safe overlays.",
+      "url": "https://liber-arcanae.fly.dev/",
+      "health": "https://liber-arcanae.fly.dev/core/health-check.html",
+      "links": [
+        { "label": "Visit", "href": "https://liber-arcanae.fly.dev/" },
+        { "label": "Health", "href": "https://liber-arcanae.fly.dev/core/health-check.html" }
+      ]
+    },
+    {
+      "id": "cosmic-helix",
+      "title": "Cosmic Helix",
+      "role": "Static Renderer",
+      "summary": "Offline vesica + helix canvas for palette study.",
+      "url": "https://cosmic-helix.fly.dev/",
+      "health": "https://cosmic-helix.fly.dev/core/health-check.html",
+      "links": [
+        { "label": "Renderer", "href": "https://cosmic-helix.fly.dev/" },
+        { "label": "Health", "href": "https://cosmic-helix.fly.dev/core/health-check.html" }
+      ]
+    }
+  ]
+}

--- a/public/core/health-check.html
+++ b/public/core/health-check.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<title>ok</title>
+<body>ok</body>
+</html>

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -13,9 +13,13 @@ self.addEventListener("message", (event) => {
     if (event.ports && event.ports[0]) {
       event.ports[0].postMessage({ version: SW_VERSION });
     } else {
-      self.clients.matchAll({ type: "window", includeUncontrolled: true }).then((clients) => {
-        clients.forEach((client) => client.postMessage({ type: "SW_VERSION_RESPONSE", version: SW_VERSION }));
-      });
+      self.clients
+        .matchAll({ type: "window", includeUncontrolled: true })
+        .then((clients) => {
+          clients.forEach((client) =>
+            client.postMessage({ type: "SW_VERSION_RESPONSE", version: SW_VERSION })
+          );
+        });
     }
   }
 });

--- a/server.mjs
+++ b/server.mjs
@@ -1,0 +1,58 @@
+import express from "express";
+import compression from "compression";
+import path from "node:path";
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const DIST_DIR = path.join(__dirname, "dist");
+
+const app = express();
+const PORT = Number(process.env.PORT || 8080);
+
+app.use(compression());
+
+// Calm headers keep offline mirrors deterministic.
+app.use((req, res, next) => {
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.setHeader("Referrer-Policy", "no-referrer");
+  next();
+});
+
+function mountStatic(prefix, relativeDir, options = {}) {
+  const full = path.join(__dirname, relativeDir);
+  if (!fs.existsSync(full)) return;
+  app.use(prefix, express.static(full, options));
+}
+
+app.get("/api/health", (_req, res) => {
+  res.json({ ok: true, status: "online" });
+});
+
+app.use(
+  express.static(DIST_DIR, {
+    extensions: ["html"],
+    setHeaders(res, filePath) {
+      if (filePath.endsWith("service-worker.js")) {
+        res.setHeader("Cache-Control", "no-store");
+      }
+    },
+  }),
+);
+
+mountStatic("/assets", "assets");
+mountStatic("/registry", "registry");
+
+app.use((req, res) => {
+  if (req.method !== "GET") {
+    res.status(405).end();
+    return;
+  }
+  res.sendFile(path.join(DIST_DIR, "index.html"));
+});
+
+app.listen(PORT, () => {
+  // eslint-disable-next-line no-console
+  console.log(`hub listening on http://0.0.0.0:${PORT}`);
+});

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,0 +1,20 @@
+import { defineConfig } from "vite";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export default defineConfig({
+  // Build the hub UI from the core directory to keep legacy structure intact.
+  root: path.resolve(__dirname, "core"),
+  publicDir: path.resolve(__dirname, "public"),
+  build: {
+    outDir: path.resolve(__dirname, "dist"),
+    emptyOutDir: true,
+    sourcemap: false,
+  },
+  server: {
+    port: 5173,
+  },
+});


### PR DESCRIPTION
## Summary
- introduce a Vite build configuration plus an Express static server and update the Docker and Fly configs for Node-based deployment
- expand the core hub page with a service status grid that renders from a configurable app list and pings each health endpoint
- add public-facing health check assets and app metadata JSON consumed by the hub status logic

## Testing
- npm install *(fails: registry returned 403 Forbidden in this environment)*
- npm run build *(fails: `vite` missing because install above could not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68d0a7bd20a083288dc81f19e2a1d040