### PR TITLE
Add Fly deployment configs and refresh helix renderer fallback

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,26 +1,39 @@
 # Cosmic Helix Renderer
 
-Static, offline-first canvas capsule aligned with the luminous cosmology canon. Rendering happens once when `index.html` loads, painting four quiet layers (vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice). All geometry is parameterised by numerology anchors `{3, 7, 9, 11, 22, 33, 99, 144}` and every helper is a small, well-commented pure function so the composition stays ND-safe.
+Static, offline-first canvas capsule aligned with the luminous cosmology canon. Rendering happens once when `index.html` loads,
+painting four calm layers (vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice). All geometry
+is parameterised by numerology anchors `{3, 7, 9, 11, 22, 33, 99, 144}` and every helper is a small, well-commented pure function
+so the composition stays ND-safe.
 
 ## Files delivered
-- `index.html` — Offline entry point. Loads the optional palette JSON without issuing network requests, reports fallback status in the header, seeds the numerology constants, and invokes the renderer with a calm notice when data is missing.
-- `js/helix-renderer.mjs` — Pure ES module containing the layered drawing helpers. Each layer explains how the numerology keeps depth without motion.
-- `data/palette.json` — Optional colour override. When absent the renderer uses its sealed fallback and paints a footer notice for reassurance.
+- `index.html` — Offline entry point. Loads the optional palette JSON using a local `fetch` attempt, reports fallback status in
+  the header, seeds the numerology constants, and invokes the renderer with a calm notice when data is missing.
+- `js/helix-renderer.mjs` — Pure ES module containing the layered drawing helpers. Each layer explains how the numerology keeps
+depth without motion.
+- `data/palette.json` — Optional colour override. When absent the renderer uses its sealed fallback and paints a footer notice
+for reassurance.
 - `README_RENDERER.md` — This guide.
 
 ## How to use (offline)
 1. Download or clone this repository.
 2. Double-click `index.html` in any modern browser. No build steps, bundlers, or servers are required.
-3. The palette loader uses module-level JSON import assertions only; if that fails (common on hardened `file://` contexts) the fallback palette activates automatically, the header reports the change, and the canvas prints "Palette fallback active" near the base.
+3. The palette loader issues a single `fetch` for `data/palette.json`. Hardened `file://` environments may block that request; when
+   it fails the fallback palette activates automatically, the header reports the change, and the canvas prints "Palette fallback
+   active" near the base.
 
 ## Layer order (back to front)
-1. **Vesica field** — Intersecting circle grid arranged by a `{3 × 7}` cadence. A central mandorla glow reinforces the vesica without motion.
-2. **Tree-of-Life scaffold** — Ten sephirot plus hidden Daath, linked by twenty-two calm paths. Pillar spacing and vertical placement derive from `{33, 99, 144}` ratios, forming a vaulted arch.
-3. **Fibonacci curve** — Logarithmic spiral seeded by the golden ratio. Quarter-turn markers align to the Fibonacci sequence up to `144` and receive pearl markers for clarity.
-4. **Double-helix lattice** — Two phase-shifted strands sampled at `22` stations, alternating rungs to imply twist. A quiet base walkway anchors the lattice without animation.
+1. **Vesica field** — Intersecting circle grid arranged by a `{3 × 7}` cadence. A central mandorla glow reinforces the vesica without
+   motion.
+2. **Tree-of-Life scaffold** — Ten sephirot plus hidden Daath, linked by twenty-two calm paths. Pillar spacing and vertical placement
+   derive from `{33, 99, 144}` ratios, forming a vaulted arch.
+3. **Fibonacci curve** — Logarithmic spiral seeded by the golden ratio. Quarter-turn markers align to the Fibonacci sequence up to `144`
+   and receive pearl markers for clarity.
+4. **Double-helix lattice** — Two phase-shifted strands sampled at `22` stations, alternating rungs to imply twist. A quiet base walkway
+   anchors the lattice without animation.
 
 ## Numerology anchors
-- Vertical placement steps through the 144-unit ladder so Malkuth rests at `144` while the supernal triad seats `33 ÷ 3 = 11` units below the crown.
+- Vertical placement steps through the 144-unit ladder so Malkuth rests at `144` while the supernal triad seats `33 ÷ 3 = 11` units below
+  the crown.
 - Daath bridges triads at `22 + 7`, Chesed/Geburah sit at `33 + 9`, Tiphareth at `33 + 22`, Netzach/Hod at `99 − 3`, Yesod at `144 − 3`.
 - The helix rails oscillate with a sine phase scaled by `{3, 11, 22}`, while rungs appear every other station to honour `33` anchors.
 - The Fibonacci spiral grows by `φ` so each quarter-turn multiplies the radius, matching the canonical progression up to `144`.
