### PR TITLE
Enhance cosmic helix offline renderer fallbacks

### DIFF
--- a/cosmic-helix/README_RENDERER.md
+++ b/cosmic-helix/README_RENDERER.md
@@ -1,31 +1,37 @@
 # Cosmic Helix Renderer (Offline, ND-safe)
 
-Static HTML + Canvas capsule that paints the layered cosmology exactly once when `index.html` is opened. The module honours the covenant: ND-safe colours, no motion, and sacred geometry rendered in four calm passes.
+Static HTML + Canvas capsule that paints the layered cosmology exactly once when `index.html` is opened. The module honours the
+covenant: ND-safe colours, no motion, and sacred geometry rendered in four calm passes.
 
 ## Files
-- `index.html` — offline entry point that applies the palette (or sealed fallback) and calls the renderer.
-- `js/helix-renderer.mjs` — ES module of pure drawing helpers sequenced in the ND-safe layer order.
-- `data/palette.json` — optional palette override. Missing data triggers the sealed palette and a gentle inline notice.
+- `index.html` — offline entry point that applies the palette, loads optional geometry overrides, and calls the renderer.
+- `js/helix-renderer.mjs` — ES module of small pure helpers sequenced in the ND-safe layer order.
+- `data/palette.json` — optional colour overrides. Missing data triggers the sealed palette and a gentle inline notice.
+- `data/geometry.json` — optional geometry overrides that respect numerology ratios. Missing data keeps the sealed layout.
 - `README_RENDERER.md` — this guide.
 
 ## Usage (offline)
-1. Double-click `cosmic-helix/index.html` in any modern browser. No server or build step required.
-2. The header status reports whether `data/palette.json` loaded. If browsers block the fetch on the `file://` protocol, the sealed palette activates automatically.
-3. The canvas renders the vesica field, Tree-of-Life scaffold, Fibonacci curve, and static double-helix lattice once. There is no animation, autoplay, or timers.
+1. Double-click `cosmic-helix/index.html` in any modern browser. No server, build step, or network connection is required.
+2. The header status confirms whether the palette and geometry files loaded. If a browser blocks `file://` fetches, the sealed
+   fallbacks stay active and the notice appears in the canvas corner.
+3. The canvas draws the four-layer cosmology exactly once: vesica grid, Tree-of-Life scaffold, Fibonacci curve, and static
+   double-helix lattice.
 
 ## Layer order (back to front)
-1. **Vesica field** — a 9×11 lattice of intersecting circles (3, 9, 11 ratios) plus a central vesica pair for womb-of-forms depth.
-2. **Tree-of-Life scaffold** — ten sephirot positioned by calm 33-based margins with twenty-two steady connective paths.
-3. **Fibonacci curve** — a logarithmic spiral sampled over 144 golden-ratio steps to evoke organic growth without motion.
-4. **Double-helix lattice** — two phase-shifted strands with thirty-three rungs, rendered as still polylines to preserve layered geometry.
+1. **Vesica field** — a 3/7/9/11 grid of intersecting circles that opens with a central vesica pair for womb-of-forms depth.
+2. **Tree-of-Life scaffold** — ten sephirot nodes with twenty-two calm paths spaced on gentle 33-based margins.
+3. **Fibonacci curve** — logarithmic spiral sampled over 144 points to suggest growth without motion.
+4. **Double-helix lattice** — two still strands with thirty-three cross ties, rendered as layered polylines to preserve depth.
 
 ## ND-safe and trauma-informed choices
-- Pure functions render once; there are no timers, autoplay, or strobe effects.
-- Palette fallbacks and status messaging keep surprises minimal and explain why fallbacks appear.
-- Calm hex colours meet WCAG-friendly contrast against the #0b0b12 background.
-- Layer separation keeps the sacred geometry volumetric instead of flattening it into a single outline.
+- No animation, autoplay, or timers; every helper is pure and runs once on load.
+- Calm palette defaults and status messaging reduce surprises, with sealed fallbacks when data is unavailable.
+- Layered geometry keeps sacred forms three-dimensional instead of flattening them.
+- ASCII quotes, UTF-8 encoding, and LF newlines maintain compatibility across offline environments.
 
 ## Customising safely
-- Update `data/palette.json` with `bg`, `ink`, `muted`, and a six-colour `layers` array to tune hues. Invalid or missing values fall back silently to the sealed palette.
-- Pass a `geometry` object into `renderHelix` (when embedding the module elsewhere) to adjust counts or spacing. Every override is validated to keep ratios positive and ND-safe.
+- Update `data/palette.json` with `bg`, `ink`, `muted`, and a six colour `layers` array to tune hues. Invalid or missing values
+  fall back silently to the sealed palette.
+- Edit `data/geometry.json` to change counts, spacing, or offsets, or pass a `geometry` object to `renderHelix` directly. The
+  renderer validates every override to ensure ratios stay positive and ND-safe.
 - Keep additions static, well-commented, and grounded in the numerology constants (3, 7, 9, 11, 22, 33, 99, 144).

