### PR TITLE
Add Cloudflare Pages-ready static renderer template

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,10 @@
+# Keep Cloudflare Pages deploys focused on the offline renderer capsule
+/*
+!.cfignore
+!_headers
+!index.html
+!README_RENDERER.md
+!data/
+!data/**
+!js/
+!js/helix-renderer.mjs

--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,11 +1,13 @@
 # Cosmic Helix Renderer
 
-Static, offline-first canvas capsule aligned with the layered cosmology canon. Rendering happens once when `index.html` loads, painting four calm layers (Vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice). Geometry constants stay anchored to `3, 7, 9, 11, 22, 33, 99, 144` and every helper is a small, well-commented pure function so the composition remains ND-safe. The visuals now echo the cathedral and portal artworks while weaving in Codex 144:99 research cues.
+Static, offline-first canvas capsule aligned with the layered cosmology canon. Rendering happens once when `index.html` loads, painting four calm layers (Vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice). Geometry constants stay anchored to `3, 7, 9, 11, 22, 33, 99, 144` and every helper is a small, well-commented pure function so the composition remains ND-safe. This folder now doubles as the copy-and-paste template for the rest of the Cathedral of Circuits repositories.
 
 ## Files delivered
-- `index.html` - Offline entry point. Loads the optional palette JSON without remote requests, reports fallback status in the header, seeds the numerology constants, and invokes the renderer with a calm notice when data is missing. The header now names the Codex 144:99 synthesis portal and points toward `codex-144-99/` and `cathedral/` for deeper study.
-- `js/helix-renderer.mjs` - Pure ES module containing the layered drawing helpers. Each layer explains how numerology keeps depth without motion, and new helpers paint mandorla glows, cathedral vaults, research chambers, and the synthesizer helix column.
+- `index.html` - Offline entry point. Loads the optional palette JSON without remote requests, reports fallback status in the header, seeds the numerology constants, and invokes the renderer with a calm notice when data is missing.
+- `js/helix-renderer.mjs` - Pure ES module containing the layered drawing helpers. Each layer explains how numerology keeps depth without motion, keeping trauma-informed guardrails explicit in comments.
 - `data/palette.json` - Optional colour override. When absent the renderer uses its sealed fallback and paints a footer notice for reassurance.
+- `_headers` - Cloudflare Pages directives applying ND-safe CORS/security headers to every request while still allowing JSON fetches from the same origin.
+- `.cfignore` - Deploy filter that keeps the static capsule self-contained by excluding development folders when publishing to Cloudflare Pages.
 - `README_RENDERER.md` - This guide.
 
 ## Offline use
@@ -13,10 +15,21 @@ Static, offline-first canvas capsule aligned with the layered cosmology canon. R
 2. Double-click `index.html` in any modern browser. No build steps, bundlers, or servers are required.
 3. The palette loader issues a single local `fetch` for `data/palette.json`. Hardened `file://` environments may block that request; when it fails the fallback palette activates automatically, the header reports the change, and the canvas prints `Palette fallback active (data/palette.json unavailable).` near the base.
 
+## Cloudflare Pages deployment
+Use these steps for every Cathedral of Circuits repository so each portal deploys independently without cross-repo dependencies:
+
+1. Commit the template files (`index.html`, `js/helix-renderer.mjs`, optional `data/*.json`, `_headers`, `.cfignore`, `README_RENDERER.md`) to the repository root.
+2. Push the repository to GitHub (or another supported git host).
+3. In the Cloudflare dashboard, create a new Pages project and connect the repository.
+4. Set the **Build command** to empty (no build) and the **Build output directory** to `.` so Pages serves the root-level files directly.
+5. Trigger the deployment. Cloudflare will honour `_headers` for security, ignore development folders listed in `.cfignore`, and serve the renderer instantly.
+
+Later, point a Cloudflare Worker router at the deployed Pages project (for example, mapping `/cosmogenesis` to `cosmogenesis-learning-engine.pages.dev`). Because each repo ships this static bundle, the Worker can route without needing shared assets.
+
 ## Layer order (back to front)
 1. **Vesica field** - Intersecting circle grid arranged by a `3 x 7` cadence. Mandorla glow, concentric portal rings, and an eight-point star echo the rose-window paintings.
-2. **Tree-of-Life scaffold** - Ten sephirot plus hidden Daath, linked by twenty-two calm paths. Vaulted arches and copper pillars mirror the `cathedral/` silhouettes while keeping ND-safe contrast.
-3. **Fibonacci curve** - Logarithmic spiral seeded by the golden ratio. Concentric “research chambers” drawn from Codex 144:99 schematics guide the laboratory rooms.
+2. **Tree-of-Life scaffold** - Ten sephirot plus hidden Daath, linked by twenty-two calm paths. Vaulted arches and copper pillars reference the cathedral silhouettes while keeping ND-safe contrast.
+3. **Fibonacci curve** - Logarithmic spiral seeded by the golden ratio. Concentric "research chambers" drawn from Codex 144:99 schematics guide the laboratory rooms.
 4. **Double-helix lattice** - Two phase-shifted strands sampled at `22` stations, alternating rungs to honour the `33` anchor. A luminous central column references the synthesizer tower.
 
 ## Numerology anchors
@@ -42,5 +55,5 @@ The loader never performs remote fetches; it only attempts to read this local JS
 ## ND-safe guardrails
 - No animation loops or timers; everything renders once.
 - Layered drawing order avoids flattening geometry, preserving depth through overlaid transparencies.
-- Comments explain why each choice is present so future curators understand the trauma-informed guardrails, including where Codex 144:99 research motifs and `cathedral/` architecture surface.
+- Comments explain why each choice is present so future curators understand the trauma-informed guardrails.
 - ASCII quotes, UTF-8 encoding, and LF newlines keep the files portable and offline friendly.

--- a/_headers
+++ b/_headers
@@ -1,0 +1,12 @@
+/*
+  Access-Control-Allow-Origin: *
+  Access-Control-Allow-Methods: GET, OPTIONS
+  Access-Control-Allow-Headers: Content-Type
+  Cache-Control: public, max-age=600
+  Cross-Origin-Resource-Policy: same-origin
+  Cross-Origin-Opener-Policy: same-origin
+  Referrer-Policy: same-origin
+  Permissions-Policy: geolocation=(), microphone=(), camera=(), interest-cohort=()
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  X-XSS-Protection: 1; mode=block

--- a/index.html
+++ b/index.html
@@ -24,13 +24,13 @@
 </head>
 <body>
   <header>
-    <div><strong>Cosmic Helix Renderer</strong> — Codex 144:99 synthesis portal (offline, ND-safe)</div>
+    <div><strong>Cosmic Helix Renderer</strong> - static layered geometry portal (offline, ND-safe)</div>
     <div class="status" id="status">Loading palette...</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">Static renderer with four calm layers: Vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice. Open this file directly; no build step or external network request is required.</p>
-  <p class="note">Cross-reference portals: <code>codex-144-99/</code> supplies research strata and <code>cathedral/</code> carries the architectural motifs mirrored here.</p>
+  <p class="note">This static renderer is the self-contained template for the Cathedral of Circuits repos. It draws four calm layers (Vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice) with no build step or dependencies.</p>
+  <p class="note">The optional <code>data/palette.json</code> file adjusts colours. When the file is missing or blocked the fallback palette is applied automatically, and a notice appears in the header. See <code>README_RENDERER.md</code> for Cloudflare Pages deployment steps plus the <code>_headers</code> and <code>.cfignore</code> usage.</p>
 
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";


### PR DESCRIPTION
## Summary
- refresh the offline helix renderer index copy so it stands alone as the reusable template
- extend the renderer README with Cloudflare Pages deployment guidance and file inventory
- add Cloudflare Pages `_headers` and `.cfignore` files to ship only the static capsule with security headers

## Testing
- not run (static files only)


------
https://chatgpt.com/codex/tasks/task_e_68d6e457e16483289d2361adaf4956f9