@@ -36,7 +49,8 @@ Update `data/palette.json` with your preferred ND-safe palette:
 }
 ```
 
-The loader never performs remote fetches; it only attempts module-level JSON import. Missing or malformed palette data never stops rendering, because the fallback palette keeps contrast calm and emits the inline notice.
+The loader never performs remote fetches; it only attempts to read this local JSON file. Missing or malformed palette data never stops
+rendering, because the fallback palette keeps contrast calm and emits the inline notice.
 
 ## ND-safe rationale
 - No animation loops or timers — everything renders once.

--- a/apps/cosmogenesis/fly.toml
+++ b/apps/cosmogenesis/fly.toml
@@ -1,0 +1,38 @@
+app = "cosmogenesis-learning-engine"
+primary_region = "ord"
+
+[build]
+  builder = "heroku/buildpacks:20"
+
+[env]
+  NODE_ENV = "production"
+  PORT = "8080"
+
+[experimental]
+  auto_rollback = true
+
+[[services]]
+  internal_port = 8080
+  protocol = "tcp"
+
+  [services.concurrency]
+    type = "connections"
+    soft_limit = 20
+    hard_limit = 25
+
+  [[services.ports]]
+    port = 80
+    handlers = ["http"]
+    force_https = true
+
+  [[services.ports]]
+    port = 443
+    handlers = ["tls", "http"]
+
+[[statics]]
+  guest_path = "/app/public"
+  url_prefix = "/brain/"
+
+[mounts]
+  source = "cathedral_data"
+  destination = "/data"

--- a/apps/liber-arcanae/fly.toml
+++ b/apps/liber-arcanae/fly.toml
@@ -1,0 +1,38 @@
+app = "liber-arcanae-tarot"
+primary_region = "ord"
+
+[build]
+  builder = "heroku/buildpacks:20"
+
+[env]
+  NODE_ENV = "production"
+  PORT = "8080"
+
+[experimental]
+  auto_rollback = true
+
+[[services]]
+  internal_port = 8080
+  protocol = "tcp"
+
+  [services.concurrency]
+    type = "connections"
+    soft_limit = 20
+    hard_limit = 25
+
+  [[services.ports]]
+    port = 80
+    handlers = ["http"]
+    force_https = true
+
+  [[services.ports]]
+    port = 443
+    handlers = ["tls", "http"]
+
+[[statics]]
+  guest_path = "/app/public"
+  url_prefix = "/soul/"
+
+[mounts]
+  source = "cathedral_data"
+  destination = "/data"

--- a/apps/stone-grimoire/fly.toml
+++ b/apps/stone-grimoire/fly.toml
@@ -1,0 +1,38 @@
+app = "stone-grimoire-cathedral"
+primary_region = "ord"
+
+[build]
+  builder = "heroku/buildpacks:20"
+
+[env]
+  NODE_ENV = "production"
+  PORT = "8080"
+
+[experimental]
+  auto_rollback = true
+
+[[services]]
+  internal_port = 8080
+  protocol = "tcp"
+
+  [services.concurrency]
+    type = "connections"
+    soft_limit = 20
+    hard_limit = 25
+
+  [[services.ports]]
+    port = 80
+    handlers = ["http"]
+    force_https = true
+
+  [[services.ports]]
+    port = 443
+    handlers = ["tls", "http"]
+
+[[statics]]
+  guest_path = "/app/public"
+  url_prefix = "/body/"
+
+[mounts]
+  source = "cathedral_data"
+  destination = "/data"

--- a/index.html
+++ b/index.html
@@ -6,51 +6,14 @@
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
   <meta name="color-scheme" content="light dark">
   <style>
-    /* ND-safe shell: calm contrast, no motion, layered spacing */
-    :root {
-      --bg: #0b0b12;
-      --ink: #e8e8f0;
-      --muted: #a6a6c1;
-      --edge: #1e2030;
-    }
-    html, body {
-      margin: 0;
-      padding: 0;
-      background: var(--bg);
-      color: var(--ink);
-      font: 14px/1.5 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
-    }
-    header {
-      padding: 12px 16px 10px 16px;
-      border-bottom: 1px solid var(--edge);
-    }
-    .status {
-      margin-top: 4px;
-      color: var(--muted);
-      font-size: 12px;
-    }
-    #stage {
-      display: block;
-      margin: 18px auto 16px auto;
-      width: 1440px;
-      height: 900px;
-      box-shadow: 0 0 0 1px var(--edge), 0 18px 48px rgba(0, 0, 0, 0.45);
-      background: transparent;
-    }
-    .note {
-      max-width: 920px;
-      margin: 0 auto 32px auto;
-      padding: 0 16px;
-      color: var(--muted);
-    }
-    @media (max-width: 1500px) {
-      #stage {
-        width: 100%;
-        height: auto;
-        max-width: 1440px;
-        aspect-ratio: 1440 / 900;
-      }
-    }
+    /* ND-safe: calm contrast, no motion, layered depth preserved */
+    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
+    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
+    .status { color:var(--muted); font-size:12px; margin-top:4px; }
+    #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
+    .note { max-width:900px; margin:0 auto 16px; padding:0 16px; color:var(--muted); }
+    code { background:#11111a; padding:2px 4px; border-radius:3px; }
   </style>
 </head>
 <body>
@@ -60,99 +23,59 @@
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">Static renderer with four calm layers: vesica field, Tree-of-Life scaffold, Fibonacci curve, and static double-helix lattice. Open directly; no network or build step is required.</p>
+  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
 
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
 
-    const statusEl = document.getElementById("status");
+    const elStatus = document.getElementById("status");
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
 
-    const NUM = {
-      THREE: 3,
-      SEVEN: 7,
-      NINE: 9,
-      ELEVEN: 11,
-      TWENTYTWO: 22,
-      THIRTYTHREE: 33,
-      NINETYNINE: 99,
-      ONEFORTYFOUR: 144
-    };
-
-    const FALLBACK = {
-      palette: {
-        bg: "#0b0b12",
-        ink: "#e8e8f0",
-        muted: "#a6a6c1",
-        layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
+    async function loadJSON(path) {
+      try {
+        const res = await fetch(path, { cache: "no-store" });
+        if (!res.ok) throw new Error(String(res.status));
+        return await res.json();
+      } catch (err) {
+        return null;
       }
-    };
-
-    async function loadPalette() {
-      const url = "./data/palette.json";
-      const attempts = [
-        async () => {
-          return import(url, { assert: { type: "json" } });
-        },
-        async () => {
-          return import(url, { with: { type: "json" } });
-        }
-      ];
-      for (const attempt of attempts) {
-        try {
-          const mod = await attempt();
-          if (mod && typeof mod === "object") {
-            const payload = mod.default && typeof mod.default === "object"
-              ? mod.default
-              : typeof mod.palette === "object"
-              ? mod.palette
-              : mod;
-            if (payload && typeof payload === "object") {
-              return payload;
-            }
-          }
-        } catch (err) {
-          // Import assertions are not universal; keep iterating to honour offline fallback.
-        }
-      }
-      return null;
     }
 
-    function applyChromeColours(palette) {
+    function applyPalette(palette) {
       const root = document.documentElement;
       if (palette.bg) root.style.setProperty("--bg", palette.bg);
       if (palette.ink) root.style.setProperty("--ink", palette.ink);
       if (palette.muted) {
         root.style.setProperty("--muted", palette.muted);
-      } else if (Array.isArray(palette.layers) && palette.layers[0]) {
+      } else if (Array.isArray(palette.layers) && palette.layers.length) {
         root.style.setProperty("--muted", palette.layers[0]);
       }
     }
 
-    const palette = await loadPalette();
-    const activePalette = palette || FALLBACK.palette;
-    const notice = palette ? "" : "Palette fallback active (local data unavailable).";
+    const defaults = {
+      palette: {
+        bg: "#0b0b12",
+        ink: "#e8e8f0",
+        layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
+      }
+    };
 
-    applyChromeColours(activePalette);
+    const paletteData = await loadJSON("./data/palette.json");
+    const palette = paletteData && typeof paletteData === "object" ? paletteData : null;
+    const activePalette = palette || defaults.palette;
+    const notice = palette ? "" : "Palette fallback active (data/palette.json unavailable).";
 
-    if (palette) {
-      statusEl.textContent = "Palette loaded from data/palette.json without network.";
-    } else {
-      statusEl.textContent = "Palette missing or blocked; using sealed fallback (no network used).";
-    }
+    applyPalette(activePalette);
+    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
 
-    // ND-safe rationale: no animation, soft contrast, layered order preserves depth.
-    const result = renderHelix(ctx, {
-      width: canvas.width,
-      height: canvas.height,
-      palette: activePalette,
-      NUM,
-      notice
-    });
+    // Numerology constants used by geometry routines
+    const NUM = { THREE: 3, SEVEN: 7, NINE: 9, ELEVEN: 11, TWENTYTWO: 22, THIRTYTHREE: 33, NINETYNINE: 99, ONEFORTYFOUR: 144 };
 
-    if (result && result.summary) {
-      statusEl.textContent += ` | ${result.summary}`;
+    // ND-safe rationale: no motion, high readability, soft colours, layered order
+    const outcome = renderHelix(ctx, { width: canvas.width, height: canvas.height, palette: activePalette, NUM, notice });
+    if (outcome && outcome.summary) {
+      elStatus.textContent += ` ${outcome.summary}`;
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add Fly.io deployment configurations for the cosmogenesis, stone-grimoire, and liber-arcanae apps
- refresh the offline helix renderer entrypoint to use a safe JSON fetch fallback and status notice
- update the renderer README to describe the new palette loading flow

## Testing
- not run (static content changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d14cdfc4508328bed6f9604ec7ccaa