--- a/cosmic-helix/data/geometry.json
+++ b/cosmic-helix/data/geometry.json
@@ -2,15 +2,17 @@
   "vesica": {
     "rows": 9,
     "columns": 11,
-    "paddingDivisor": 11,
+    "paddingFactor": 11,
     "radiusFactor": 1.5,
     "strokeDivisor": 99,
     "alpha": 0.55
   },
   "treeOfLife": {
-    "marginDivisor": 11,
+    "marginFactor": 11,
     "radiusDivisor": 22,
-    "labelOffset": -24,
+    "pathWidthDivisor": 33,
+    "labelOffset": 8,
+    "labelFont": "13px system-ui, -apple-system, Segoe UI, sans-serif",
     "nodes": [
       { "id": "kether", "title": "Kether", "meaning": "Crown", "level": 0, "xFactor": 0.5 },
       { "id": "chokmah", "title": "Chokmah", "meaning": "Wisdom", "level": 1, "xFactor": 0.7 },
@@ -46,23 +48,26 @@
       ["netzach", "yesod"],
       ["hod", "yesod"],
       ["yesod", "malkuth"]
-    ],
-    "labelFont": "13px system-ui, -apple-system, Segoe UI, sans-serif"
+    ]
   },
   "fibonacci": {
     "sampleCount": 144,
     "turns": 3,
-    "baseRadiusDivisor": 3,
+    "baseRadiusDivisor": 9,
     "phi": 1.618033988749895,
-    "alpha": 0.85
+    "alpha": 0.85,
+    "thickness": 2.5,
+    "centerOffsetX": 0.62,
+    "centerOffsetY": 0.58
   },
   "helix": {
-    "sampleCount": 144,
-    "cycles": 3,
-    "amplitudeDivisor": 3,
-    "phaseOffset": 180,
-    "crossTieCount": 33,
-    "strandAlpha": 0.85,
-    "rungAlpha": 0.6
+    "strandPoints": 144,
+    "rungCount": 33,
+    "sideMarginDivisor": 11,
+    "amplitudeDivisor": 9,
+    "frequencyTurns": 3,
+    "strandThickness": 3,
+    "rungAlpha": 0.6,
+    "verticalCenterOffset": 0
   }
 }

--- a/cosmic-helix/index.html
+++ b/cosmic-helix/index.html
@@ -96,7 +96,7 @@
       ONEFORTYFOUR: 144
     });
 
-    const FALLBACK = Object.freeze({
+    const DEFAULTS = Object.freeze({
       palette: {
         bg: "#0b0b12",
         ink: "#e8e8f0",
@@ -105,7 +105,7 @@
       }
     });
 
-    async function loadPalette(path) {
+    async function loadJSON(path) {
       try {
         const response = await fetch(path, { cache: "no-store" });
         if (!response.ok) {
@@ -134,23 +134,39 @@
         return;
       }
 
-      const paletteData = await loadPalette("./data/palette.json");
-      const activePalette = paletteData ? paletteData : FALLBACK.palette;
+      const [paletteData, geometryData] = await Promise.all([
+        loadJSON("./data/palette.json"),
+        loadJSON("./data/geometry.json")
+      ]);
+
+      const activePalette = paletteData || DEFAULTS.palette;
+      const activeGeometry = geometryData && typeof geometryData === "object" ? geometryData : undefined;
+
       applyTheme(activePalette);
+
+      const noticeLines = [];
+      if (!paletteData) {
+        noticeLines.push("Palette fallback active.");
+      }
+      if (!geometryData) {
+        noticeLines.push("Geometry fallback active.");
+      }
+      const notice = noticeLines.length ? noticeLines.join("\n") : "";
 
       const result = renderHelix(context, {
         width: canvas.width,
         height: canvas.height,
         palette: activePalette,
+        geometry: activeGeometry,
         NUM,
-        notice: paletteData ? null : "Palette missing; sealed fallback active."
+        notice
       });
 
       if (result.ok) {
-        const parts = [];
-        parts.push(paletteData ? "Palette loaded." : "Palette missing; fallback palette in use.");
-        parts.push(result.notice ? "Fallback notice rendered." : "Render complete.");
-        updateStatus(parts.join(" "));
+        const paletteMessage = paletteData ? "Palette loaded." : "Palette missing; using sealed fallback.";
+        const geometryMessage = geometryData ? " Geometry loaded." : " Geometry fallback in use.";
+        const noticeMessage = notice ? " Fallback notice rendered." : " Render complete.";
+        updateStatus(paletteMessage + geometryMessage + noticeMessage);
       } else {
         updateStatus("Renderer error: " + (result.reason || "unknown"));
       }


### PR DESCRIPTION
## Summary
- load palette and geometry overrides with clear ND-safe fallbacks in the offline renderer
- align geometry override schema with the renderer defaults and document the behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d49402a87c8328bc0b1b719a934ae4